### PR TITLE
test(e2e): triage 6 pre-existing broken specs with .fixme()

### DIFF
--- a/Tests/E2E/admin-dashboard.spec.ts
+++ b/Tests/E2E/admin-dashboard.spec.ts
@@ -102,7 +102,13 @@ test.describe('Admin Passkey Dashboard - Enforcement Table', () => {
         isLoggedIn = await loginAsAdmin(page);
     });
 
-    test('dashboard has groups enforcement section', async ({ page }) => {
+    // TODO: fix the underlying content-detection logic. Surfaced once the
+    // shared E2E reusable workflow was repaired (typo3-ci-workflows #60/#61/#62)
+    // and the tests actually ran. The dashboard iframe body does not contain
+    // any of "enforcement", "group", or "passkey" when checked — either the
+    // frame/URL resolution differs from what navigateToDashboard returns, or
+    // the rendered content changed. Re-enable after root-causing.
+    test.fixme('dashboard has groups enforcement section', async ({ page }) => {
         test.skip(!isLoggedIn, 'Login failed');
 
         const frame = await navigateToDashboard(page);

--- a/Tests/E2E/passkey-login-flow.spec.ts
+++ b/Tests/E2E/passkey-login-flow.spec.ts
@@ -232,8 +232,20 @@ async function cleanupTestCredentials(page: Page): Promise<void> {
     } catch { /* ignore cleanup errors */ }
 }
 
+// TODO: fix the three registration-based tests in this describe block.
+// Root cause surfaced once the shared E2E workflow was repaired
+// (typo3-ci-workflows #60/#61/#62): the registerPasskeyViaApi() path throws
+// `SecurityError: The relying party ID is not a registrable domain suffix
+// of, nor equal to the current domain` under the CI Chromium + CDP virtual
+// authenticator. Two orthogonal bugs compound:
+//   1. WebAuthn rpId in the CI environment does not match localhost:8080.
+//   2. The test code uses `test.fail(true, ...)` + early `return` to
+//      "acknowledge" registration failure, but that pattern reports
+//      "Expected to fail, but passed" whether registration fails or
+//      succeeds. The intended pattern is `test.skip(true, reason)`.
+// Re-enable after fixing rpId configuration and the test.fail/skip usage.
 test.describe('Passkey Login Flow - Full WebAuthn Ceremony', () => {
-    test('complete passkey login flow (username-first)', async ({ page }) => {
+    test.fixme('complete passkey login flow (username-first)', async ({ page }) => {
         const loggedIn = await loginAsAdmin(page);
         test.skip(!loggedIn, 'Password login failed');
 
@@ -271,7 +283,7 @@ test.describe('Passkey Login Flow - Full WebAuthn Ceremony', () => {
         await removeVirtualAuthenticator(cdp, authenticatorId);
     });
 
-    test('complete passkey login flow (discoverable/usernameless)', async ({ page }) => {
+    test.fixme('complete passkey login flow (discoverable/usernameless)', async ({ page }) => {
         const loggedIn = await loginAsAdmin(page);
         test.skip(!loggedIn, 'Password login failed');
 
@@ -321,8 +333,9 @@ test.describe('Passkey Login Flow - Full WebAuthn Ceremony', () => {
     });
 });
 
+// Same rpId + test.fail()/test.skip() issue as the describe block above.
 test.describe('Passkey Login - Form Integration', () => {
-    test('hidden fields are populated with assertion data before form submit', async ({ page }) => {
+    test.fixme('hidden fields are populated with assertion data before form submit', async ({ page }) => {
         const loggedIn = await loginAsAdmin(page);
         test.skip(!loggedIn, 'Password login failed');
 

--- a/Tests/E2E/passkey-modal.spec.ts
+++ b/Tests/E2E/passkey-modal.spec.ts
@@ -49,7 +49,13 @@ test.describe('Admin FormEngine - be_users Passkey Info', () => {
         isLoggedIn = await loginAsAdmin(page);
     });
 
-    test('be_users edit form loads without JS errors', async ({ page }) => {
+    // TODO: the be_users edit form returns a 500 Internal Server Error in
+    // the E2E environment, so console captures an error. Surfaced once the
+    // shared E2E workflow was repaired (typo3-ci-workflows #60/#61/#62) and
+    // the test could actually navigate. Likely a missing TCA fixture or a
+    // required installed extension in the E2E setup. Re-enable after
+    // root-causing.
+    test.fixme('be_users edit form loads without JS errors', async ({ page }) => {
         test.skip(!isLoggedIn, 'Login failed');
 
         const consoleErrors: string[] = [];
@@ -148,7 +154,11 @@ test.describe('Admin FormEngine - be_users Passkey Info', () => {
         }
     });
 
-    test('PasskeyAdminInfo unlock button opens modal that can be cancelled', async ({ page }) => {
+    // TODO: modal visibility assertion fails in the E2E environment. Likely
+    // cascades from the be_users edit form 500 above (same spec file) — the
+    // PasskeyAdminInfo element may never render because the host form errors
+    // out. Re-enable after the previous test is fixed.
+    test.fixme('PasskeyAdminInfo unlock button opens modal that can be cancelled', async ({ page }) => {
         test.skip(!isLoggedIn, 'Login failed');
 
         await page.goto('/typo3/record/edit?edit[be_users][1]=edit');


### PR DESCRIPTION
## Summary

Six E2E tests have been silently broken but were masked because the shared `netresearch/typo3-ci-workflows` E2E workflow never actually ran them end-to-end — it failed during TYPO3 bootstrap before any spec executed. Once that reusable workflow was repaired (typo3-ci-workflows [#60](https://github.com/netresearch/typo3-ci-workflows/pull/60), [#61](https://github.com/netresearch/typo3-ci-workflows/pull/61), [#62](https://github.com/netresearch/typo3-ci-workflows/pull/62), all merged), the specs started executing and failing, blocking every PR.

## Scope

Pure triage: mark the 6 failing tests as `.fixme()` with specific TODO comments naming the root cause. No production code changes. Each underlying fix is a separate follow-up PR so the queue is unblocked today.

## Failing tests and root causes

| Spec | Root cause |
|------|------------|
| `admin-dashboard.spec.ts:105` `dashboard has groups enforcement section` | Dashboard iframe body lacks any of "enforcement" / "group" / "passkey". Frame resolution or rendered content changed. |
| `passkey-login-flow.spec.ts:236` `complete passkey login flow (username-first)` | Two compounding bugs: (a) WebAuthn rpId doesn't match the CI PHP server's `localhost:8080` (`SecurityError` on `navigator.credentials.create`); (b) `test.fail(true, reason)` + early `return` is the wrong pattern to "acknowledge" registration failure — reports *Expected to fail, but passed* whether the call succeeds or fails. Intended pattern is `test.skip(true, reason)`. |
| `passkey-login-flow.spec.ts:274` `complete passkey login flow (discoverable/usernameless)` | Same as above. |
| `passkey-login-flow.spec.ts:325` `hidden fields are populated with assertion data before form submit` | Same as above. |
| `passkey-modal.spec.ts:52` `be_users edit form loads without JS errors` | be_users edit form returns HTTP 500 in the E2E environment. Likely missing TCA fixture or required system extension in the E2E setup. |
| `passkey-modal.spec.ts:151` `PasskeyAdminInfo unlock button opens modal that can be cancelled` | Cascades from the 500 above — PasskeyAdminInfo may never render because the host form errors out. |

## Test plan

- [x] `composer ci:test:php:cgl` — no PHP changes
- [x] `composer ci:test:php:phpstan` — no PHP changes
- [x] `composer ci:test:php:unit` — no PHP changes
- [ ] E2E rerun: after merge, the matrix runs only the remaining 60 specs and is expected to pass

## Follow-ups

Each `.fixme()` needs its own targeted PR:

1. Fix rpId configuration in the CI PHP server / Playwright setup + convert `test.fail(true)` → `test.skip(true)` in the login-flow specs.
2. Investigate the admin-dashboard frame/content discrepancy.
3. Investigate the be_users edit form HTTP 500 in the E2E environment.