### PR TITLE
fix(setup): use TCA-based user settings column on TYPO3 14+

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -8,6 +8,7 @@
 declare(strict_types=1);
 
 use Netresearch\NrPasskeysBe\UserSettings\PasskeySettingsPanel;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 defined('TYPO3') or die();
@@ -16,11 +17,28 @@ defined('TYPO3') or die();
 // Must be in ext_tables.php because cms-setup/ext_tables.php initializes
 // $GLOBALS['TYPO3_USER_SETTINGS'] (including showitem with mfaProviders).
 // Registration in ext_localconf.php would be overwritten by the setup module.
-$GLOBALS['TYPO3_USER_SETTINGS']['columns']['passkeys'] = [
-    'type' => 'user',
-    'userFunc' => PasskeySettingsPanel::class . '->render',
-    'label' => 'LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang.xlf:manage.title',
-];
+//
+// TYPO3 14 introduced UserSettingsSchema::getTca() which copies legacy columns
+// verbatim into fake TCA columns. Because the legacy format has no 'config' key,
+// SingleFieldContainer::inlineFieldShouldBeSkipped() does null + array → TypeError.
+// For TYPO3 14+ register via the TCA-based API so the 'config' key is present.
+$label = 'LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang.xlf:manage.title';
+
+if ((new Typo3Version())->getMajorVersion() >= 14) {
+    $GLOBALS['TCA']['be_users']['columns']['user_settings']['columns']['passkeys'] = [
+        'label' => $label,
+        'config' => [
+            'type' => 'user',
+            'userFunc' => PasskeySettingsPanel::class . '->render',
+        ],
+    ];
+} else {
+    $GLOBALS['TYPO3_USER_SETTINGS']['columns']['passkeys'] = [
+        'type' => 'user',
+        'userFunc' => PasskeySettingsPanel::class . '->render',
+        'label' => $label,
+    ];
+}
 
 ExtensionManagementUtility::addFieldsToUserSettings(
     'passkeys',


### PR DESCRIPTION
## Problem

On TYPO3 14, opening **User Settings** (Setup module) crashes with:

```
TypeError: Unsupported operand types: null + array
  in SingleFieldContainer.php line 152
```

## Root Cause

`UserSettingsSchema::getTca()` (introduced in TYPO3 14) copies `$GLOBALS['TYPO3_USER_SETTINGS']['columns']` entries **verbatim** into fake TCA columns without converting the legacy format. The legacy format has no `config` key (`type` and `userFunc` are top-level keys). `SingleFieldContainer::inlineFieldShouldBeSkipped()` then does:

```php
$fieldConfig = $this->data['processedTca']['columns'][$fieldName]['config']; // null
$fieldConfig += [...]; // TypeError: null + array
```

## Fix

For TYPO3 14+, register the `passkeys` panel via the new TCA-based API (`$GLOBALS['TCA']['be_users']['columns']['user_settings']['columns']`) which includes a proper `config` key. The legacy `$GLOBALS['TYPO3_USER_SETTINGS']` registration is kept for TYPO3 12/13.

## Test plan

- [ ] Open User Settings in TYPO3 14 backend — no crash, passkeys panel renders
- [ ] Open User Settings in TYPO3 12/13 — still works (legacy path unchanged)
- [ ] CI matrix (PHP 8.2/8.3/8.4 × TYPO3 12/13/14) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)