### PR TITLE
chore: migrate generic workflows to .github

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -5,7 +5,7 @@ on:
 permissions: {}
 jobs:
   auto-merge:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/auto-merge-deps.yml@main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -5,7 +5,7 @@ on:
 permissions: {}
 jobs:
   auto-merge:
-    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
 permissions: {}
 jobs:
   analyze:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/codeql.yml@main
+    uses: netresearch/.github/.github/workflows/codeql.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,7 +9,7 @@ on:
 permissions: {}
 jobs:
   analyze:
-    uses: netresearch/.github/.github/workflows/codeql.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,7 +4,7 @@ on:
 permissions: {}
 jobs:
   review:
-    uses: netresearch/.github/.github/workflows/dependency-review.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -4,7 +4,7 @@ on:
 permissions: {}
 jobs:
   review:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/dependency-review.yml@main
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   pr-quality:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/pr-quality.yml@main
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   pr-quality:
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,7 @@ on:
 permissions: {}
 jobs:
   scorecard:
-    uses: netresearch/.github/.github/workflows/scorecard.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
     permissions:
       contents: read
       security-events: write

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,7 +7,7 @@ on:
 permissions: {}
 jobs:
   scorecard:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/scorecard.yml@main
+    uses: netresearch/.github/.github/workflows/scorecard.yml@f87ee244a6e0d78c24e0bd58794563ab8d916943 # main
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
Migrate generic workflow references from typo3-ci-workflows to netresearch/.github for org-wide consolidation.