### PR TITLE
fix(ci): re-enable E2E job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,12 @@ jobs:
       # typo3-ci-workflows requires phpstan-typo3 ^2||^3 which needs TYPO3 ^13.4+
       # Remove it for v12 builds; individual deps in composer.json cover v12
       remove-dev-deps: '[{"dep":"netresearch/typo3-ci-workflows","only-for":"^13.4|^14.1"}]'
-  # E2E tests are available via Build/Scripts/runTests.sh e2e (local)
-  # and will be enabled in CI once typo3-ci-workflows e2e.yml is stable
-  # e2e:
-  #   if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-  #   uses: netresearch/typo3-ci-workflows/.github/workflows/e2e.yml@main
-  #   permissions:
-  #     contents: read
-  #   with:
-  #     php-version: '8.4'
-  #     test-command: 'npm run test:e2e'
-  #     artifact-path: 'Tests/E2E/'
+  e2e:
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    uses: netresearch/typo3-ci-workflows/.github/workflows/e2e.yml@main
+    permissions:
+      contents: read
+    with:
+      php-version: '8.4'
+      test-command: 'npm run test:e2e'
+      artifact-path: 'Tests/E2E/'


### PR DESCRIPTION
## Summary
- Uncomment the E2E job in `ci.yml` so it runs on PRs and merge groups
- The upstream cache issue in `typo3-ci-workflows` is being fixed separately; the job should be enabled now regardless

## Test plan
- [ ] Verify the E2E job appears in CI checks on this PR