### PR TITLE
feat: dashboard UX improvements, help button, adoption badges, MFA guidance

### DIFF
--- a/Classes/Controller/AdminModuleController.php
+++ b/Classes/Controller/AdminModuleController.php
@@ -11,12 +11,16 @@ namespace Netresearch\NrPasskeysBe\Controller;
 
 use Netresearch\NrPasskeysBe\Domain\Enum\EnforcementLevel;
 use Netresearch\NrPasskeysBe\Service\AdoptionStatsService;
+use Netresearch\NrPasskeysBe\Service\ExtensionConfigurationService;
 use Netresearch\NrPasskeysBe\Utility\TranslationTrait;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Backend\Template\Components\ButtonBar;
 use TYPO3\CMS\Backend\Template\ModuleTemplate;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
+use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Page\PageRenderer;
 
 /**
@@ -30,6 +34,8 @@ final class AdminModuleController
     public function __construct(
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
         private readonly AdoptionStatsService $adoptionStatsService,
+        private readonly ExtensionConfigurationService $configService,
+        private readonly IconFactory $iconFactory,
         private readonly PageRenderer $pageRenderer,
         private readonly UriBuilder $uriBuilder,
     ) {}
@@ -42,6 +48,7 @@ final class AdminModuleController
         $moduleTemplate = $this->moduleTemplateFactory->create($request);
         $moduleTemplate->setTitle($this->translate('module.title', 'Passkey Management'));
         $this->buildDocHeaderMenu($moduleTemplate, 'dashboard');
+        $this->addHelpButton($moduleTemplate);
 
         $stats = $this->adoptionStatsService->getStats();
 
@@ -77,13 +84,32 @@ final class AdminModuleController
             ];
         }
 
+        $config = $this->configService->getConfiguration();
+        $hasEnforcement = false;
+        foreach ($groupData as $group) {
+            if ($group['enforcement'] !== EnforcementLevel::Off->value) {
+                $hasEnforcement = true;
+                break;
+            }
+        }
+
+        $adoptionPercentage = $stats->adoptionPercentage();
+
         $moduleTemplate->assignMultiple([
             'totalUsers' => $stats->totalUsers,
             'usersWithPasskeys' => $stats->usersWithPasskeys,
-            'adoptionPercentage' => $stats->adoptionPercentage(),
+            'adoptionPercentage' => $adoptionPercentage,
+            'adoptionBadge' => self::adoptionBadge($adoptionPercentage, $stats->totalUsers),
             'groups' => $groupData,
             'usersWithoutPasskeys' => $userData,
             'enforcementLevels' => $this->getEnforcementLevelOptions(),
+            'helpUrl' => (string) $this->uriBuilder->buildUriFromRoute('admin_passkeys.help'),
+            'configRpId' => $this->configService->getEffectiveRpId(),
+            'configRpIdIsAutoDetected' => $config->getRpId() === '',
+            'configOriginIsAutoDetected' => $config->getOrigin() === '',
+            'hasEnforcement' => $hasEnforcement,
+            'hasGroups' => $groupData !== [],
+            'isNewInstallation' => $stats->usersWithPasskeys === 0,
         ]);
 
         $this->pageRenderer->loadJavaScriptModule(
@@ -105,6 +131,7 @@ final class AdminModuleController
         $moduleTemplate = $this->moduleTemplateFactory->create($request);
         $moduleTemplate->setTitle($this->translate('module.title', 'Passkey Management') . ' – ' . $this->translate('module.help', 'Help'));
         $this->buildDocHeaderMenu($moduleTemplate, 'help');
+        $this->addHelpButton($moduleTemplate);
 
         $moduleTemplate->assignMultiple([
             'dashboardUrl' => (string) $this->uriBuilder->buildUriFromRoute('admin_passkeys'),
@@ -164,4 +191,43 @@ final class AdminModuleController
         return $options;
     }
 
+    /**
+     * Add a help icon button to the right side of the DocHeader button bar.
+     */
+    private function addHelpButton(ModuleTemplate $moduleTemplate): void
+    {
+        $buttonBar = $moduleTemplate->getDocHeaderComponent()->getButtonBar();
+        $helpButton = $buttonBar->makeLinkButton()
+            ->setHref((string) $this->uriBuilder->buildUriFromRoute('admin_passkeys.help'))
+            ->setTitle($this->translate('module.help', 'Help'))
+            ->setIcon($this->iconFactory->getIcon(
+                'actions-question-circle',
+                // v12: IconSize doesn't exist, getIcon() accepts string 'small'
+                // v13+: IconSize enum required
+                // @phpstan-ignore argument.type
+                \enum_exists(IconSize::class) ? IconSize::SMALL : 'small',
+            ))
+            ->setShowLabelText(false);
+        $buttonBar->addButton($helpButton, ButtonBar::BUTTON_POSITION_RIGHT, 1);
+    }
+
+    /**
+     * Determine the adoption badge tier based on percentage.
+     *
+     * @return array{label: string, class: string, icon: string}
+     */
+    private static function adoptionBadge(float $percentage, int $totalUsers): array
+    {
+        if ($totalUsers === 0) {
+            return ['label' => 'No users', 'class' => 'badge-secondary', 'icon' => 'actions-minus'];
+        }
+
+        return match (true) {
+            $percentage >= 100.0 => ['label' => 'Platinum', 'class' => 'badge-info', 'icon' => 'actions-bolt'],
+            $percentage >= 75.0 => ['label' => 'Gold', 'class' => 'badge-warning', 'icon' => 'actions-star'],
+            $percentage >= 50.0 => ['label' => 'Silver', 'class' => 'badge-secondary', 'icon' => 'actions-check'],
+            $percentage >= 25.0 => ['label' => 'Bronze', 'class' => 'badge-success', 'icon' => 'actions-arrow-up'],
+            default => ['label' => 'Getting started', 'class' => 'badge-danger', 'icon' => 'actions-rocket'],
+        };
+    }
 }

--- a/Classes/Controller/AdminModuleController.php
+++ b/Classes/Controller/AdminModuleController.php
@@ -91,7 +91,7 @@ final class AdminModuleController
             'totalUsers' => $stats->totalUsers,
             'usersWithPasskeys' => $stats->usersWithPasskeys,
             'adoptionPercentage' => $adoptionPercentage,
-            'adoptionBadge' => self::adoptionBadge($adoptionPercentage, $stats->totalUsers),
+            'adoptionBadge' => $this->adoptionBadge($adoptionPercentage, $stats->totalUsers),
             'groups' => $groupData,
             'usersWithoutPasskeys' => $userData,
             'enforcementLevels' => $this->getEnforcementLevelOptions(),
@@ -206,18 +206,18 @@ final class AdminModuleController
      *
      * @return array{label: string, class: string, icon: string}
      */
-    private static function adoptionBadge(float $percentage, int $totalUsers): array
+    private function adoptionBadge(float $percentage, int $totalUsers): array
     {
         if ($totalUsers === 0) {
-            return ['label' => 'No users', 'class' => 'badge-secondary', 'icon' => 'actions-minus'];
+            return ['label' => $this->translate('dashboard.badge.noUsers', 'No users'), 'class' => 'badge-secondary', 'icon' => 'actions-minus'];
         }
 
         return match (true) {
-            $percentage >= 100.0 => ['label' => 'Platinum', 'class' => 'badge-success', 'icon' => 'actions-bolt'],
-            $percentage >= 75.0 => ['label' => 'Gold', 'class' => 'badge-info', 'icon' => 'actions-star'],
-            $percentage >= 50.0 => ['label' => 'Silver', 'class' => 'badge-secondary', 'icon' => 'actions-check'],
-            $percentage >= 25.0 => ['label' => 'Bronze', 'class' => 'badge-warning', 'icon' => 'actions-arrow-up'],
-            default => ['label' => 'Getting started', 'class' => 'badge-danger', 'icon' => 'actions-rocket'],
+            $percentage >= 100.0 => ['label' => $this->translate('dashboard.badge.platinum', 'Platinum'), 'class' => 'badge-success', 'icon' => 'actions-bolt'],
+            $percentage >= 75.0 => ['label' => $this->translate('dashboard.badge.gold', 'Gold'), 'class' => 'badge-info', 'icon' => 'actions-star'],
+            $percentage >= 50.0 => ['label' => $this->translate('dashboard.badge.silver', 'Silver'), 'class' => 'badge-secondary', 'icon' => 'actions-check'],
+            $percentage >= 25.0 => ['label' => $this->translate('dashboard.badge.bronze', 'Bronze'), 'class' => 'badge-warning', 'icon' => 'actions-arrow-up'],
+            default => ['label' => $this->translate('dashboard.badge.gettingStarted', 'Getting started'), 'class' => 'badge-danger', 'icon' => 'actions-rocket'],
         };
     }
 }

--- a/Classes/Controller/AdminModuleController.php
+++ b/Classes/Controller/AdminModuleController.php
@@ -85,14 +85,6 @@ final class AdminModuleController
         }
 
         $config = $this->configService->getConfiguration();
-        $hasEnforcement = false;
-        foreach ($groupData as $group) {
-            if ($group['enforcement'] !== EnforcementLevel::Off->value) {
-                $hasEnforcement = true;
-                break;
-            }
-        }
-
         $adoptionPercentage = $stats->adoptionPercentage();
 
         $moduleTemplate->assignMultiple([
@@ -107,8 +99,6 @@ final class AdminModuleController
             'configRpId' => $this->configService->getEffectiveRpId(),
             'configRpIdIsAutoDetected' => $config->getRpId() === '',
             'configOriginIsAutoDetected' => $config->getOrigin() === '',
-            'hasEnforcement' => $hasEnforcement,
-            'hasGroups' => $groupData !== [],
             'isNewInstallation' => $stats->usersWithPasskeys === 0,
         ]);
 
@@ -223,10 +213,10 @@ final class AdminModuleController
         }
 
         return match (true) {
-            $percentage >= 100.0 => ['label' => 'Platinum', 'class' => 'badge-info', 'icon' => 'actions-bolt'],
-            $percentage >= 75.0 => ['label' => 'Gold', 'class' => 'badge-warning', 'icon' => 'actions-star'],
+            $percentage >= 100.0 => ['label' => 'Platinum', 'class' => 'badge-success', 'icon' => 'actions-bolt'],
+            $percentage >= 75.0 => ['label' => 'Gold', 'class' => 'badge-info', 'icon' => 'actions-star'],
             $percentage >= 50.0 => ['label' => 'Silver', 'class' => 'badge-secondary', 'icon' => 'actions-check'],
-            $percentage >= 25.0 => ['label' => 'Bronze', 'class' => 'badge-success', 'icon' => 'actions-arrow-up'],
+            $percentage >= 25.0 => ['label' => 'Bronze', 'class' => 'badge-warning', 'icon' => 'actions-arrow-up'],
             default => ['label' => 'Getting started', 'class' => 'badge-danger', 'icon' => 'actions-rocket'],
         };
     }

--- a/README.md
+++ b/README.md
@@ -80,12 +80,43 @@ Activate the extension in the TYPO3 Extension Manager or via CLI:
 vendor/bin/typo3 extension:activate nr_passkeys_be
 ```
 
+## Quick Start
+
+After installation, follow these steps:
+
+1. **Review extension settings** — Go to **Admin Tools > Settings > Extension Configuration > nr_passkeys_be** and verify the Relying Party settings (`rpId`, `rpName`, `origin`). The defaults auto-detect from your domain, which works for most single-domain setups.
+
+2. **Open the Passkey Management module** — Navigate to **Admin Tools > Passkey Management**. The Dashboard shows adoption statistics and the Help tab provides a full rollout guide with recovery procedures and FAQ.
+
+3. **Register your own passkey** — Go to **User Settings > Passkeys** and register a passkey to verify the setup works on your device.
+
+4. **Enable enforcement for a pilot group** — On the Dashboard, set a small group (e.g., your admin team) to *Encourage*. Users will see a dismissible banner prompting them to set up a passkey.
+
+5. **Roll out gradually** — Progress through *Encourage* → *Required* → *Enforced* as adoption grows. See the Help tab in the backend module for the complete rollout guide.
+
+> **Full documentation:** [docs.typo3.org/p/netresearch/nr-passkeys-be](https://docs.typo3.org/p/netresearch/nr-passkeys-be/main/en-us/) · [Configuration reference](Documentation/Configuration/Index.rst)
+
+## Passkeys & MFA
+
+Passkeys are **inherently multi-factor**: they combine *something you have* (your device) with *something you are* (biometric) or *something you know* (device PIN). They are also phishing-resistant — the credential is cryptographically bound to the origin.
+
+**For most TYPO3 backends, passkeys alone are more secure than password + TOTP.** The FIDO Alliance and W3C consider passkeys a stronger replacement for password + OTP. Adding TYPO3's MFA on top is optional defence-in-depth, not a requirement.
+
+Consider keeping MFA enabled alongside passkeys only if:
+- Your security policy explicitly mandates independent factors (e.g., PCI-DSS)
+- Your threat model includes authenticator device compromise
+
+See the Help tab in **Admin Tools > Passkey Management** for details on MFA coexistence and middleware processing order.
+
 ## Configuration
 
 Extension settings are available in **Admin Tools > Settings > Extension Configuration > nr_passkeys_be**:
 
 | Setting | Default | Description |
 |---------|---------|-------------|
+| `rpId` | *(auto-detect)* | Relying Party domain (e.g., `example.com`) |
+| `rpName` | `TYPO3 Backend` | Display name shown during passkey registration |
+| `origin` | *(auto-detect)* | Full origin URL (e.g., `https://example.com`) |
 | `challengeTtlSeconds` | `120` | Challenge token lifetime in seconds |
 | `discoverableLoginEnabled` | `true` | Allow username-less login via resident credentials |
 | `disablePasswordLogin` | `false` | Block password login for users with registered passkeys |
@@ -97,7 +128,7 @@ Extension settings are available in **Admin Tools > Settings > Extension Configu
 | `userVerification` | `required` | WebAuthn user verification requirement |
 | `allowedAlgorithms` | `ES256` | Comma-separated signing algorithms |
 
-See [Configuration documentation](Documentation/Configuration/Index.rst) for all settings including `rpId`, `rpName`, and `origin`.
+See the [Configuration documentation](Documentation/Configuration/Index.rst) for detailed descriptions of each setting.
 
 ## How It Works
 
@@ -132,7 +163,9 @@ The extension registers a TYPO3 authentication service at priority 80 (above `Sa
 
 ## Documentation
 
-Full documentation is available in the [Documentation/](Documentation/) directory, covering installation, configuration, administration, and developer guides.
+- **Online documentation:** [docs.typo3.org/p/netresearch/nr-passkeys-be](https://docs.typo3.org/p/netresearch/nr-passkeys-be/main/en-us/)
+- **In the backend:** Admin Tools > Passkey Management > Help tab (rollout guide, recovery, FAQ)
+- **Source:** [Documentation/](Documentation/) directory (RST format)
 
 ## Development
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -209,6 +209,24 @@
             <trans-unit id="dashboard.usersWithout.editUser" resname="dashboard.usersWithout.editUser">
                 <source>Edit user record</source>
             </trans-unit>
+            <trans-unit id="dashboard.badge.noUsers" resname="dashboard.badge.noUsers">
+                <source>No users</source>
+            </trans-unit>
+            <trans-unit id="dashboard.badge.gettingStarted" resname="dashboard.badge.gettingStarted">
+                <source>Getting started</source>
+            </trans-unit>
+            <trans-unit id="dashboard.badge.bronze" resname="dashboard.badge.bronze">
+                <source>Bronze</source>
+            </trans-unit>
+            <trans-unit id="dashboard.badge.silver" resname="dashboard.badge.silver">
+                <source>Silver</source>
+            </trans-unit>
+            <trans-unit id="dashboard.badge.gold" resname="dashboard.badge.gold">
+                <source>Gold</source>
+            </trans-unit>
+            <trans-unit id="dashboard.badge.platinum" resname="dashboard.badge.platinum">
+                <source>Platinum</source>
+            </trans-unit>
             <trans-unit id="dashboard.allAdopted.title" resname="dashboard.allAdopted.title">
                 <source>Full Adoption</source>
             </trans-unit>

--- a/Resources/Private/Templates/AdminModule/Dashboard.html
+++ b/Resources/Private/Templates/AdminModule/Dashboard.html
@@ -10,6 +10,51 @@
     </p>
 
     <div id="passkey-dashboard">
+        <!-- Quick Start Guide (shown for new installations) -->
+        <f:if condition="{isNewInstallation}">
+            <f:be.infobox title="Getting started" state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_INFO')}">
+                <p>No passkeys have been registered yet. Follow these steps to get started:</p>
+                <ol class="mb-0">
+                    <li class="mb-2">
+                        <strong>Review extension settings</strong> &mdash;
+                        Go to <em>Admin Tools &gt; Settings &gt; Extension Configuration &gt; nr_passkeys_be</em>
+                        and verify the Relying Party settings.
+                        <f:if condition="{configRpIdIsAutoDetected}">
+                            <br /><span class="text-body-secondary">
+                                Relying Party ID is currently auto-detected as <code>{configRpId}</code>.
+                                For production, consider setting it explicitly.
+                            </span>
+                        </f:if>
+                    </li>
+                    <li class="mb-2">
+                        <strong>Register your own passkey first</strong> &mdash;
+                        Go to your <em>User Settings &gt; Passkeys</em> tab and register a passkey
+                        to verify the setup works on your device.
+                    </li>
+                    <li class="mb-2">
+                        <strong>Set a pilot group to &quot;Encourage&quot;</strong> &mdash;
+                        Use the group table below to set a small group (e.g., your admin team)
+                        to <em>Encourage</em>. Users will see a dismissible banner prompting them
+                        to register a passkey.
+                    </li>
+                    <li>
+                        <strong>Roll out gradually</strong> &mdash;
+                        See the <a href="{helpUrl}">Help tab</a> for a full rollout guide
+                        covering all enforcement levels and recovery procedures.
+                    </li>
+                </ol>
+            </f:be.infobox>
+        </f:if>
+
+        <!-- Configuration hints -->
+        <f:if condition="{configRpIdIsAutoDetected} && {configOriginIsAutoDetected} && {isNewInstallation} == 0">
+            <f:be.infobox title="Configuration note" state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_WARNING')}">
+                Both Relying Party ID and Origin are auto-detected (currently <code>{configRpId}</code>).
+                For production environments with multiple domains or reverse proxies, consider setting
+                these explicitly in <em>Admin Tools &gt; Settings &gt; Extension Configuration</em>.
+            </f:be.infobox>
+        </f:if>
+
         <!-- Adoption Statistics Cards -->
         <div class="card-container mb-4" role="group" aria-label="{f:translate(key: 'dashboard.adoption.title', extensionName: 'NrPasskeysBe')}">
             <div class="card card-size-fixed-small">
@@ -34,11 +79,27 @@
                         <span class="card-title" aria-label="{f:format.number(decimals: 1)}{adoptionPercentage}{/f:format.number}% {f:translate(key: 'dashboard.adoptionRate', extensionName: 'NrPasskeysBe')}">
                             <f:format.number decimals="1">{adoptionPercentage}</f:format.number>%
                         </span>
-                        <span class="card-subtitle"><f:translate key="dashboard.adoptionRate" extensionName="NrPasskeysBe" /></span>
+                        <span class="card-subtitle">
+                            <f:translate key="dashboard.adoptionRate" extensionName="NrPasskeysBe" />
+                            <span class="badge {adoptionBadge.class} ms-1">
+                                <core:icon identifier="{adoptionBadge.icon}" size="small" />
+                                {adoptionBadge.label}
+                            </span>
+                        </span>
                     </div>
                 </div>
             </div>
         </div>
+
+        <!-- MFA hint: suggest dropping MFA when passkeys are adopted -->
+        <f:if condition="{usersWithPasskeys} > 0">
+            <f:be.infobox title="Passkeys &amp; MFA" state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_NOTICE')}">
+                Passkeys are inherently multi-factor (device + biometric/PIN) and phishing-resistant.
+                For most environments, passkeys alone are more secure than password + TOTP.
+                Consider disabling the MFA requirement for passkey-authenticated users.
+                <a href="{helpUrl}">Learn more in the Help tab.</a>
+            </f:be.infobox>
+        </f:if>
 
         <!-- Group Enforcement Table -->
         <f:if condition="{groups}">
@@ -139,12 +200,12 @@
                                     <td>
                                         <f:if condition="{user.gracePeriodRemainingDays} > 0">
                                             <f:then>
-                                                <span class="badge text-bg-warning">{user.gracePeriodRemainingDays} <f:translate key="dashboard.usersWithout.days" extensionName="NrPasskeysBe" /></span>
+                                                <span class="badge badge-warning">{user.gracePeriodRemainingDays} <f:translate key="dashboard.usersWithout.days" extensionName="NrPasskeysBe" /></span>
                                             </f:then>
                                             <f:else>
                                                 <f:if condition="{user.gracePeriodStart} > 0">
                                                     <f:then>
-                                                        <span class="badge text-bg-danger"><f:translate key="dashboard.usersWithout.expired" extensionName="NrPasskeysBe" /></span>
+                                                        <span class="badge badge-danger"><f:translate key="dashboard.usersWithout.expired" extensionName="NrPasskeysBe" /></span>
                                                     </f:then>
                                                     <f:else>
                                                         <span class="text-body-secondary">-</span>
@@ -156,7 +217,7 @@
                                     <td>
                                         <f:if condition="{user.hasActiveNudge}">
                                             <f:then>
-                                                <span class="badge text-bg-info"><f:translate key="dashboard.usersWithout.nudgeActive" extensionName="NrPasskeysBe">Active</f:translate></span>
+                                                <span class="badge badge-info"><f:translate key="dashboard.usersWithout.nudgeActive" extensionName="NrPasskeysBe">Active</f:translate></span>
                                             </f:then>
                                             <f:else>
                                                 <span class="text-body-secondary">-</span>
@@ -201,7 +262,7 @@
             </f:then>
             <f:else>
                 <f:if condition="{groups}">
-                    <f:be.infobox title="{f:translate(key: 'dashboard.allAdopted.title', extensionName: 'NrPasskeysBe')}" state="{f:constant(name: 'TYPO3\CMS\Core\Type\ContextualFeedbackSeverity::OK')}">
+                    <f:be.infobox title="{f:translate(key: 'dashboard.allAdopted.title', extensionName: 'NrPasskeysBe')}" state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_OK')}">
                         <f:translate key="dashboard.allAdopted.body" extensionName="NrPasskeysBe">All active backend users have registered passkeys.</f:translate>
                     </f:be.infobox>
                 </f:if>

--- a/Resources/Private/Templates/AdminModule/Dashboard.html
+++ b/Resources/Private/Templates/AdminModule/Dashboard.html
@@ -47,7 +47,7 @@
         </f:if>
 
         <!-- Configuration hints -->
-        <f:if condition="{configRpIdIsAutoDetected} && {configOriginIsAutoDetected} && {isNewInstallation} == 0">
+        <f:if condition="{configRpIdIsAutoDetected} && {configOriginIsAutoDetected} && !{isNewInstallation}">
             <f:be.infobox title="Configuration note" state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_WARNING')}">
                 Both Relying Party ID and Origin are auto-detected (currently <code>{configRpId}</code>).
                 For production environments with multiple domains or reverse proxies, consider setting

--- a/Resources/Private/Templates/AdminModule/Help.html
+++ b/Resources/Private/Templates/AdminModule/Help.html
@@ -54,7 +54,7 @@
                 login reminding them to register a passkey. They can dismiss the
                 banner and continue working normally.
             </p>
-            <f:be.infobox title="Tip" state="{f:constant(name: 'TYPO3\CMS\Core\Type\ContextualFeedbackSeverity::INFO')}">
+            <f:be.infobox title="Tip" state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_INFO')}">
                 Start with a pilot group (e.g., your admin team) to validate the
                 workflow before widening the rollout.
             </f:be.infobox>
@@ -146,7 +146,7 @@
                     re-register a passkey.
                 </li>
             </ul>
-            <f:be.infobox title="Important" state="{f:constant(name: 'TYPO3\CMS\Core\Type\ContextualFeedbackSeverity::WARNING')}">
+            <f:be.infobox title="Important" state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_WARNING')}">
                 Remember to restore the group's enforcement level after the user
                 has re-registered a passkey. Leaving enforcement lowered
                 indefinitely weakens your security posture.
@@ -159,35 +159,56 @@
     <!-- ================================================================== -->
     <div class="card mb-3">
         <div class="card-header">
-            <h2 class="card-title mb-0">MFA coexistence</h2>
+            <h2 class="card-title mb-0">Passkeys &amp; MFA (two-factor authentication)</h2>
         </div>
         <div class="card-body">
-            <p>
-                Passkeys and TYPO3's built-in multi-factor authentication (MFA) serve
-                different purposes and can be used together.
-            </p>
+            <f:be.infobox title="Are passkeys secure enough without additional MFA?" state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_INFO')}">
+                <p>
+                    <strong>Yes, for most use cases.</strong> Passkeys are inherently
+                    multi-factor: they combine <em>something you have</em> (your device)
+                    with <em>something you are</em> (biometric) or <em>something you
+                    know</em> (device PIN). They are also phishing-resistant by design
+                    &mdash; the credential is cryptographically bound to the origin and
+                    cannot be replayed on a different site.
+                </p>
+                <p>
+                    The FIDO Alliance and W3C consider passkeys a
+                    <strong>stronger replacement for password + OTP</strong>.
+                    For most TYPO3 backends, passkey-only login is more secure than
+                    password + TOTP. Adding MFA on top is optional defence-in-depth,
+                    not a requirement.
+                </p>
+            </f:be.infobox>
 
             <h3>Passkeys replace passwords, not MFA</h3>
             <p>
-                A passkey is a <strong>password replacement</strong>. It proves the
-                user's identity through a cryptographic challenge verified by their
-                device's biometric sensor or security key. It does
-                <strong>not</strong> replace the MFA step.
+                Technically, a passkey is a <strong>password replacement</strong> in
+                TYPO3's authentication chain. It proves the user's identity through a
+                cryptographic challenge verified by their device's biometric sensor or
+                security key. TYPO3's MFA layer runs independently after authentication.
             </p>
 
-            <h3>MFA adds an independent second factor</h3>
+            <h3>Do I need both passkeys and MFA?</h3>
             <p>
-                TYPO3's MFA (TOTP, recovery codes, etc.) adds a separate
-                verification layer. If MFA is required for a user or group, it
-                will still be prompted <em>in addition</em> to the passkey login.
+                For most environments, <strong>passkeys alone provide stronger security
+                than password + TOTP</strong>. Consider keeping MFA enabled only if:
+            </p>
+            <ul>
+                <li>Your security policy explicitly requires defence-in-depth with independent factors</li>
+                <li>You need compliance with standards that mandate a separate MFA step (e.g., PCI-DSS)</li>
+                <li>Your threat model includes authenticator device compromise</li>
+            </ul>
+            <p>
+                If none of the above apply, you can safely disable TYPO3's MFA requirement
+                for passkey-authenticated users without reducing your security posture.
             </p>
 
             <h3>Both can be active simultaneously</h3>
             <p>
                 A user can have both a registered passkey and an active MFA provider.
-                This provides defence in depth: the passkey protects against
-                credential theft and phishing, while MFA protects against
-                authenticator compromise.
+                If MFA is required for a user or group, it will still be prompted
+                <em>in addition</em> to the passkey login. This provides maximum
+                defence-in-depth but adds friction.
             </p>
 
             <h3>Middleware processing order</h3>
@@ -213,7 +234,7 @@
                     <strong>Backend rendering</strong> &mdash; normal backend access.
                 </li>
             </ol>
-            <f:be.infobox title="Note" state="{f:constant(name: 'TYPO3\CMS\Core\Type\ContextualFeedbackSeverity::NOTICE')}">
+            <f:be.infobox title="Note" state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_NOTICE')}">
                 Users who log in with a passkey skip step 3 entirely because they
                 have already proven they own a registered credential.
             </f:be.infobox>

--- a/Tests/Unit/Controller/AdminModuleControllerTest.php
+++ b/Tests/Unit/Controller/AdminModuleControllerTest.php
@@ -9,17 +9,21 @@ declare(strict_types=1);
 
 namespace Netresearch\NrPasskeysBe\Tests\Unit\Controller;
 
+use Netresearch\NrPasskeysBe\Configuration\ExtensionConfiguration as ExtensionConfigurationVO;
 use Netresearch\NrPasskeysBe\Controller\AdminModuleController;
 use Netresearch\NrPasskeysBe\Domain\Dto\AdoptionStats;
 use Netresearch\NrPasskeysBe\Domain\Dto\GroupEnforcementInfo;
 use Netresearch\NrPasskeysBe\Domain\Dto\UserPasskeyStatus;
 use Netresearch\NrPasskeysBe\Service\AdoptionStatsService;
+use Netresearch\NrPasskeysBe\Service\ExtensionConfigurationService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Backend\Template\Components\ButtonBar;
+use TYPO3\CMS\Backend\Template\Components\Buttons\LinkButton;
 use TYPO3\CMS\Backend\Template\Components\DocHeaderComponent;
 use TYPO3\CMS\Backend\Template\Components\Menu\Menu;
 use TYPO3\CMS\Backend\Template\Components\Menu\MenuItem;
@@ -27,6 +31,8 @@ use TYPO3\CMS\Backend\Template\Components\MenuRegistry;
 use TYPO3\CMS\Backend\Template\ModuleTemplate;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Http\HtmlResponse;
+use TYPO3\CMS\Core\Imaging\Icon;
+use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Page\PageRenderer;
 
@@ -39,6 +45,10 @@ final class AdminModuleControllerTest extends TestCase
 
     private AdoptionStatsService&MockObject $adoptionStatsService;
 
+    private ExtensionConfigurationService&MockObject $configService;
+
+    private IconFactory&MockObject $iconFactory;
+
     private PageRenderer&MockObject $pageRenderer;
 
     private UriBuilder&MockObject $uriBuilder;
@@ -49,6 +59,11 @@ final class AdminModuleControllerTest extends TestCase
 
         $this->moduleTemplateFactory = $this->createMock(ModuleTemplateFactory::class);
         $this->adoptionStatsService = $this->createMock(AdoptionStatsService::class);
+        $this->configService = $this->createMock(ExtensionConfigurationService::class);
+        $this->configService->method('getConfiguration')->willReturn(new ExtensionConfigurationVO());
+        $this->configService->method('getEffectiveRpId')->willReturn('localhost');
+        $this->iconFactory = $this->createMock(IconFactory::class);
+        $this->iconFactory->method('getIcon')->willReturn($this->createMock(Icon::class));
         $this->pageRenderer = $this->createMock(PageRenderer::class);
         $this->uriBuilder = $this->createMock(UriBuilder::class);
         $this->uriBuilder->method('buildUriFromRoute')->willReturn('/typo3/record/edit?mocked=1');
@@ -56,6 +71,8 @@ final class AdminModuleControllerTest extends TestCase
         $this->subject = new AdminModuleController(
             $this->moduleTemplateFactory,
             $this->adoptionStatsService,
+            $this->configService,
+            $this->iconFactory,
             $this->pageRenderer,
             $this->uriBuilder,
         );
@@ -78,8 +95,18 @@ final class AdminModuleControllerTest extends TestCase
         $menuRegistry = $this->createMock(MenuRegistry::class);
         $menuRegistry->method('makeMenu')->willReturn($menu);
 
+        $linkButton = $this->createMock(LinkButton::class);
+        $linkButton->method('setHref')->willReturnSelf();
+        $linkButton->method('setTitle')->willReturnSelf();
+        $linkButton->method('setIcon')->willReturnSelf();
+        $linkButton->method('setShowLabelText')->willReturnSelf();
+
+        $buttonBar = $this->createMock(ButtonBar::class);
+        $buttonBar->method('makeLinkButton')->willReturn($linkButton);
+
         $docHeader = $this->createMock(DocHeaderComponent::class);
         $docHeader->method('getMenuRegistry')->willReturn($menuRegistry);
+        $docHeader->method('getButtonBar')->willReturn($buttonBar);
 
         $moduleTemplate = $this->createMock(ModuleTemplate::class);
         $moduleTemplate->method('getDocHeaderComponent')->willReturn($docHeader);
@@ -125,7 +152,10 @@ final class AdminModuleControllerTest extends TestCase
                     && isset($variables['enforcementLevels']['off'])
                     && isset($variables['enforcementLevels']['encourage'])
                     && isset($variables['enforcementLevels']['required'])
-                    && isset($variables['enforcementLevels']['enforced']);
+                    && isset($variables['enforcementLevels']['enforced'])
+                    && \array_key_exists('helpUrl', $variables)
+                    && \array_key_exists('configRpId', $variables)
+                    && \array_key_exists('isNewInstallation', $variables);
             }));
 
         $expectedResponse = new HtmlResponse('<html></html>');

--- a/Tests/Unit/Controller/AdminModuleControllerTest.php
+++ b/Tests/Unit/Controller/AdminModuleControllerTest.php
@@ -17,6 +17,7 @@ use Netresearch\NrPasskeysBe\Domain\Dto\UserPasskeyStatus;
 use Netresearch\NrPasskeysBe\Service\AdoptionStatsService;
 use Netresearch\NrPasskeysBe\Service\ExtensionConfigurationService;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -389,5 +390,65 @@ final class AdminModuleControllerTest extends TestCase
             'required' => 'Erforderlich',
             'enforced' => 'Erzwungen',
         ], $levels);
+    }
+
+    /**
+     * @return array<string, array{int, int, string}>
+     */
+    public static function adoptionBadgeTierProvider(): array
+    {
+        return [
+            'no users' => [0, 0, 'No users'],
+            'getting started (0%)' => [10, 0, 'Getting started'],
+            'getting started (20%)' => [10, 2, 'Getting started'],
+            'bronze (25%)' => [4, 1, 'Bronze'],
+            'bronze (49%)' => [100, 49, 'Bronze'],
+            'silver (50%)' => [10, 5, 'Silver'],
+            'silver (74%)' => [100, 74, 'Silver'],
+            'gold (75%)' => [4, 3, 'Gold'],
+            'gold (99%)' => [100, 99, 'Gold'],
+            'platinum (100%)' => [5, 5, 'Platinum'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('adoptionBadgeTierProvider')]
+    public function dashboardActionAssignsCorrectAdoptionBadge(int $totalUsers, int $withPasskeys, string $expectedLabel): void
+    {
+        $stats = new AdoptionStats(
+            totalUsers: $totalUsers,
+            usersWithPasskeys: $withPasskeys,
+            groups: [],
+            usersWithoutPasskeys: [],
+        );
+
+        $this->adoptionStatsService
+            ->method('getStats')
+            ->willReturn($stats);
+
+        $capturedVariables = [];
+        $moduleTemplate = $this->createModuleTemplateMock();
+        $moduleTemplate->method('setTitle');
+        $moduleTemplate->method('assignMultiple')
+            ->willReturnCallback(static function (array $vars) use (&$capturedVariables, $moduleTemplate): ModuleTemplate {
+                $capturedVariables = $vars;
+                return $moduleTemplate;
+            });
+        $moduleTemplate->method('renderResponse')
+            ->willReturn(new HtmlResponse('<html></html>'));
+
+        $this->moduleTemplateFactory
+            ->method('create')
+            ->willReturn($moduleTemplate);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $this->subject->dashboardAction($request);
+
+        self::assertArrayHasKey('adoptionBadge', $capturedVariables);
+        $badge = $capturedVariables['adoptionBadge'];
+        self::assertIsArray($badge);
+        self::assertSame($expectedLabel, $badge['label']);
+        self::assertArrayHasKey('class', $badge);
+        self::assertArrayHasKey('icon', $badge);
     }
 }


### PR DESCRIPTION
## Summary

Addresses user feedback from [NRNR-1532](https://jira.netresearch.de/browse/NRNR-1532):

- **Quick Start guide** on Dashboard for new installations (no passkeys yet) with step-by-step setup instructions and config status hints
- **Help button** in DocHeader (question-mark icon via ButtonBar API) so the Help tab is discoverable without the dropdown menu
- **MFA hint** on Dashboard suggesting admins can drop MFA requirement when passkeys are active
- **Adoption badges** (gamification): Getting started → Bronze → Silver → Gold → Platinum, always visible on adoption rate card
- **Enhanced Help page**: renamed MFA section to "Passkeys & MFA", added prominent "Are passkeys secure enough without MFA?" infobox
- **README**: Quick Start section, Passkeys & MFA guidance, TER docs link, rpId/rpName/origin in config table

### Cross-version compatibility

- Uses `InfoboxViewHelper::STATE_*` integer constants (works on v12/v13/v14) instead of `ContextualFeedbackSeverity` enum (v14 only as infobox state)
- Uses `enum_exists(IconSize::class)` runtime check with `'small'` string fallback for v12
- All UI elements follow TYPO3 backend conventions (`f:be.infobox`, `badge-*` classes, `card-container`, ButtonBar API)

## Test plan

- [ ] Dashboard shows "Getting started" card when no passkeys are registered
- [ ] Dashboard shows adoption badge (Getting started/Bronze/Silver/Gold/Platinum)
- [ ] Dashboard shows MFA hint when users have passkeys
- [ ] Help button (question-mark icon) visible in DocHeader on all views
- [ ] Help tab renders correctly with enhanced MFA section
- [ ] Verify on v12, v13, and v14 — no rendering errors
- [ ] PHPStan, unit tests, CGL pass