### PR TITLE
chore: support TYPO3 14.3 LTS (incl. webauthn-lib 5.3 migration)

### DIFF
--- a/.ddev/commands/web/install-v14
+++ b/.ddev/commands/web/install-v14
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-## Description: Install TYPO3 14.x with your extension
+## Description: Install TYPO3 14.3 LTS with your extension
 ## Usage: install-v14
 ## Example: ddev install-v14
 
@@ -13,18 +13,17 @@ composer config extra.typo3/cms.web-dir public -d /var/www/html/$VERSION
 composer config repositories.$EXTENSION_KEY path ../../$EXTENSION_KEY -d /var/www/html/$VERSION
 composer config --no-plugins allow-plugins.typo3/cms-composer-installers true -d /var/www/html/$VERSION
 composer config --no-plugins allow-plugins.typo3/class-alias-loader true -d /var/www/html/$VERSION
-# t3/cms has no v14 release - use typo3/minimal + additional packages
 # typo3/minimal provides: cms-core, cms-backend, cms-extbase, cms-filelist, cms-fluid, cms-frontend
 # typo3/cms-install provides: setup command, configuration:set
-composer req typo3/minimal:'^14' typo3/cms-install:'^14' typo3/cms-fluid-styled-content:'^14' typo3/cms-rte-ckeditor:'^14' $PACKAGE_NAME:'*@dev' --no-progress -n -d /var/www/html/$VERSION
-composer req typo3/cms-extensionmanager --no-progress -n -d /var/www/html/$VERSION
-composer req --dev typo3/cms-styleguide --no-progress -n -d /var/www/html/$VERSION
+composer req typo3/minimal:'^14.3' typo3/cms-install:'^14.3' typo3/cms-fluid-styled-content:'^14.3' typo3/cms-rte-ckeditor:'^14.3' $PACKAGE_NAME:'*@dev' --no-progress -n -d /var/www/html/$VERSION
+composer req typo3/cms-extensionmanager:'^14.3' --no-progress -n -d /var/www/html/$VERSION
+composer req --dev typo3/cms-styleguide:'^14.3' --no-progress -n -d /var/www/html/$VERSION
 
-# Introduction Package may not support latest TYPO3 v14 - install if available
+# Introduction Package may not support TYPO3 v14.3 LTS - install if available
 if composer req typo3/cms-introduction --no-progress -n -d /var/www/html/$VERSION 2>/dev/null; then
     INTRO_INSTALLED=true
 else
-    echo "Note: typo3/cms-introduction not available for TYPO3 v14 - skipping demo content"
+    echo "Note: typo3/cms-introduction not available for TYPO3 v14.3 - skipping demo content"
     INTRO_INSTALLED=false
 fi
 
@@ -35,7 +34,7 @@ mysql -h db -u root -p"root" -e "CREATE DATABASE ${VERSION};"
 
 vendor/bin/typo3 setup -n --dbname=$VERSION --password=$TYPO3_DB_PASSWORD --create-site="https://${VERSION}.nr-passkeys-be.ddev.site" --admin-user-password=$TYPO3_SETUP_ADMIN_PASSWORD
 
-# Write all configuration directly to additional.php (configuration:set may not exist in v14)
+# Write all configuration directly to additional.php (configuration:set may not exist in v14.3)
 mkdir -p /var/www/html/$VERSION/config/system
 cat > /var/www/html/$VERSION/config/system/additional.php << 'ADDITIONALPHP'
 <?php
@@ -59,7 +58,7 @@ fi
 
 vendor/bin/typo3 extension:setup
 
-# Configure site sets for v14 (only if Bootstrap Package is available via introduction)
+# Configure site sets for v14.3 (only if Bootstrap Package is available via introduction)
 if [ "$INTRO_INSTALLED" = "true" ] && [ -f config/sites/main/config.yaml ]; then
     if ! grep -q "^dependencies:" config/sites/main/config.yaml; then
         echo "" >> config/sites/main/config.yaml
@@ -82,7 +81,7 @@ echo "TYPO3 Styleguide is available for UI pattern reference"
 if [ "$INTRO_INSTALLED" = "true" ]; then
     echo "Introduction Package installed with demo content"
 else
-    echo "Introduction Package skipped (not yet available for TYPO3 v14)"
+    echo "Introduction Package skipped (not yet available for TYPO3 v14.3)"
 fi
 
 # Auto-configure extension if configure script exists

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ TYPO3 extension for passwordless backend authentication via WebAuthn/FIDO2 Passk
 
 ## Key context
 - Extension key: `nr_passkeys_be`, Namespace: `Netresearch\NrPasskeysBe`
-- PHP ^8.2, TYPO3 ^12.4 || ^13.4 || ^14.1, `web-auth/webauthn-lib` ^5.2
+- PHP ^8.2, TYPO3 ^12.4 || ^13.4 || ^14.3, `web-auth/webauthn-lib` ^5.2
 - Passkeys are **primary credentials** (NOT MFA), auth priority 80
 - PER-CS3.0 code style, PHPStan level 10, `declare(strict_types=1)` in all files
 - Do NOT commit `composer.lock`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,7 @@ TYPO3 extension for passwordless backend authentication via WebAuthn/FIDO2 Passk
 
 ## Key context
 - Extension key: `nr_passkeys_be`, Namespace: `Netresearch\NrPasskeysBe`
-- PHP ^8.2, TYPO3 ^12.4 || ^13.4 || ^14.3, `web-auth/webauthn-lib` ^5.2
+- PHP ^8.2, TYPO3 ^12.4 || ^13.4 || ^14.3, `web-auth/webauthn-lib` ^5.3
 - Passkeys are **primary credentials** (NOT MFA), auth priority 80
 - PER-CS3.0 code style, PHPStan level 10, `declare(strict_types=1)` in all files
 - Do NOT commit `composer.lock`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
     with:
       php-versions: '["8.2", "8.3", "8.4", "8.5"]'
-      typo3-versions: '["^12.4", "^13.4", "^14.1"]'
+      typo3-versions: '["^12.4", "^13.4", "^14.3"]'
       typo3-packages: '["typo3/cms-core", "typo3/cms-backend", "typo3/cms-setup"]'
       php-extensions: intl, mbstring, xml, openssl, pdo_mysql
       run-rector: false
@@ -21,7 +21,7 @@ jobs:
       upload-coverage: false
       # typo3-ci-workflows requires phpstan-typo3 ^2||^3 which needs TYPO3 ^13.4+
       # Remove it for v12 builds; individual deps in composer.json cover v12
-      remove-dev-deps: '[{"dep":"netresearch/typo3-ci-workflows","only-for":"^13.4|^14.1"}]'
+      remove-dev-deps: '[{"dep":"netresearch/typo3-ci-workflows","only-for":"^13.4|^14.3"}]'
   e2e:
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     uses: netresearch/typo3-ci-workflows/.github/workflows/e2e.yml@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
     uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
     permissions:
       contents: read
+      actions: read
     with:
       php-versions: '["8.2", "8.3", "8.4", "8.5"]'
       typo3-versions: '["^12.4", "^13.4", "^14.3"]'
@@ -27,6 +28,7 @@ jobs:
     uses: netresearch/typo3-ci-workflows/.github/workflows/e2e.yml@main
     permissions:
       contents: read
+      actions: read
     with:
       php-version: '8.4'
       test-command: 'npm run test:e2e'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ admin dashboard with adoption stats, and onboarding UX (banner, interstitial, re
 | Namespace | `Netresearch\NrPasskeysBe` |
 | TYPO3 | ^12.4 \|\| ^13.4 \|\| ^14.3 |
 | PHP | ^8.2 |
-| WebAuthn lib | `web-auth/webauthn-lib` ^5.2 |
+| WebAuthn lib | `web-auth/webauthn-lib` ^5.3 |
 
 ## Global Rules
 - Conventional Commits: `type(scope): subject`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ admin dashboard with adoption stats, and onboarding UX (banner, interstitial, re
 | Composer | `netresearch/nr-passkeys-be` |
 | Extension key | `nr_passkeys_be` |
 | Namespace | `Netresearch\NrPasskeysBe` |
-| TYPO3 | ^12.4 \|\| ^13.4 \|\| ^14.1 |
+| TYPO3 | ^12.4 \|\| ^13.4 \|\| ^14.3 |
 | PHP | ^8.2 |
 | WebAuthn lib | `web-auth/webauthn-lib` ^5.2 |
 

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -83,4 +83,4 @@ TYPO3 extension source code. Namespace: `Netresearch\NrPasskeysBe`. Follows PER-
 - [ ] `composer ci:test:php:unit` passes
 - [ ] TCA changes have matching SQL in `ext_tables.sql`
 - [ ] No deprecated TYPO3 APIs
-- [ ] Tested on TYPO3 ^12.4, ^13.4, and ^14.1
+- [ ] Tested on TYPO3 ^12.4, ^13.4, and ^14.3

--- a/Classes/Authentication/PasskeyAuthenticationService.php
+++ b/Classes/Authentication/PasskeyAuthenticationService.php
@@ -16,10 +16,12 @@ use Netresearch\NrPasskeysBe\Service\EnforcementService;
 use Netresearch\NrPasskeysBe\Service\ExtensionConfigurationService;
 use Netresearch\NrPasskeysBe\Service\RateLimiterService;
 use Netresearch\NrPasskeysBe\Service\WebAuthnService;
+use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\NullLogger;
 use Throwable;
 use TYPO3\CMS\Core\Authentication\AbstractAuthenticationService;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -144,8 +146,7 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
 
         $rawUname = $this->login['uname'] ?? '';
         $username = \is_string($rawUname) ? $rawUname : '';
-        $rawIp = GeneralUtility::getIndpEnv('REMOTE_ADDR');
-        $ip = \is_string($rawIp) ? $rawIp : '';
+        $ip = $this->getRemoteAddress();
 
         try {
             // Check lockout
@@ -354,5 +355,26 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
         \assert($this->logger instanceof \Psr\Log\LoggerInterface);
 
         return $this->logger;
+    }
+
+    /**
+     * Resolve the remote address from the current request, with $_SERVER fallback.
+     */
+    private function getRemoteAddress(): string
+    {
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
+        if ($request instanceof ServerRequestInterface) {
+            $params = $request->getAttribute('normalizedParams');
+            if ($params instanceof NormalizedParams) {
+                return $params->getRemoteAddress();
+            }
+        }
+
+        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $sysConf = \is_array($confVars) && isset($confVars['SYS']) && \is_array($confVars['SYS'])
+            ? $confVars['SYS']
+            : [];
+
+        return NormalizedParams::createFromServerParams($_SERVER, $sysConf)->getRemoteAddress();
     }
 }

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -19,7 +19,7 @@ use RuntimeException;
 use Throwable;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Http\NormalizedParams;
 
 final class LoginController
 {
@@ -46,8 +46,7 @@ final class LoginController
             ? (string) $body['username']
             : '';
 
-        $remoteAddr = GeneralUtility::getIndpEnv('REMOTE_ADDR');
-        $ip = \is_string($remoteAddr) ? $remoteAddr : '';
+        $ip = $this->getRemoteAddress($request);
 
         // Discoverable (usernameless) login
         if ($username === '') {
@@ -145,8 +144,7 @@ final class LoginController
             return new JsonResponse(['error' => 'Missing required fields'], 400);
         }
 
-        $remoteAddr = GeneralUtility::getIndpEnv('REMOTE_ADDR');
-        $ip = \is_string($remoteAddr) ? $remoteAddr : '';
+        $ip = $this->getRemoteAddress($request);
 
         try {
             $this->rateLimiterService->checkRateLimit('login_verify', $ip);
@@ -210,6 +208,24 @@ final class LoginController
         $rawUid = $row['uid'] ?? null;
 
         return \is_numeric($rawUid) ? (int) $rawUid : null;
+    }
+
+    /**
+     * Resolve the remote address from the request, with $_SERVER fallback.
+     */
+    private function getRemoteAddress(ServerRequestInterface $request): string
+    {
+        $params = $request->getAttribute('normalizedParams');
+        if ($params instanceof NormalizedParams) {
+            return $params->getRemoteAddress();
+        }
+
+        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $sysConf = \is_array($confVars) && isset($confVars['SYS']) && \is_array($confVars['SYS'])
+            ? $confVars['SYS']
+            : [];
+
+        return NormalizedParams::createFromServerParams($_SERVER, $sysConf)->getRemoteAddress();
     }
 
 }

--- a/Classes/Domain/Dto/VerifiedAssertion.php
+++ b/Classes/Domain/Dto/VerifiedAssertion.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrPasskeysBe\Domain\Dto;
 
 use Netresearch\NrPasskeysBe\Domain\Model\Credential;
-use Webauthn\PublicKeyCredentialSource;
+use Webauthn\CredentialRecord;
 
 /**
  * Value object wrapping a verified WebAuthn assertion result.
@@ -19,6 +19,6 @@ final readonly class VerifiedAssertion
 {
     public function __construct(
         public Credential $credential,
-        public PublicKeyCredentialSource $source,
+        public CredentialRecord $source,
     ) {}
 }

--- a/Classes/Service/ExtensionConfigurationService.php
+++ b/Classes/Service/ExtensionConfigurationService.php
@@ -10,9 +10,10 @@ declare(strict_types=1);
 namespace Netresearch\NrPasskeysBe\Service;
 
 use Netresearch\NrPasskeysBe\Utility\TypeCastTrait;
+use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Http\NormalizedParams;
 
 final class ExtensionConfigurationService
 {
@@ -56,8 +57,7 @@ final class ExtensionConfigurationService
             return $rpId;
         }
 
-        $rawHost = GeneralUtility::getIndpEnv('HTTP_HOST');
-        $host = \is_string($rawHost) ? $rawHost : '';
+        $host = $this->getNormalizedParams()->getHttpHost();
 
         return $host !== '' ? $host : 'localhost';
     }
@@ -69,13 +69,32 @@ final class ExtensionConfigurationService
             return $origin;
         }
 
-        $rawSsl = GeneralUtility::getIndpEnv('TYPO3_SSL');
-        $isHttps = \is_string($rawSsl) ? $rawSsl !== '' && $rawSsl !== '0' : !empty($rawSsl);
-        $scheme = $isHttps ? 'https' : 'http';
-        $rawHost = GeneralUtility::getIndpEnv('HTTP_HOST');
-        $host = \is_string($rawHost) ? $rawHost : '';
+        $params = $this->getNormalizedParams();
+        $scheme = $params->isHttps() ? 'https' : 'http';
+        $host = $params->getHttpHost();
 
         return $scheme . '://' . ($host !== '' ? $host : 'localhost');
+    }
+
+    /**
+     * Resolve NormalizedParams from the current request, with a $_SERVER fallback for CLI/tests.
+     */
+    private function getNormalizedParams(): NormalizedParams
+    {
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
+        if ($request instanceof ServerRequestInterface) {
+            $params = $request->getAttribute('normalizedParams');
+            if ($params instanceof NormalizedParams) {
+                return $params;
+            }
+        }
+
+        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $sysConf = \is_array($confVars) && isset($confVars['SYS']) && \is_array($confVars['SYS'])
+            ? $confVars['SYS']
+            : [];
+
+        return NormalizedParams::createFromServerParams($_SERVER, $sysConf);
     }
 
     /**

--- a/Classes/Service/WebAuthnService.php
+++ b/Classes/Service/WebAuthnService.php
@@ -29,6 +29,7 @@ use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\AuthenticatorAttestationResponseValidator;
 use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
+use Webauthn\CredentialRecord;
 use Webauthn\Denormalizer\WebauthnSerializerFactory;
 use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialCreationOptions;
@@ -36,7 +37,6 @@ use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialParameters;
 use Webauthn\PublicKeyCredentialRequestOptions;
 use Webauthn\PublicKeyCredentialRpEntity;
-use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 use Webauthn\TrustPath\EmptyTrustPath;
 
@@ -128,7 +128,7 @@ final class WebAuthnService
         int $beUserUid,
         string $username,
         string $displayName,
-    ): PublicKeyCredentialSource {
+    ): CredentialRecord {
         $challenge = $this->challengeService->verifyChallengeToken($challengeToken);
 
         $rpId = $this->configService->getEffectiveRpId();
@@ -348,7 +348,7 @@ final class WebAuthnService
 
         try {
             $updatedSource = $validator->check(
-                publicKeyCredentialSource: $storedSource,
+                credentialRecord: $storedSource,
                 authenticatorAssertionResponse: $response,
                 publicKeyCredentialRequestOptions: $requestOptions,
                 host: $rpId,
@@ -384,7 +384,7 @@ final class WebAuthnService
      * Store a verified registration result as a Credential.
      */
     public function storeCredential(
-        PublicKeyCredentialSource $source,
+        CredentialRecord $source,
         int $beUserUid,
         string $label,
     ): Credential {
@@ -499,13 +499,13 @@ final class WebAuthnService
         return \hash_hmac('sha256', (string) $beUserUid, $derivedKey, true);
     }
 
-    private function credentialToSource(Credential $credential): PublicKeyCredentialSource
+    private function credentialToSource(Credential $credential): CredentialRecord
     {
         $aaguid = $credential->getAaguid() !== ''
             ? \Symfony\Component\Uid\Uuid::fromString($credential->getAaguid())
             : \Symfony\Component\Uid\Uuid::v4();
 
-        return PublicKeyCredentialSource::create(
+        return CredentialRecord::create(
             publicKeyCredentialId: $credential->getCredentialId(),
             type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
             transports: $credential->getTransportsArray(),

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ install-v13: ## Install TYPO3 13.4 LTS with extension
 	ddev install-v13
 
 .PHONY: install-v14
-install-v14: ## Install TYPO3 14.x with extension
+install-v14: ## Install TYPO3 14.3 LTS with extension
 	ddev install-v14
 
 .PHONY: install-all
@@ -68,7 +68,7 @@ urls: ## Show all access URLs
 	@echo "  Frontend: https://v13.nr-passkeys-be.ddev.site/"
 	@echo "  Backend:  https://v13.nr-passkeys-be.ddev.site/typo3/"
 	@echo ""
-	@echo "TYPO3 14.x:"
+	@echo "TYPO3 14.3 LTS:"
 	@echo "  Frontend: https://v14.nr-passkeys-be.ddev.site/"
 	@echo "  Backend:  https://v14.nr-passkeys-be.ddev.site/typo3/"
 	@echo ""

--- a/Tests/Functional/Authentication/PasskeyAuthenticationServiceMfaBypassTest.php
+++ b/Tests/Functional/Authentication/PasskeyAuthenticationServiceMfaBypassTest.php
@@ -21,7 +21,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration as Typo3ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
-use Webauthn\PublicKeyCredentialSource;
+use Webauthn\CredentialRecord;
 
 /**
  * Functional tests for the skipMfaOnPasskeyAuth feature.
@@ -175,7 +175,7 @@ final class PasskeyAuthenticationServiceMfaBypassTest extends FunctionalTestCase
         $credential = new Credential(uid: 10, beUser: 5, label: 'Functional Test Key');
         $verified = new VerifiedAssertion(
             credential: $credential,
-            source: $this->createMock(PublicKeyCredentialSource::class),
+            source: $this->createMock(CredentialRecord::class),
         );
 
         $webAuthnService = $this->createMock(WebAuthnService::class);

--- a/Tests/Unit/Authentication/PasskeyAuthenticationServiceTest.php
+++ b/Tests/Unit/Authentication/PasskeyAuthenticationServiceTest.php
@@ -30,7 +30,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use Webauthn\PublicKeyCredentialSource;
+use Webauthn\CredentialRecord;
 
 #[CoversClass(PasskeyAuthenticationService::class)]
 final class PasskeyAuthenticationServiceTest extends TestCase
@@ -141,7 +141,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
             )
             ->willReturn(new VerifiedAssertion(
                 credential: $credential,
-                source: $this->createMock(PublicKeyCredentialSource::class),
+                source: $this->createMock(CredentialRecord::class),
             ));
 
         $this->rateLimiterService
@@ -188,7 +188,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
             ->method('verifyAssertionResponse')
             ->willReturn(new VerifiedAssertion(
                 credential: $credential,
-                source: $this->createMock(PublicKeyCredentialSource::class),
+                source: $this->createMock(CredentialRecord::class),
             ));
 
         $subject = new PasskeyAuthenticationService();
@@ -774,7 +774,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
             ->method('verifyAssertionResponse')
             ->willReturn(new VerifiedAssertion(
                 credential: $credential,
-                source: $this->createMock(PublicKeyCredentialSource::class),
+                source: $this->createMock(CredentialRecord::class),
             ));
 
         $this->rateLimiterService
@@ -1141,7 +1141,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
             )
             ->willReturn(new VerifiedAssertion(
                 credential: $credential,
-                source: $this->createMock(PublicKeyCredentialSource::class),
+                source: $this->createMock(CredentialRecord::class),
             ));
 
         // Both getUser and authUser should use the same decoded payload

--- a/Tests/Unit/Controller/ManagementControllerTest.php
+++ b/Tests/Unit/Controller/ManagementControllerTest.php
@@ -28,9 +28,9 @@ use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRpEntity;
-use Webauthn\PublicKeyCredentialSource;
 use Webauthn\PublicKeyCredentialUserEntity;
 
 #[CoversClass(ManagementController::class)]
@@ -143,7 +143,7 @@ final class ManagementControllerTest extends TestCase
             'label' => 'My YubiKey',
         ]);
 
-        $sourceMock = $this->createMock(PublicKeyCredentialSource::class);
+        $sourceMock = $this->createMock(CredentialRecord::class);
         $this->webAuthnService
             ->expects(self::once())
             ->method('verifyRegistrationResponse')
@@ -565,7 +565,7 @@ final class ManagementControllerTest extends TestCase
             'label' => '   ',
         ]);
 
-        $sourceMock = $this->createMock(PublicKeyCredentialSource::class);
+        $sourceMock = $this->createMock(CredentialRecord::class);
         $this->webAuthnService
             ->method('verifyRegistrationResponse')
             ->willReturn($sourceMock);
@@ -652,7 +652,7 @@ final class ManagementControllerTest extends TestCase
             'label' => 'My Key',
         ]);
 
-        $sourceMock = $this->createMock(PublicKeyCredentialSource::class);
+        $sourceMock = $this->createMock(CredentialRecord::class);
         $this->webAuthnService
             ->expects(self::once())
             ->method('verifyRegistrationResponse')
@@ -703,7 +703,7 @@ final class ManagementControllerTest extends TestCase
             // no label provided
         ]);
 
-        $sourceMock = $this->createMock(PublicKeyCredentialSource::class);
+        $sourceMock = $this->createMock(CredentialRecord::class);
         $this->webAuthnService
             ->method('verifyRegistrationResponse')
             ->willReturn($sourceMock);
@@ -732,7 +732,7 @@ final class ManagementControllerTest extends TestCase
             'label' => $longLabel,
         ]);
 
-        $sourceMock = $this->createMock(PublicKeyCredentialSource::class);
+        $sourceMock = $this->createMock(CredentialRecord::class);
         $this->webAuthnService
             ->method('verifyRegistrationResponse')
             ->willReturn($sourceMock);

--- a/Tests/Unit/Domain/Dto/VerifiedAssertionTest.php
+++ b/Tests/Unit/Domain/Dto/VerifiedAssertionTest.php
@@ -14,7 +14,7 @@ use Netresearch\NrPasskeysBe\Domain\Model\Credential;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Webauthn\PublicKeyCredentialSource;
+use Webauthn\CredentialRecord;
 
 #[CoversClass(VerifiedAssertion::class)]
 final class VerifiedAssertionTest extends TestCase
@@ -23,7 +23,7 @@ final class VerifiedAssertionTest extends TestCase
     public function constructorSetsProperties(): void
     {
         $credential = new Credential(uid: 1, beUser: 42, label: 'Test Key');
-        $source = $this->createMock(PublicKeyCredentialSource::class);
+        $source = $this->createMock(CredentialRecord::class);
 
         $dto = new VerifiedAssertion(
             credential: $credential,

--- a/Tests/Unit/Service/WebAuthnServiceTest.php
+++ b/Tests/Unit/Service/WebAuthnServiceTest.php
@@ -29,9 +29,9 @@ use Psr\Log\LoggerInterface;
 use ReflectionMethod;
 use RuntimeException;
 use Throwable;
+use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
-use Webauthn\PublicKeyCredentialSource;
 
 #[CoversClass(WebAuthnService::class)]
 final class WebAuthnServiceTest extends TestCase
@@ -283,7 +283,7 @@ final class WebAuthnServiceTest extends TestCase
         $label = 'Work Laptop Key';
         $expectedUid = 42;
 
-        $source = PublicKeyCredentialSource::create(
+        $source = CredentialRecord::create(
             publicKeyCredentialId: 'credential-id-xyz',
             type: 'public-key',
             transports: ['usb', 'nfc'],
@@ -468,7 +468,7 @@ final class WebAuthnServiceTest extends TestCase
         $expectedUid = 55;
 
         $uuid = \Symfony\Component\Uid\Uuid::v4();
-        $source = PublicKeyCredentialSource::create(
+        $source = CredentialRecord::create(
             publicKeyCredentialId: 'test-cred-id',
             type: 'public-key',
             transports: ['usb', 'ble', 'nfc'],
@@ -696,7 +696,7 @@ final class WebAuthnServiceTest extends TestCase
         $beUserUid = 111;
         $label = 'Test Key';
 
-        $source = PublicKeyCredentialSource::create(
+        $source = CredentialRecord::create(
             publicKeyCredentialId: 'cred-id',
             type: 'public-key',
             transports: [],
@@ -897,7 +897,7 @@ final class WebAuthnServiceTest extends TestCase
         $beUserUid = 456;
         $label = 'Test';
 
-        $source = PublicKeyCredentialSource::create(
+        $source = CredentialRecord::create(
             publicKeyCredentialId: 'cred-id',
             type: 'public-key',
             transports: [],
@@ -1164,7 +1164,7 @@ final class WebAuthnServiceTest extends TestCase
         // Assert
         self::assertInstanceOf(VerifiedAssertion::class, $result);
         self::assertSame($credential, $result->credential);
-        self::assertInstanceOf(PublicKeyCredentialSource::class, $result->source);
+        self::assertInstanceOf(CredentialRecord::class, $result->source);
         self::assertSame(1, $result->source->counter);
     }
 
@@ -1505,10 +1505,10 @@ final class WebAuthnServiceTest extends TestCase
 
         $reflection = new ReflectionMethod($this->subject, 'credentialToSource');
 
-        /** @var PublicKeyCredentialSource $source */
+        /** @var CredentialRecord $source */
         $source = $reflection->invoke($this->subject, $credential);
 
-        self::assertInstanceOf(PublicKeyCredentialSource::class, $source);
+        self::assertInstanceOf(CredentialRecord::class, $source);
         self::assertSame('cred-id-123', $source->publicKeyCredentialId);
         self::assertSame('cose-public-key', $source->credentialPublicKey);
         self::assertSame('user-handle', $source->userHandle);
@@ -1542,7 +1542,7 @@ final class WebAuthnServiceTest extends TestCase
 
         $reflection = new ReflectionMethod($this->subject, 'credentialToSource');
 
-        /** @var PublicKeyCredentialSource $source */
+        /** @var CredentialRecord $source */
         $source = $reflection->invoke($this->subject, $credential);
 
         self::assertSame($fixedAaguid, $source->aaguid->toString());

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -25,3 +25,18 @@ if (!\defined('LF')) {
 require __DIR__ . '/../.Build/vendor/autoload.php';
 
 DG\BypassFinals::enable();
+
+// NormalizedParams::createFromServerParams() reads Environment::getCurrentScript()
+// and getPublicPath(); initialize Environment so the fallback path works in tests.
+$projectPath = \dirname(__DIR__);
+\TYPO3\CMS\Core\Core\Environment::initialize(
+    new \TYPO3\CMS\Core\Core\ApplicationContext('Testing'),
+    true,
+    true,
+    $projectPath,
+    $projectPath,
+    $projectPath . '/var',
+    $projectPath . '/config',
+    $projectPath . '/bootstrap.php',
+    'UNIX',
+);

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "typo3/cms-core": "^12.4 || ^13.4 || ^14.3",
         "typo3/cms-backend": "^12.4 || ^13.4 || ^14.3",
         "typo3/cms-setup": "^12.4 || ^13.4 || ^14.3",
-        "web-auth/webauthn-lib": "^5.2"
+        "web-auth/webauthn-lib": "^5.3"
     },
     "require-dev": {
         "netresearch/typo3-ci-workflows": "^1.2",

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     },
     "require": {
         "php": "^8.2",
-        "typo3/cms-core": "^12.4 || ^13.4 || ^14.1",
-        "typo3/cms-backend": "^12.4 || ^13.4 || ^14.1",
-        "typo3/cms-setup": "^12.4 || ^13.4 || ^14.1",
+        "typo3/cms-core": "^12.4 || ^13.4 || ^14.3",
+        "typo3/cms-backend": "^12.4 || ^13.4 || ^14.3",
+        "typo3/cms-setup": "^12.4 || ^13.4 || ^14.3",
         "web-auth/webauthn-lib": "^5.2"
     },
     "require-dev": {


### PR DESCRIPTION
## Description

Unblocks installing this extension alongside TYPO3 14.3 LTS (released 2026-04-21) and bumps the supported floor accordingly.

The blocker was a `phpdocumentor/reflection-docblock` constraint conflict — TYPO3 14.3 requires `^6.0.3`, but `web-auth/webauthn-lib 5.2.x` only accepts `^5.3`. webauthn-lib 5.3.0 (released 2026-05-01, see [#830](https://github.com/web-auth/webauthn-framework/issues/830)) loosens that to `^5.3 || ^6.0`. 5.3 also deprecates `PublicKeyCredentialSource` in favour of the new `CredentialRecord` base class, and TYPO3 14.3 itself deprecates `GeneralUtility::getIndpEnv()`. Both deprecations are migrated in this PR.

## Type of Change

- [x] Refactoring (no functional changes) — `webauthn-lib` API + `NormalizedParams` migrations
- [x] Other — TYPO3 LTS support bump, CI permissions fix

## Changes Made

**Commit 1 — `refactor(webauthn): migrate to web-auth/webauthn-lib 5.3 CredentialRecord API`** ([a2c8348](https://github.com/netresearch/t3x-nr-passkeys-be/commit/a2c8348))
- `WebAuthnService`: swap `PublicKeyCredentialSource` for `CredentialRecord` on return / parameter types
- `AuthenticatorAssertionResponseValidator::check()` keyword arg renamed `publicKeyCredentialSource:` → `credentialRecord:`
- `VerifiedAssertion` DTO: `source` property type
- Test mocks across 5 files updated to target `CredentialRecord`

**Commit 2 — `chore(typo3): bump TYPO3 14.x baseline to ^14.3 LTS`** ([1e1fb6a](https://github.com/netresearch/t3x-nr-passkeys-be/commit/1e1fb6a))
- `composer.json`: `typo3/cms-{core,backend,setup}` `^14.1` → `^14.3`
- CI matrix and `remove-dev-deps` filter
- DDEV `install-v14`: pin all `typo3/*` packages to `^14.3` so the local v14 environment matches the supported LTS
- Docs: `AGENTS.md`, `Classes/AGENTS.md`, `.github/copilot-instructions.md`, `Makefile`

**Commit 3 — `chore(deps): raise web-auth/webauthn-lib floor to ^5.3`** ([4383657](https://github.com/netresearch/t3x-nr-passkeys-be/commit/4383657))
- `composer.json`: `web-auth/webauthn-lib` `^5.2` → `^5.3` (matches the API now in use)
- Addresses Copilot + Gemini review feedback (6 review threads, all resolved)

**Commit 4 — `ci: grant actions:read to reusable workflow callers`** ([0533835](https://github.com/netresearch/t3x-nr-passkeys-be/commit/0533835))
- `netresearch/typo3-ci-workflows@main` added a `preflight` gate (2026-05-02) that calls the GitHub Actions API to skip duplicate post-merge runs. With our top-level `permissions: {}` it failed with `startup_failure`. Forward `actions: read` to both reusable callers so the gate can run.

**Commit 5 — `refactor: replace deprecated GeneralUtility::getIndpEnv() with NormalizedParams`** ([b2cfd8e](https://github.com/netresearch/t3x-nr-passkeys-be/commit/b2cfd8e))
- 6 deprecated call sites (`PasskeyAuthenticationService`, `LoginController`, `ExtensionConfigurationService`) → `NormalizedParams`
- Read from the PSR-7 request when available (controllers get it injected, services pull from `\$GLOBALS['TYPO3_REQUEST']`); fall back to `NormalizedParams::createFromServerParams(\$_SERVER, \$sysConf)` for CLI/test contexts
- `NormalizedParams` is available since TYPO3 v9.4 — works across the whole supported range without compat shims
- `Tests/bootstrap.php`: initialize `Environment` so the `\$_SERVER` fallback works under PHPUnit

## Testing

- [x] Composer resolves: `typo3/cms-core v14.3.0` + `web-auth/webauthn-lib 5.3.1` + `phpdocumentor/reflection-docblock 6.0.3`
- [x] PHPStan level 10 (incl. phpat architecture rules): 0 errors
- [x] Unit tests: 559/559
- [x] Fuzz tests: 131/131
- [x] JS tests (Vitest): 63/63
- [x] PHP-CS-Fixer (PER-CS3.0): clean
- [x] Zero deprecation warnings under TYPO3 v14.3 (was 6 before commit 5)

## Checklist

- [x] My code follows the project's coding standards (PER-CS3.0)
- [x] I have added tests covering my changes (existing tests updated)
- [x] I have updated documentation as needed (AGENTS.md, copilot-instructions, Makefile)
- [x] My commits follow the conventional commit format
- [x] I have rebased on the latest main branch