### PR TITLE
fix(setup): register proper renderType for TYPO3 14 user settings panel

### DIFF
--- a/Classes/UserSettings/PasskeySettingsPanel.php
+++ b/Classes/UserSettings/PasskeySettingsPanel.php
@@ -85,7 +85,7 @@ final class PasskeySettingsPanel
     /**
      * @param array<string, string> $urls Token-protected backend route URLs
      */
-    private function buildHtml(int $passkeyCount, array $urls): string
+    public function buildHtml(int $passkeyCount, array $urls): string
     {
         $infoText = $this->translate(
             'manage.info.passkeys',

--- a/Classes/UserSettings/PasskeySettingsPanelElement.php
+++ b/Classes/UserSettings/PasskeySettingsPanelElement.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\UserSettings;
+
+use Netresearch\NrPasskeysBe\Service\CredentialRepository;
+use Netresearch\NrPasskeysBe\Utility\TranslationTrait;
+use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Page\PageRenderer;
+
+/**
+ * FormEngine render element for the passkey management panel in User Settings.
+ *
+ * Registered as renderType 'nrPasskeySettingsPanel' and used on TYPO3 14+.
+ * TYPO3 12/13 still uses the userFunc approach via PasskeySettingsPanel.
+ *
+ * HTML generation is delegated to PasskeySettingsPanel::buildHtml() to avoid
+ * duplication between the userFunc and FormEngine code paths.
+ *
+ * @internal
+ */
+final class PasskeySettingsPanelElement extends AbstractFormElement
+{
+    use TranslationTrait;
+
+    public function __construct(
+        private readonly CredentialRepository $credentialRepository,
+        private readonly UriBuilder $uriBuilder,
+        private readonly PageRenderer $pageRenderer,
+        private readonly PasskeySettingsPanel $panel,
+    ) {}
+
+    /**
+     * Required for TYPO3 v12 compatibility: NodeFactory uses method_exists() to
+     * choose between the DI path (setData) and the legacy constructor path.
+     *
+     * @param array<string, mixed> $data
+     * @see PasskeyInfoElement::setData()
+     */
+    public function setData(array $data): void
+    {
+        $this->data = $data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function render(): array
+    {
+        /** @var array<string, mixed> $resultArray */
+        $resultArray = $this->initializeResultArray();
+
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+        if (!$backendUser instanceof BackendUserAuthentication) {
+            return $resultArray;
+        }
+
+        $rawUid = $backendUser->user['uid'] ?? null;
+        $userId = \is_numeric($rawUid) ? (int) $rawUid : 0;
+        if ($userId === 0) {
+            return $resultArray;
+        }
+
+        $typo3Conf = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $sysConf = \is_array($typo3Conf) ? ($typo3Conf['SYS'] ?? null) : null;
+        $encryptionKey = \is_array($sysConf) && \is_string($sysConf['encryptionKey'] ?? null)
+            ? $sysConf['encryptionKey']
+            : '';
+        if (\strlen($encryptionKey) < 32) {
+            $warning = $this->translate(
+                'manage.warning.encryptionKey',
+                'Passkey management is unavailable. The TYPO3 encryption key is missing or too short (minimum 32 characters). Configure it in Admin Tools > Settings > Configure Installation-Wide Options.',
+            );
+            $resultArray['html'] = '<div class="alert alert-danger">' . \htmlspecialchars($warning, ENT_QUOTES, 'UTF-8') . '</div>';
+
+            return $resultArray;
+        }
+
+        $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-passkeys-be/PasskeyManagement.js');
+
+        $passkeyCount = $this->credentialRepository->countByBeUser($userId);
+
+        $urls = [
+            'list'            => (string) $this->uriBuilder->buildUriFromRoute('ajax_passkeys_manage_list'),
+            'registerOptions' => (string) $this->uriBuilder->buildUriFromRoute('ajax_passkeys_manage_registration_options'),
+            'registerVerify'  => (string) $this->uriBuilder->buildUriFromRoute('ajax_passkeys_manage_registration_verify'),
+            'rename'          => (string) $this->uriBuilder->buildUriFromRoute('ajax_passkeys_manage_rename'),
+            'remove'          => (string) $this->uriBuilder->buildUriFromRoute('ajax_passkeys_manage_remove'),
+        ];
+
+        $resultArray['html'] = $this->panel->buildHtml($passkeyCount, $urls);
+
+        return $resultArray;
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -70,8 +70,11 @@ services:
   Netresearch\NrPasskeysBe\Controller\AdminModuleController:
     public: true
 
-  # FormEngine element must be public for GeneralUtility::makeInstance() DI resolution.
+  # FormEngine elements must be public for GeneralUtility::makeInstance() DI resolution.
   # Required by NodeFactory on TYPO3 v12 (setData path) and v13+ alike.
   Netresearch\NrPasskeysBe\Form\Element\PasskeyInfoElement:
+    public: true
+
+  Netresearch\NrPasskeysBe\UserSettings\PasskeySettingsPanelElement:
     public: true
 

--- a/Tests/Unit/UserSettings/PasskeySettingsPanelElementTest.php
+++ b/Tests/Unit/UserSettings/PasskeySettingsPanelElementTest.php
@@ -1,0 +1,220 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Tests\Unit\UserSettings;
+
+use Netresearch\NrPasskeysBe\Service\CredentialRepository;
+use Netresearch\NrPasskeysBe\UserSettings\PasskeySettingsPanel;
+use Netresearch\NrPasskeysBe\UserSettings\PasskeySettingsPanelElement;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use stdClass;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Http\Uri;
+use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Page\PageRenderer;
+
+#[CoversClass(PasskeySettingsPanelElement::class)]
+final class PasskeySettingsPanelElementTest extends TestCase
+{
+    private CredentialRepository&MockObject $credentialRepository;
+    private UriBuilder&MockObject $uriBuilder;
+    private PageRenderer&MockObject $pageRenderer;
+    private PasskeySettingsPanel $panel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // TYPO3 constant used by AbstractFormElement::wrapWithFieldsetAndLegend()
+        if (!\defined('LF')) {
+            \define('LF', "\n");
+        }
+
+        $this->credentialRepository = $this->createMock(CredentialRepository::class);
+        $this->pageRenderer = $this->createMock(PageRenderer::class);
+
+        $this->uriBuilder = $this->createMock(UriBuilder::class);
+        $this->uriBuilder
+            ->method('buildUriFromRoute')
+            ->willReturnCallback(static function (string $routeName): Uri {
+                return new Uri('/typo3/ajax/passkeys/' . $routeName . '?token=test');
+            });
+
+        $this->panel = new PasskeySettingsPanel();
+
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = \str_repeat('a', 64);
+
+        $languageService = $this->createMock(LanguageService::class);
+        $languageService->method('sL')->willReturnCallback(
+            static fn(string $key): string => \basename(\str_replace(':', '/', $key)),
+        );
+        $GLOBALS['LANG'] = $languageService;
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER'], $GLOBALS['LANG'], $GLOBALS['TYPO3_CONF_VARS']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function renderReturnsEmptyHtmlWhenNoBackendUser(): void
+    {
+        unset($GLOBALS['BE_USER']);
+
+        $result = $this->createSubject()->render();
+
+        self::assertEmpty($result['html'] ?? '');
+    }
+
+    #[Test]
+    public function renderReturnsEmptyHtmlWhenBackendUserIsNotAuthentication(): void
+    {
+        $GLOBALS['BE_USER'] = new stdClass();
+
+        $result = $this->createSubject()->render();
+
+        self::assertEmpty($result['html'] ?? '');
+    }
+
+    #[Test]
+    public function renderReturnsEmptyHtmlWhenUserUidIsZero(): void
+    {
+        $this->setUpBackendUser(0);
+
+        $result = $this->createSubject()->render();
+
+        self::assertEmpty($result['html'] ?? '');
+    }
+
+    #[Test]
+    public function renderReturnsErrorHtmlWhenEncryptionKeyTooShort(): void
+    {
+        $this->setUpBackendUser(1);
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey'] = 'short';
+
+        $result = $this->createSubject()->render();
+
+        self::assertStringContainsString('alert alert-danger', $result['html'] ?? '');
+        self::assertStringNotContainsString('passkey-management-container', $result['html'] ?? '');
+    }
+
+    #[Test]
+    public function renderReturnsErrorHtmlWhenEncryptionKeyMissing(): void
+    {
+        $this->setUpBackendUser(1);
+        unset($GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']);
+
+        $result = $this->createSubject()->render();
+
+        self::assertStringContainsString('alert alert-danger', $result['html'] ?? '');
+    }
+
+    #[Test]
+    public function renderReturnsManagementContainerOnSuccessPath(): void
+    {
+        $this->setUpBackendUser(1);
+        $this->credentialRepository->method('countByBeUser')->willReturn(3);
+
+        $result = $this->createSubject()->render();
+
+        self::assertStringContainsString('id="passkey-management-container"', $result['html'] ?? '');
+    }
+
+    #[Test]
+    public function renderLoadsJavaScriptModule(): void
+    {
+        $this->setUpBackendUser(1);
+        $this->credentialRepository->method('countByBeUser')->willReturn(0);
+
+        $this->pageRenderer
+            ->expects(self::once())
+            ->method('loadJavaScriptModule')
+            ->with('@netresearch/nr-passkeys-be/PasskeyManagement.js');
+
+        $this->createSubject()->render();
+    }
+
+    #[Test]
+    public function renderUsesCorrectUserIdForRepository(): void
+    {
+        $this->setUpBackendUser(42);
+
+        $this->credentialRepository
+            ->expects(self::once())
+            ->method('countByBeUser')
+            ->with(42)
+            ->willReturn(0);
+
+        $this->createSubject()->render();
+    }
+
+    #[Test]
+    public function renderDelegatesHtmlGenerationToPanel(): void
+    {
+        $this->setUpBackendUser(1);
+        $this->credentialRepository->method('countByBeUser')->willReturn(2);
+
+        $result = $this->createSubject()->render();
+
+        // HTML comes from PasskeySettingsPanel::buildHtml() — spot-check its output
+        self::assertStringContainsString('id="passkey-list-table"', $result['html'] ?? '');
+        self::assertStringContainsString('id="passkey-add-btn"', $result['html'] ?? '');
+        self::assertStringContainsString('badge-success', $result['html'] ?? '');
+    }
+
+    #[Test]
+    public function renderReturnsArrayWithHtmlKey(): void
+    {
+        $this->setUpBackendUser(1);
+        $this->credentialRepository->method('countByBeUser')->willReturn(0);
+
+        $result = $this->createSubject()->render();
+
+        self::assertIsArray($result);
+        self::assertArrayHasKey('html', $result);
+    }
+
+    #[Test]
+    public function setDataPopulatesDataProperty(): void
+    {
+        $subject = $this->createSubject(['tableName' => 'be_users_settings']);
+        // setData is exercised indirectly; verify render() still works
+        $this->setUpBackendUser(1);
+        $this->credentialRepository->method('countByBeUser')->willReturn(0);
+
+        $result = $subject->render();
+
+        self::assertIsArray($result);
+    }
+
+    private function createSubject(array $data = []): PasskeySettingsPanelElement
+    {
+        $subject = new PasskeySettingsPanelElement(
+            $this->credentialRepository,
+            $this->uriBuilder,
+            $this->pageRenderer,
+            $this->panel,
+        );
+        $subject->setData($data);
+
+        return $subject;
+    }
+
+    private function setUpBackendUser(int $uid): void
+    {
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => $uid];
+        $GLOBALS['BE_USER'] = $backendUser;
+    }
+}

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -47,6 +47,14 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1739000000] = [
     'class' => \Netresearch\NrPasskeysBe\Form\Element\PasskeyInfoElement::class,
 ];
 
+// Register FormEngine render type for the passkey management panel in User Settings (TYPO3 14+).
+// TYPO3 14 requires an explicit renderType on type="user" columns; userFunc alone triggers a warning.
+$GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1748450000] = [
+    'nodeName' => 'nrPasskeySettingsPanel',
+    'priority' => 40,
+    'class' => \Netresearch\NrPasskeysBe\UserSettings\PasskeySettingsPanelElement::class,
+];
+
 // Register cache for challenge nonces
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['nr_passkeys_be_nonce'] ??= [];
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['nr_passkeys_be_nonce']['backend'] ??=

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -29,7 +29,7 @@ if ((new Typo3Version())->getMajorVersion() >= 14) {
         'label' => $label,
         'config' => [
             'type' => 'user',
-            'userFunc' => PasskeySettingsPanel::class . '->render',
+            'renderType' => 'nrPasskeySettingsPanel',
         ],
     ];
 } else {


### PR DESCRIPTION
## Problem

TYPO3 14 logs a warning in the backend when a `type="user"` column has no explicit `renderType`:

> Field be_users__passkeys of table be_users_settings is registered as type="user" element without a specific renderType.

## Fix

- Add `PasskeySettingsPanelElement` extending `AbstractFormElement` — follows the existing `PasskeyInfoElement` pattern
- Register it as renderType `nrPasskeySettingsPanel` in `ext_localconf.php`
- Update the TYPO3 14 branch in `ext_tables.php` to use `renderType` instead of `userFunc`
- TYPO3 12/13 is unchanged (still uses `PasskeySettingsPanel` via `userFunc`)

## Test plan

- [ ] Open User Settings in TYPO3 14 — passkeys panel renders, no warning in log
- [ ] Open User Settings in TYPO3 12/13 — still works via `userFunc` path
- [ ] CI matrix green

🤖 Generated with [Claude Code](https://claude.com/claude-code)