### PR TITLE
fix(docs): replace Documentation/CLAUDE.md symlink with real file (unblocks Intercept render)

### DIFF
--- a/Documentation/CLAUDE.md
+++ b/Documentation/CLAUDE.md
@@ -1,1 +1,73 @@
-AGENTS.md
+<!-- FOR AI AGENTS - Scoped to Documentation/ -->
+<!-- Last updated: 2026-03-02 -->
+
+# Documentation AGENTS.md
+
+**Scope:** TYPO3 extension documentation following docs.typo3.org standards.
+
+## Structure
+
+```
+Documentation/
+  Index.rst                          -> Main entry point (toctree)
+  guides.xml                         -> Render configuration (version must match ext_emconf.php)
+  Includes.rst.txt                   -> Shared substitutions and highlight directive
+  Introduction/Index.rst             -> What the extension does, features, support matrix
+  Installation/Index.rst             -> Composer install, activation, system requirements
+  Configuration/Index.rst            -> Extension settings (13 confvals)
+  DeploymentScenarios/Index.rst      -> Multi-env setup, DB sync, shared rpId
+  DeploymentScenarios/Onboarding.rst -> User onboarding, recovery, DDEV, containers
+  Usage/Index.rst                    -> End-user guide: registering/using passkeys
+  Administration/Index.rst           -> Admin guide: API endpoints, lockouts, revocation
+  Administration/Enforcement.rst     -> Enforcement levels, grace periods, dashboard
+  Administration/Database.rst        -> Credential lifecycle, table schema, monitoring
+  DeveloperGuide/Index.rst           -> Developer guide entry point
+  DeveloperGuide/Architecture.rst    -> Extension structure, auth flow, domain model
+  DeveloperGuide/ControllersAndServices.rst -> Routes, controllers, services, JS modules
+  DeveloperGuide/Testing.rst         -> Test commands and test suite overview
+  Security/Index.rst                 -> Security model, threat mitigation
+  Security/Deployment.rst            -> Production deployment requirements
+  Troubleshooting/Index.rst          -> Common errors, logging, debug mode
+  Changelog/Index.rst                -> Version history
+```
+
+## Standards
+
+- **Format**: reStructuredText (.rst)
+- **Encoding**: UTF-8, LF line endings, 4-space indentation
+- **Max line length**: 80 characters
+- **File naming**: CamelCase directories, `Index.rst` in each
+- **Headings**: Sentence case, underline characters: `=` (h1), `-` (h2), `~` (h3), `^` (h4)
+- **Code blocks**: Use `.. code-block::` with `:caption:` for 5+ lines
+- **Cross-references**: Use `:ref:` labels, not file paths
+- **TYPO3 directives**: `.. confval::`, `.. versionadded::`, `.. deprecated::`, `.. note::`, `.. tip::`
+
+## Rendering
+
+```bash
+# Local rendering via DDEV
+ddev docs
+
+# Or directly via Docker
+docker run --rm -v $(pwd):/project ghcr.io/typo3-documentation/render-guides:latest \
+  --no-progress --output=/project/Documentation-GENERATED-temp /project/Documentation
+```
+
+Output goes to `Documentation-GENERATED-temp/` (gitignored).
+
+## Publishing
+
+- Published via docs.typo3.org webhook (configured on GitHub)
+- Extension registered at extensions.typo3.org as `nr_passkeys_be`
+- `guides.xml` contains interlink shortcode and project metadata
+
+## Rules
+
+- Update `guides.xml` version + `ext_emconf.php` version together at release time
+- Keep RST compatible with TYPO3 render-guides (phpDocumentor-based)
+- Screenshots go in `Images/` subdirectories as PNG with `:alt:` text
+- Every directory must have an `Index.rst`
+- Use `.. versionadded::` for new features, `.. deprecated::` for removed ones
+- Keep README.md and Documentation/ in sync (config names, feature list, API endpoints)
+- Use `.. confval::` for configuration settings, `:guilabel:` for UI elements
+- Route paths in docs are relative to `/typo3/` (see DeveloperGuide note)


### PR DESCRIPTION
## Summary

TYPO3 render-guides fails on symlinks. The v0.8.1 tag push triggered Intercept's render job, which aborted with:

\`\`\`
[League\\Flysystem\\SymbolicLinkEncountered]
Unsupported symbolic link encountered at location
/github/workspace/t3docsproject/Documentation/CLAUDE.md
\`\`\`

See the failed run: [TYPO3-Documentation/t3docs-ci-deploy#24833594481](https://github.com/TYPO3-Documentation/t3docs-ci-deploy/actions/runs/24833594481). docs.typo3.org has no \`/0.8.x/en-us/\` tree for this extension as a result.

## Fix

Replace the \`Documentation/CLAUDE.md\` symlink (pointed at \`AGENTS.md\`) with a real file copy. The other symlinks in the repo (root \`CLAUDE.md\`, \`Classes/\`, \`Tests/\`, \`Resources/\`, \`.github/workflows/\`) are outside the render scope and stay untouched.

## Tradeoff

One file needs to stay in sync with \`Documentation/AGENTS.md\`. Follow-up: add a CI check that diffs the two files and fails if they diverge — keeps the single-source-of-truth discipline with a mechanical safety net.

## Test plan

- [ ] Merge this PR.
- [ ] Push to \`main\` re-triggers Intercept for the main branch; check [t3docs-ci-deploy actions](https://github.com/TYPO3-Documentation/t3docs-ci-deploy/actions/workflows/main-rendering.yml) for a success.
- [ ] Cut v0.8.2 to verify the full release orchestrator end-to-end with rendering working.