### PR TITLE
test(e2e): target the backend module iframe by id

### DIFF
--- a/Tests/E2E/user-settings.spec.ts
+++ b/Tests/E2E/user-settings.spec.ts
@@ -70,15 +70,16 @@ test.describe('User Settings - Page & JS', () => {
         // PasskeySettingsPanel::buildHtml(); their absence means the FormEngine
         // wiring is broken.
         //
-        // The setup module renders inside a backend module iframe, and the
-        // passkey field lives in a non-default settings tab. So pierce the
-        // iframe and assert the panel is attached to the DOM rather than
-        // visible (asserting visibility would require driving the tab UI,
-        // which is brittle and orthogonal to "did the panel render").
+        // The setup module renders inside the backend module iframe
+        // (#typo3-contentIframe), and the passkey field lives in a non-default
+        // settings tab. So pierce the iframe and assert the panel is attached
+        // to the DOM rather than visible (asserting visibility would require
+        // driving the tab UI, which is brittle and orthogonal to "did the
+        // panel render").
         await page.goto('/typo3/module/user/setup');
         await page.waitForLoadState('networkidle');
 
-        const moduleFrame = page.frameLocator('iframe');
+        const moduleFrame = page.frameLocator('#typo3-contentIframe');
         await expect(moduleFrame.locator('#passkey-management-container')).toBeAttached();
         await expect(moduleFrame.locator('#passkey-add-btn')).toBeAttached();
         await expect(moduleFrame.locator('#passkey-list-table')).toBeAttached();


### PR DESCRIPTION
Follow-up to #64. Tightens the User Settings E2E assertions to use `page.frameLocator('#typo3-contentIframe')` instead of the generic `'iframe'` selector.

## Why

`'iframe'` works today only because the setup page happens to have exactly one iframe — it would silently bind to the wrong frame if another were ever added (the same wrong-frame trap that made #64's first run look like a product bug). The id is stable and is the selector documented in the `typo3-testing` skill.

## Verification

Confirmed on a live **TYPO3 14.3.2** instance: `iframe id=typo3-contentIframe, name=list_frame`. The `renders on the setup page` test passes with the id selector:

```
[1/1] … passkey management panel renders on the setup page
  1 passed (7.9s)
```

Behaviour unchanged (still `toBeAttached`). Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)