### PR TITLE
test(setup): cover v14 panel FormEngine wiring + assert E2E render

### DIFF
--- a/Tests/E2E/user-settings.spec.ts
+++ b/Tests/E2E/user-settings.spec.ts
@@ -62,6 +62,28 @@ test.describe('User Settings - Page & JS', () => {
         await expect(page).toHaveURL(/user\/setup|setup/);
     });
 
+    test('passkey management panel renders on the setup page', async ({ page }) => {
+        // Regression guard for the v0.9.1/v0.9.2 fix: on TYPO3 14 a bare
+        // type=user column (without renderType) made SingleFieldContainer
+        // throw and the panel never rendered. The panel container, add button
+        // and list table are emitted server-side by
+        // PasskeySettingsPanel::buildHtml(); their absence means the FormEngine
+        // wiring is broken.
+        //
+        // The setup module renders inside a backend module iframe, and the
+        // passkey field lives in a non-default settings tab. So pierce the
+        // iframe and assert the panel is attached to the DOM rather than
+        // visible (asserting visibility would require driving the tab UI,
+        // which is brittle and orthogonal to "did the panel render").
+        await page.goto('/typo3/module/user/setup');
+        await page.waitForLoadState('networkidle');
+
+        const moduleFrame = page.frameLocator('iframe');
+        await expect(moduleFrame.locator('#passkey-management-container')).toBeAttached();
+        await expect(moduleFrame.locator('#passkey-add-btn')).toBeAttached();
+        await expect(moduleFrame.locator('#passkey-list-table')).toBeAttached();
+    });
+
     test('passkey management JS loads without errors', async ({ page }) => {
         const consoleErrors: string[] = [];
         page.on('console', (msg) => {
@@ -73,11 +95,12 @@ test.describe('User Settings - Page & JS', () => {
         await page.goto('/typo3/module/user/setup');
         await page.waitForTimeout(3000);
 
+        // Only infrastructure noise is filtered. Passkey-specific errors
+        // ("Too few arguments", "Load passkeys error", invalid JSON) are NOT
+        // suppressed — those are exactly the symptoms of a broken panel and
+        // must fail the test.
         const realErrors = consoleErrors.filter(
-            (e) => !e.includes('favicon') && !e.includes('404') && !e.includes('net::')
-                && !e.includes('Too few arguments')
-                && !e.includes('is not valid JSON')
-                && !e.includes('Load passkeys error'),
+            (e) => !e.includes('favicon') && !e.includes('404') && !e.includes('net::'),
         );
         expect(realErrors).toHaveLength(0);
     });

--- a/Tests/Functional/UserSettings/PasskeySettingsPanelRegistrationTest.php
+++ b/Tests/Functional/UserSettings/PasskeySettingsPanelRegistrationTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Tests\Functional\UserSettings;
+
+use Netresearch\NrPasskeysBe\UserSettings\PasskeySettingsPanel;
+use Netresearch\NrPasskeysBe\UserSettings\PasskeySettingsPanelElement;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Backend\Form\NodeFactory;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Regression tests for the User Settings passkey panel FormEngine wiring.
+ *
+ * These guard the v0.9.1/v0.9.2 fix: on TYPO3 14 the `passkeys` user-settings
+ * column must carry an explicit `renderType` (a bare `type=user` column made
+ * SingleFieldContainer throw "Too few arguments" and logged a missing-renderType
+ * warning). The unit tests for PasskeySettingsPanelElement mock all FormEngine
+ * dependencies and therefore never exercise the registration that actually broke.
+ *
+ * @see PasskeySettingsPanelElement
+ * @see PasskeySettingsPanel
+ */
+#[CoversNothing]
+final class PasskeySettingsPanelRegistrationTest extends FunctionalTestCase
+{
+    protected array $coreExtensionsToLoad = [
+        'setup',
+    ];
+
+    protected array $testExtensionsToLoad = [
+        'netresearch/nr-passkeys-be',
+    ];
+
+    /**
+     * The node must resolve to our element via the registered renderType.
+     *
+     * This is the load-bearing assertion: it proves ext_localconf.php registered
+     * the `nrPasskeySettingsPanel` node and that the service is constructable via
+     * DI (public: true). Independent of TYPO3 version, since the node registry
+     * entry is registered unconditionally.
+     */
+    #[Test]
+    public function nodeFactoryResolvesPasskeySettingsPanelRenderType(): void
+    {
+        $nodeFactory = GeneralUtility::makeInstance(NodeFactory::class);
+
+        // create() instantiates and calls setData() but does not call render(),
+        // so a minimal data array carrying only the renderType is sufficient.
+        $node = $nodeFactory->create(['renderType' => 'nrPasskeySettingsPanel']);
+
+        self::assertInstanceOf(PasskeySettingsPanelElement::class, $node);
+    }
+
+    /**
+     * On TYPO3 14+ the passkeys column is registered through the TCA-based
+     * user-settings API and must declare type=user WITH the renderType.
+     * A bare type=user (the v0.9.0 state) is exactly what regressed.
+     */
+    #[Test]
+    public function userSettingsColumnDeclaresRenderTypeOnTypo3V14(): void
+    {
+        if ((new Typo3Version())->getMajorVersion() < 14) {
+            self::markTestSkipped('TCA-based user settings column is TYPO3 v14+ only.');
+        }
+
+        $config = $GLOBALS['TCA']['be_users']['columns']['user_settings']['columns']['passkeys']['config'] ?? null;
+
+        self::assertIsArray($config, 'passkeys user-settings column must be registered on v14+');
+        self::assertSame('user', $config['type'] ?? null);
+        self::assertSame(
+            'nrPasskeySettingsPanel',
+            $config['renderType'] ?? null,
+            'type=user column must declare a renderType or SingleFieldContainer throws',
+        );
+    }
+
+    /**
+     * On TYPO3 12/13 the legacy userFunc path is used and no FormEngine
+     * renderType is wired for the user-settings column.
+     */
+    #[Test]
+    public function userSettingsColumnUsesUserFuncBelowTypo3V14(): void
+    {
+        if ((new Typo3Version())->getMajorVersion() >= 14) {
+            self::markTestSkipped('Legacy userFunc path applies to TYPO3 < 14 only.');
+        }
+
+        $column = $GLOBALS['TYPO3_USER_SETTINGS']['columns']['passkeys'] ?? null;
+
+        self::assertIsArray($column, 'passkeys user-settings column must be registered on v12/v13');
+        self::assertSame('user', $column['type'] ?? null);
+        self::assertSame(
+            PasskeySettingsPanel::class . '->render',
+            $column['userFunc'] ?? null,
+        );
+    }
+}


### PR DESCRIPTION
## Why

The v0.9.1/v0.9.2 fix registered an explicit `renderType` (`nrPasskeySettingsPanel`) for the User Settings passkey panel on TYPO3 14. An independent review flagged that **nothing actually verified the wiring**: the unit test mocks all FormEngine dependencies, and the E2E test **suppressed the exact error signatures** the original bug produced (`Too few arguments`, `Load passkeys error`, invalid JSON) while only asserting "page loads" — so it stayed green even if the panel were broken.

## What

**New functional regression test** `Tests/Functional/UserSettings/PasskeySettingsPanelRegistrationTest`:
- `nodeFactoryResolvesPasskeySettingsPanelRenderType` — proves `ext_localconf.php` registered the node and the service is DI-constructable (`public: true`).
- `userSettingsColumnDeclaresRenderTypeOnTypo3V14` (v14+) — `passkeys` column declares `type=user` **with** `renderType`.
- `userSettingsColumnUsesUserFuncBelowTypo3V14` (v12/13) — legacy `userFunc` path is wired.

**E2E tightened** (`user-settings.spec.ts`):
- Assert the panel renders: `#passkey-management-container`, `#passkey-add-btn`, `#passkey-list-table`. The v14 setup module renders inside a **backend module iframe** and the field sits in a non-default settings tab, so the test pierces the iframe (`frameLocator`) and asserts `toBeAttached` (asserting visibility would require driving the tab UI, which is brittle and orthogonal to "did the panel render").
- Stops suppressing passkey-specific console errors; only infra noise (favicon/404/net::) remains filtered.

## Note on the first CI run

The initial push asserted `page.locator('#passkey-management-container').toBeVisible()`, which failed — `page.locator` does **not** pierce the TYPO3 v14 module iframe. Investigation (local TYPO3 14.3.2, looking inside the module iframe) confirmed **the shipped panel renders correctly** — there is **no product bug**; only the test assertion needed to target the iframe. **No production code changed.**

## Verification

On **TYPO3 14.3.2 / PHP 8.5**:
- Functional: `2 passed, 1 skipped` (skip = v12/13-only path).
- Full `user-settings` E2E spec: **8 passed** (against a real instance).
- CGL (php-cs-fixer) + PHPStan level 10: clean.