### PR TITLE
fix: critical onboarding lockout + security/v14-deprecation/arch/docs review findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,7 +155,7 @@ Makefile                  -> make up (dev), make ci (checks), make test-e2e, mak
 - Discoverable login behind `discoverableLoginEnabled` feature flag
 - V14 uses web components (`typo3-backend-module-router`) instead of `.scaffold-content-module`
 - TER publish workflow requires `v` prefix stripping for version validation
-- Shared traits: TranslationTrait, BackendUserTrait (Controller/), TypeCastTrait (Utility/)
+- Shared traits: JsonBodyTrait, BackendUserTrait (Controller/); TranslationTrait, TypeCastTrait (Utility/)
 - RateLimiterService uses atomic locking (LockFactory) with dual counters (per-IP + per-username)
 - Encryption key access centralized in ExtensionConfigurationService::getEncryptionKey()
 - Mutation testing: MSI >= 80%, covered MSI >= 80% (infection.json5)

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -120,11 +120,12 @@ parameters:
             message: '#expects string, mixed given#'
             path: %currentWorkingDirectory%/Classes/Controller/AdminModuleController.php
             reportUnmatched: false
-        # TYPO3 v14 deprecations (makeMenu/makeMenuItem) - will be addressed in v15 migration
-        -
-            message: '#Call to deprecated method#'
-            path: %currentWorkingDirectory%/Classes/Controller/AdminModuleController.php
-            reportUnmatched: false
+        # NOTE: the former blanket '#Call to deprecated method#' suppression for
+        # AdminModuleController has been removed. The v14 docheader-component
+        # deprecations (makeMenu/makeMenuItem/makeLinkButton) are now handled with
+        # ComponentFactory on v14+ and precise inline @phpstan-ignore on the
+        # v12/v13-only fallback calls, so a future unrelated deprecation on this
+        # file is no longer silently masked.
         # TYPO3 AbstractAuthenticationService uses untyped arrays from parent class
         -
             message: '#no value type specified in iterable type array#'

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -120,12 +120,25 @@ parameters:
             message: '#expects string, mixed given#'
             path: %currentWorkingDirectory%/Classes/Controller/AdminModuleController.php
             reportUnmatched: false
-        # NOTE: the former blanket '#Call to deprecated method#' suppression for
-        # AdminModuleController has been removed. The v14 docheader-component
-        # deprecations (makeMenu/makeMenuItem/makeLinkButton) are now handled with
-        # ComponentFactory on v14+ and precise inline @phpstan-ignore on the
-        # v12/v13-only fallback calls, so a future unrelated deprecation on this
-        # file is no longer silently masked.
+        # Docheader components are built via ComponentFactory on TYPO3 v14+ and via
+        # the make* API on v12/v13 (where it is NOT deprecated). These suppressions
+        # are SPECIFIC to that cross-version split (not a blanket '#deprecated method#'),
+        # so an unrelated future deprecation on this file still surfaces. reportUnmatched
+        # is false because each only applies to the version that triggers it.
+        # -- v14: the v12/v13 fallback make* calls are deprecated there:
+        -
+            message: '#Call to deprecated method (makeMenu|makeMenuItem|makeLinkButton)\(\)#'
+            path: %currentWorkingDirectory%/Classes/Controller/AdminModuleController.php
+            reportUnmatched: false
+        # -- v12/v13: ComponentFactory does not exist there:
+        -
+            message: '#TYPO3\\CMS\\Backend\\Template\\Components\\ComponentFactory#'
+            path: %currentWorkingDirectory%/Classes/Controller/AdminModuleController.php
+            reportUnmatched: false
+        -
+            message: '#should return TYPO3\\CMS\\Backend\\Template\\Components\\(Menu\\Menu|Menu\\MenuItem|Buttons\\LinkButton) but returns mixed#'
+            path: %currentWorkingDirectory%/Classes/Controller/AdminModuleController.php
+            reportUnmatched: false
         # TYPO3 AbstractAuthenticationService uses untyped arrays from parent class
         -
             message: '#no value type specified in iterable type array#'

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -15,7 +15,7 @@ TYPO3 extension source code. Namespace: `Netresearch\NrPasskeysBe`. Follows PER-
 | `Controller/AdminController.php` | Admin-only JSON API: list/revoke passkeys, update enforcement, send reminders |
 | `Controller/AdminModuleController.php` | Backend module: admin dashboard with adoption stats and enforcement controls |
 | `Controller/JsonBodyTrait.php` | Shared JSON request body parsing for all controllers |
-| `Controller/TranslationTrait.php` | Shared translation helper with fallback (uses $GLOBALS['LANG']) |
+| `Utility/TranslationTrait.php` | Shared translation helper with fallback (uses $GLOBALS['LANG']) |
 | `Controller/BackendUserTrait.php` | Extracts authenticated user from $GLOBALS['BE_USER'] as AuthenticatedUser DTO |
 | `Domain/Dto/EnforcementStatus.php` | User's enforcement status, grace period, passkey ownership |
 | `Domain/Dto/AdoptionStats.php` | Passkey adoption statistics per group |
@@ -52,7 +52,7 @@ TYPO3 extension source code. Namespace: `Netresearch\NrPasskeysBe`. Follows PER-
 - Use constructor DI via `Services.yaml` for all services/controllers
 - **Exception**: `PasskeyAuthenticationService` uses `GeneralUtility::makeInstance()` (TYPO3 auth chain, no DI)
 - **Exception**: `PasskeySettingsPanel` uses `GeneralUtility::makeInstance()` (TYPO3 callUserFunction, no DI)
-- Shared traits: `JsonBodyTrait`, `TranslationTrait`, `BackendUserTrait` (Controller/), `TypeCastTrait` (Utility/)
+- Shared traits: `JsonBodyTrait`, `BackendUserTrait` (Controller/); `TranslationTrait`, `TypeCastTrait` (Utility/)
 - No Extbase models — `Credential` is a plain PHP class
 - No ViewHelpers in this extension
 - User enumeration prevention: dummy responses with randomized timing for unknown users

--- a/Classes/Authentication/PasskeyAuthenticationService.php
+++ b/Classes/Authentication/PasskeyAuthenticationService.php
@@ -108,37 +108,50 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
     {
         $payload = $this->getPasskeyPayload();
         if ($payload === null) {
-            // Not a passkey login attempt - check per-user enforcement
-            if ($this->getExtensionConfigService()->getConfiguration()->isDisablePasswordLogin()) {
-                $uid = \is_numeric($user['uid'] ?? null) ? (int) $user['uid'] : 0;
-                if ($uid > 0 && $this->hasRegisteredPasskeys($uid)) {
-                    $this->getLogger()->warning('Password login blocked for user with registered passkeys', [
-                        'be_user_uid' => $uid,
-                    ]);
+            // Not a passkey login attempt - check per-user/per-group enforcement.
+            //
+            // Fail-open: any failure of the enforcement checks (e.g. a database
+            // outage while querying credentials or be_groups) MUST NOT lock every
+            // backend user out of password login. On error we log and fall through
+            // to the password service (return 100). Legitimate blocks are explicit
+            // `return 0` statements that are not affected by the catch.
+            try {
+                if ($this->getExtensionConfigService()->getConfiguration()->isDisablePasswordLogin()) {
+                    $uid = \is_numeric($user['uid'] ?? null) ? (int) $user['uid'] : 0;
+                    if ($uid > 0 && $this->hasRegisteredPasskeys($uid)) {
+                        $this->getLogger()->warning('Password login blocked for user with registered passkeys', [
+                            'be_user_uid' => $uid,
+                        ]);
 
-                    return 0;
-                }
-            }
-
-            // Per-group enforcement: block password login when the user's group demands passkeys
-            /** @var array<string, mixed> $user TYPO3 backend user record from AbstractAuthenticationService */
-            $status = $this->getEnforcementService()->getStatus($user);
-            if ($status->hasPasskeys) {
-                if ($status->level === EnforcementLevel::Enforced) {
-                    $this->getLogger()->warning('Password login blocked by group enforcement', [
-                        'username' => $user['username'] ?? '',
-                    ]);
-
-                    return 0;
+                        return 0;
+                    }
                 }
 
-                if ($status->level === EnforcementLevel::Required && $status->isGracePeriodExpired()) {
-                    $this->getLogger()->warning('Password login blocked: grace period expired', [
-                        'username' => $user['username'] ?? '',
-                    ]);
+                // Per-group enforcement: block password login when the user's group demands passkeys
+                /** @var array<string, mixed> $user TYPO3 backend user record from AbstractAuthenticationService */
+                $status = $this->getEnforcementService()->getStatus($user);
+                if ($status->hasPasskeys) {
+                    if ($status->level === EnforcementLevel::Enforced) {
+                        $this->getLogger()->warning('Password login blocked by group enforcement', [
+                            'username' => $user['username'] ?? '',
+                        ]);
 
-                    return 0;
+                        return 0;
+                    }
+
+                    if ($status->level === EnforcementLevel::Required && $status->isGracePeriodExpired()) {
+                        $this->getLogger()->warning('Password login blocked: grace period expired', [
+                            'username' => $user['username'] ?? '',
+                        ]);
+
+                        return 0;
+                    }
                 }
+            } catch (Throwable $e) {
+                $this->getLogger()->error('Passkey enforcement check failed; allowing password login (fail-open)', [
+                    'be_user_uid' => $user['uid'] ?? null,
+                    'error' => $e->getMessage(),
+                ]);
             }
 
             return 100;
@@ -190,7 +203,9 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
             // Return 200 = authenticated, stop further auth processing
             return 200;
         } catch (Throwable $e) {
-            $this->getRateLimiterService()->recordFailure($username, $ip);
+            // Passkey assertions are unforgeable; do not feed the cross-IP
+            // per-username lockout (avoids an account-lockout DoS).
+            $this->getRateLimiterService()->recordFailure($username, $ip, countUserLockout: false);
 
             $this->getLogger()->warning('Passkey authentication failed', [
                 'be_user_uid' => $user['uid'],

--- a/Classes/Command/RecoveryCommand.php
+++ b/Classes/Command/RecoveryCommand.php
@@ -66,13 +66,13 @@ final class RecoveryCommand extends Command
         $disableGroup = $input->getOption('disable-group');
         if (\is_string($disableGroup) && $disableGroup !== '') {
             $uid = (int) $disableGroup;
-            $count = $this->disableEnforcement($uid);
+            $count = $this->disableEnforcementForGroup($uid);
             $io->success(\sprintf('Passkey enforcement set to "off" for group %d (%d row(s) updated).', $uid, $count));
             $didSomething = true;
         }
 
         if ($input->getOption('disable-all') === true) {
-            $count = $this->disableEnforcement(null);
+            $count = $this->disableEnforcementForAllGroups();
             $io->success(\sprintf('Passkey enforcement set to "off" for all groups (%d row(s) updated).', $count));
             $didSomething = true;
         }
@@ -120,23 +120,29 @@ final class RecoveryCommand extends Command
     }
 
     /**
-     * Set passkey_enforcement to "off" for one group (by UID) or for all groups.
+     * Set passkey_enforcement to "off" for a single group.
      *
      * @return int number of affected rows
      */
-    private function disableEnforcement(?int $groupUid): int
+    private function disableEnforcementForGroup(int $groupUid): int
     {
         $connection = $this->connectionPool->getConnectionForTable(self::TABLE_GROUPS);
 
-        if ($groupUid !== null) {
-            return $connection->update(self::TABLE_GROUPS, ['passkey_enforcement' => 'off'], ['uid' => $groupUid]);
-        }
+        return $connection->update(self::TABLE_GROUPS, ['passkey_enforcement' => 'off'], ['uid' => $groupUid]);
+    }
 
-        $queryBuilder = $connection->createQueryBuilder();
+    /**
+     * Set passkey_enforcement to "off" for all groups.
+     *
+     * @return int number of affected rows
+     */
+    private function disableEnforcementForAllGroups(): int
+    {
+        $queryBuilder = $this->connectionPool->getConnectionForTable(self::TABLE_GROUPS)->createQueryBuilder();
         $queryBuilder
             ->update(self::TABLE_GROUPS)
             ->set('passkey_enforcement', 'off');
 
-        return (int) $queryBuilder->executeStatement();
+        return $queryBuilder->executeStatement();
     }
 }

--- a/Classes/Command/RecoveryCommand.php
+++ b/Classes/Command/RecoveryCommand.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Command;
+
+use Netresearch\NrPasskeysBe\Service\RateLimiterService;
+use Netresearch\NrPasskeysBe\Utility\TypeCastTrait;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Emergency, out-of-band recovery from the CLI.
+ *
+ * Covers the lockout scenarios that have no in-backend escape: e.g. a group set to
+ * Enforced where every member (including admins) lost access to their authenticator,
+ * or an account locked out by failed attempts. Run on the server, no backend login
+ * required.
+ */
+#[AsCommand(
+    name: 'passkeys:recovery',
+    description: 'Emergency recovery: list/disable passkey enforcement and reset login lockouts from the CLI.',
+)]
+final class RecoveryCommand extends Command
+{
+    use TypeCastTrait;
+
+    private const TABLE_GROUPS = 'be_groups';
+
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+        private readonly RateLimiterService $rateLimiterService,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('list', null, InputOption::VALUE_NONE, 'List all backend user groups and their passkey enforcement level')
+            ->addOption('disable-group', null, InputOption::VALUE_REQUIRED, 'Set passkey enforcement to "off" for the given be_groups UID')
+            ->addOption('disable-all', null, InputOption::VALUE_NONE, 'Set passkey enforcement to "off" for ALL backend user groups')
+            ->addOption('unlock', null, InputOption::VALUE_REQUIRED, 'Reset the login lockout counters for the given username');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $didSomething = false;
+
+        if ($input->getOption('list') === true) {
+            $this->listGroups($io);
+            $didSomething = true;
+        }
+
+        $disableGroup = $input->getOption('disable-group');
+        if (\is_string($disableGroup) && $disableGroup !== '') {
+            $uid = (int) $disableGroup;
+            $count = $this->disableEnforcement($uid);
+            $io->success(\sprintf('Passkey enforcement set to "off" for group %d (%d row(s) updated).', $uid, $count));
+            $didSomething = true;
+        }
+
+        if ($input->getOption('disable-all') === true) {
+            $count = $this->disableEnforcement(null);
+            $io->success(\sprintf('Passkey enforcement set to "off" for all groups (%d row(s) updated).', $count));
+            $didSomething = true;
+        }
+
+        $unlock = $input->getOption('unlock');
+        if (\is_string($unlock) && $unlock !== '') {
+            $this->rateLimiterService->resetLockout($unlock);
+            $io->success(\sprintf('Login lockout reset for user "%s".', $unlock));
+            $didSomething = true;
+        }
+
+        if (!$didSomething) {
+            $io->note('Nothing to do. Use --list, --disable-group=UID, --disable-all or --unlock=USERNAME.');
+
+            return Command::INVALID;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function listGroups(SymfonyStyle $io): void
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_GROUPS);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $rows = $queryBuilder
+            ->select('uid', 'title', 'passkey_enforcement', 'passkey_grace_period_days')
+            ->from(self::TABLE_GROUPS)
+            ->where($queryBuilder->expr()->eq('deleted', 0))
+            ->orderBy('uid')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $tableRows = [];
+        foreach ($rows as $row) {
+            $tableRows[] = [
+                (string) self::intVal($row['uid'] ?? null),
+                self::stringVal($row['title'] ?? null),
+                self::stringVal($row['passkey_enforcement'] ?? null, 'off'),
+                (string) self::intVal($row['passkey_grace_period_days'] ?? null),
+            ];
+        }
+
+        $io->table(['UID', 'Title', 'Enforcement', 'Grace (days)'], $tableRows);
+    }
+
+    /**
+     * Set passkey_enforcement to "off" for one group (by UID) or for all groups.
+     *
+     * @return int number of affected rows
+     */
+    private function disableEnforcement(?int $groupUid): int
+    {
+        $connection = $this->connectionPool->getConnectionForTable(self::TABLE_GROUPS);
+
+        if ($groupUid !== null) {
+            return $connection->update(self::TABLE_GROUPS, ['passkey_enforcement' => 'off'], ['uid' => $groupUid]);
+        }
+
+        $queryBuilder = $connection->createQueryBuilder();
+        $queryBuilder
+            ->update(self::TABLE_GROUPS)
+            ->set('passkey_enforcement', 'off');
+
+        return (int) $queryBuilder->executeStatement();
+    }
+}

--- a/Classes/Controller/AdminModuleController.php
+++ b/Classes/Controller/AdminModuleController.php
@@ -17,11 +17,17 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Template\Components\ButtonBar;
+use TYPO3\CMS\Backend\Template\Components\Buttons\LinkButton;
+use TYPO3\CMS\Backend\Template\Components\ComponentFactory;
+use TYPO3\CMS\Backend\Template\Components\Menu\Menu;
+use TYPO3\CMS\Backend\Template\Components\Menu\MenuItem;
+use TYPO3\CMS\Backend\Template\Components\MenuRegistry;
 use TYPO3\CMS\Backend\Template\ModuleTemplate;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Imaging\IconSize;
 use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Backend module controller for the passkey management admin module.
@@ -31,6 +37,13 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 final class AdminModuleController
 {
     use TranslationTrait;
+
+    /**
+     * Resolved docheader ComponentFactory (TYPO3 v14+), or null on v12/v13 where it
+     * does not exist. false means "not yet resolved" (lazy, resolved at most once).
+     */
+    private ComponentFactory|false|null $componentFactory = false;
+
     public function __construct(
         private readonly ModuleTemplateFactory $moduleTemplateFactory,
         private readonly AdoptionStatsService $adoptionStatsService,
@@ -136,10 +149,10 @@ final class AdminModuleController
     private function buildDocHeaderMenu(ModuleTemplate $moduleTemplate, string $activeTab): void
     {
         $menuRegistry = $moduleTemplate->getDocHeaderComponent()->getMenuRegistry();
-        $menu = $menuRegistry->makeMenu();
+        $menu = $this->createMenu($menuRegistry);
         $menu->setIdentifier('PasskeyManagementMenu');
 
-        $dashboardItem = $menu->makeMenuItem()
+        $dashboardItem = $this->createMenuItem($menu)
             ->setTitle($this->translate('module.dashboard', 'Dashboard'))
             ->setHref((string) $this->uriBuilder->buildUriFromRoute('admin_passkeys'));
         if ($activeTab === 'dashboard') {
@@ -147,7 +160,7 @@ final class AdminModuleController
         }
         $menu->addMenuItem($dashboardItem);
 
-        $helpItem = $menu->makeMenuItem()
+        $helpItem = $this->createMenuItem($menu)
             ->setTitle($this->translate('module.help', 'Help'))
             ->setHref((string) $this->uriBuilder->buildUriFromRoute('admin_passkeys.help'));
         if ($activeTab === 'help') {
@@ -156,6 +169,49 @@ final class AdminModuleController
         $menu->addMenuItem($helpItem);
 
         $menuRegistry->addMenu($menu);
+    }
+
+    /**
+     * Create a docheader Menu, using the v14+ ComponentFactory when available and
+     * falling back to the (v12/v13-only, non-deprecated there) MenuRegistry::makeMenu().
+     */
+    private function createMenu(MenuRegistry $menuRegistry): Menu
+    {
+        $factory = $this->componentFactory();
+        if ($factory !== null) {
+            return $factory->createMenu();
+        }
+
+        return $menuRegistry->makeMenu(); // @phpstan-ignore method.deprecated
+    }
+
+    /**
+     * Create a docheader MenuItem, using the v14+ ComponentFactory when available and
+     * falling back to the (v12/v13-only, non-deprecated there) Menu::makeMenuItem().
+     */
+    private function createMenuItem(Menu $menu): MenuItem
+    {
+        $factory = $this->componentFactory();
+        if ($factory !== null) {
+            return $factory->createMenuItem();
+        }
+
+        return $menu->makeMenuItem(); // @phpstan-ignore method.deprecated
+    }
+
+    /**
+     * Resolve the docheader ComponentFactory once. Returns null on TYPO3 v12/v13
+     * where the class does not exist (callers fall back to the deprecated make* API).
+     */
+    private function componentFactory(): ?ComponentFactory
+    {
+        if ($this->componentFactory === false) {
+            $this->componentFactory = \class_exists(ComponentFactory::class)
+                ? GeneralUtility::makeInstance(ComponentFactory::class)
+                : null;
+        }
+
+        return $this->componentFactory;
     }
 
     /**
@@ -187,7 +243,7 @@ final class AdminModuleController
     private function addHelpButton(ModuleTemplate $moduleTemplate): void
     {
         $buttonBar = $moduleTemplate->getDocHeaderComponent()->getButtonBar();
-        $helpButton = $buttonBar->makeLinkButton()
+        $helpButton = $this->createLinkButton($buttonBar)
             ->setHref((string) $this->uriBuilder->buildUriFromRoute('admin_passkeys.help'))
             ->setTitle($this->translate('module.help', 'Help'))
             ->setIcon($this->iconFactory->getIcon(
@@ -196,6 +252,20 @@ final class AdminModuleController
             ))
             ->setShowLabelText(false);
         $buttonBar->addButton($helpButton, ButtonBar::BUTTON_POSITION_RIGHT, 1);
+    }
+
+    /**
+     * Create a docheader LinkButton, using the v14+ ComponentFactory when available and
+     * falling back to the (v12/v13-only, non-deprecated there) ButtonBar::makeLinkButton().
+     */
+    private function createLinkButton(ButtonBar $buttonBar): LinkButton
+    {
+        $factory = $this->componentFactory();
+        if ($factory !== null) {
+            return $factory->createLinkButton();
+        }
+
+        return $buttonBar->makeLinkButton(); // @phpstan-ignore method.deprecated
     }
 
     /**

--- a/Classes/Controller/AdminModuleController.php
+++ b/Classes/Controller/AdminModuleController.php
@@ -182,7 +182,7 @@ final class AdminModuleController
             return $factory->createMenu();
         }
 
-        return $menuRegistry->makeMenu(); // @phpstan-ignore method.deprecated
+        return $menuRegistry->makeMenu();
     }
 
     /**
@@ -196,7 +196,7 @@ final class AdminModuleController
             return $factory->createMenuItem();
         }
 
-        return $menu->makeMenuItem(); // @phpstan-ignore method.deprecated
+        return $menu->makeMenuItem();
     }
 
     /**
@@ -265,7 +265,7 @@ final class AdminModuleController
             return $factory->createLinkButton();
         }
 
-        return $buttonBar->makeLinkButton(); // @phpstan-ignore method.deprecated
+        return $buttonBar->makeLinkButton();
     }
 
     /**

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -83,8 +83,8 @@ final class LoginController
         try {
             $this->rateLimiterService->checkRateLimit('login_options', $ip);
             $this->rateLimiterService->checkLockout($username, $ip);
-        } catch (RuntimeException) {
-            return new JsonResponse(['error' => 'Too many requests'], 429, ['Retry-After' => '60']);
+        } catch (RuntimeException $e) {
+            return $this->throttledResponse($e);
         }
 
         $this->rateLimiterService->recordAttempt('login_options', $ip);
@@ -164,8 +164,8 @@ final class LoginController
         try {
             $this->rateLimiterService->checkRateLimit('login_verify', $ip);
             $this->rateLimiterService->checkLockout($username, $ip);
-        } catch (RuntimeException) {
-            return new JsonResponse(['error' => 'Too many requests'], 429, ['Retry-After' => '60']);
+        } catch (RuntimeException $e) {
+            return $this->throttledResponse($e);
         }
 
         $this->rateLimiterService->recordAttempt('login_verify', $ip);
@@ -199,6 +199,27 @@ final class LoginController
 
             return new JsonResponse(['error' => 'Authentication failed'], 401);
         }
+    }
+
+    /**
+     * Build a 429 response distinguishing an account lockout from transient rate
+     * limiting (UX-3). The lockout exception carries code 1700000011; the client
+     * uses the 'locked' flag to show the dedicated "account locked" message.
+     */
+    private function throttledResponse(RuntimeException $e): ResponseInterface
+    {
+        $locked = $e->getCode() === 1700000011;
+
+        return new JsonResponse(
+            [
+                'error' => $locked
+                    ? 'Account temporarily locked. Please contact your administrator.'
+                    : 'Too many requests. Please try again later.',
+                'locked' => $locked,
+            ],
+            429,
+            ['Retry-After' => '60'],
+        );
     }
 
     private function findBeUserUid(string $username): ?int

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -89,15 +89,30 @@ final class LoginController
 
         $this->rateLimiterService->recordAttempt('login_options', $ip);
 
-        // Look up user - return generic response for unknown users to prevent enumeration
+        // Look up user. To prevent username enumeration, an unknown user receives a
+        // DECOY options response with the SAME shape and HTTP 200 status as a real
+        // user (deterministic per-username decoy credentials). A later assertion
+        // against the decoy fails exactly as a wrong passkey would.
         $beUserUid = $this->findBeUserUid($username);
         if ($beUserUid === null) {
-            // Use a short sleep to normalize timing
+            // Short randomized sleep to further normalize timing.
             \usleep(\random_int(50000, 150000));
 
-            return new JsonResponse([
-                'error' => 'Authentication failed',
-            ], 401);
+            try {
+                $result = $this->webAuthnService->createDecoyAssertionOptions($username);
+                $optionsJson = $this->webAuthnService->serializeRequestOptions($result->options);
+
+                return new JsonResponse([
+                    'options' => \json_decode($optionsJson, true, 512, JSON_THROW_ON_ERROR),
+                    'challengeToken' => $result->challengeToken,
+                ]);
+            } catch (Throwable $e) {
+                $this->logger->error('Failed to generate decoy assertion options', [
+                    'error' => $e->getMessage(),
+                ]);
+
+                return new JsonResponse(['error' => 'Internal error'], 500);
+            }
         }
 
         try {
@@ -172,7 +187,9 @@ final class LoginController
 
             return new JsonResponse(['status' => 'ok']);
         } catch (RuntimeException $e) {
-            $this->rateLimiterService->recordFailure($username, $ip);
+            // Do not feed the cross-IP per-username lockout (passkey assertions are
+            // unforgeable; counting them only enables an account-lockout DoS).
+            $this->rateLimiterService->recordFailure($username, $ip, countUserLockout: false);
 
             $this->logger->warning('Passkey assertion verification failed', [
                 'username_hash' => \hash('sha256', $username),

--- a/Classes/EventListener/InjectPasskeyLoginFields.php
+++ b/Classes/EventListener/InjectPasskeyLoginFields.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrPasskeysBe\EventListener;
 
 use Netresearch\NrPasskeysBe\Service\ExtensionConfigurationService;
+use Netresearch\NrPasskeysBe\Utility\TranslationTrait;
 use TYPO3\CMS\Backend\LoginProvider\Event\ModifyPageLayoutOnLoginProviderSelectionEvent;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Attribute\AsEventListener;
@@ -18,6 +19,8 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 #[AsEventListener(identifier: 'nr-passkeys-be/inject-passkey-login-fields')]
 final readonly class InjectPasskeyLoginFields
 {
+    use TranslationTrait;
+
     public function __construct(
         private ExtensionConfigurationService $configService,
         private PageRenderer $pageRenderer,
@@ -42,6 +45,26 @@ final readonly class InjectPasskeyLoginFields
             'rpId' => $this->configService->getEffectiveRpId(),
             'origin' => $this->configService->getEffectiveOrigin(),
             'discoverableEnabled' => $config->isDiscoverableLoginEnabled(),
+            // Server-translated UI labels for PasskeyLogin.js (the login screen is
+            // pre-authentication, so labels are injected here rather than via
+            // addInlineLanguageLabelFile/TYPO3.lang). JS keeps English fallbacks.
+            'labels' => [
+                'signIn' => $this->translate('login.provider.label', 'Sign in with a passkey'),
+                'loading' => $this->translate('login.button.passkey.loading', 'Authenticating…'),
+                'errorUnsupported' => $this->translate('login.error.unsupported', 'Your browser does not support Passkeys (WebAuthn).'),
+                'errorInsecure' => $this->translate('login.error.insecure', 'Passkeys require a secure connection (HTTPS).'),
+                'errorRateLimit' => $this->translate('login.error.rateLimit', 'Too many attempts. Please try again later.'),
+                'errorGeneric' => $this->translate('login.error.generic', 'Authentication failed. Please try again.'),
+                'errorCancelled' => $this->translate('login.error.cancelled', 'Authentication was cancelled.'),
+                'errorNotAllowed' => $this->translate('login.error.notAllowed', 'Authentication was cancelled or no passkey found for this site. Have you registered a passkey?'),
+                'errorSecurity' => $this->translate('login.error.security', 'Security error. Please check your connection.'),
+                'errorUsernameRequired' => $this->translate('login.error.usernameRequired', 'Please enter your username.'),
+                'errorVerifyFailed' => $this->translate('login.error.verifyFailed', 'Passkey authentication failed. Your passkey was not accepted. Please try again or sign in with your password.'),
+                'dividerOr' => $this->translate('login.divider.or', 'or'),
+                'helpTitle' => $this->translate('login.help.title', 'What are passkeys?'),
+                'helpContent' => $this->translate('login.help.content', 'Passkeys are a modern replacement for passwords.'),
+                'helpLearnMore' => $this->translate('login.help.learnMore', 'Learn more about passkeys'),
+            ],
         ];
 
         $this->pageRenderer->addJsInlineCode(

--- a/Classes/EventListener/InjectPasskeyLoginFields.php
+++ b/Classes/EventListener/InjectPasskeyLoginFields.php
@@ -54,6 +54,7 @@ final readonly class InjectPasskeyLoginFields
                 'errorUnsupported' => $this->translate('login.error.unsupported', 'Your browser does not support Passkeys (WebAuthn).'),
                 'errorInsecure' => $this->translate('login.error.insecure', 'Passkeys require a secure connection (HTTPS).'),
                 'errorRateLimit' => $this->translate('login.error.rateLimit', 'Too many attempts. Please try again later.'),
+                'errorLocked' => $this->translate('login.error.locked', 'Account temporarily locked. Please contact your administrator.'),
                 'errorGeneric' => $this->translate('login.error.generic', 'Authentication failed. Please try again.'),
                 'errorCancelled' => $this->translate('login.error.cancelled', 'Authentication was cancelled.'),
                 'errorNotAllowed' => $this->translate('login.error.notAllowed', 'Authentication was cancelled or no passkey found for this site. Have you registered a passkey?'),

--- a/Classes/Form/Element/PasskeyInfoElement.php
+++ b/Classes/Form/Element/PasskeyInfoElement.php
@@ -223,11 +223,24 @@ class PasskeyInfoElement extends AbstractFormElement
         if ($isManagementAllowed) {
             /** @var list<JavaScriptModuleInstruction> $jsModules */
             $jsModules = $resultArray['javaScriptModules'] ?? [];
+            $ll = 'LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang.xlf:';
             $jsModules[] = JavaScriptModuleInstruction::create(
                 '@netresearch/nr-passkeys-be/PasskeyAdminInfo.js',
             )->instance('#' . $fieldId, [
                 'userId' => $userId,
                 'username' => $username,
+                // Server-translated notification labels (the Modal labels are passed via
+                // data-* attributes; these cover the JS Notification.* calls). I18N-3.
+                'labels' => [
+                    'revoked' => $lang->sL($ll . 'admin.passkeys.notification.revoked'),
+                    'revokeFailed' => $lang->sL($ll . 'admin.passkeys.notification.revokeFailed'),
+                    'revokeAllDone' => $lang->sL($ll . 'admin.passkeys.notification.revokeAllDone'),
+                    'revokeAllFailed' => $lang->sL($ll . 'admin.passkeys.notification.revokeAllFailed'),
+                    'unlockDone' => $lang->sL($ll . 'admin.passkeys.notification.unlockDone'),
+                    'unlockFailed' => $lang->sL($ll . 'admin.passkeys.notification.unlockFailed'),
+                    'requestFailed' => $lang->sL($ll . 'admin.passkeys.notification.requestFailed'),
+                    'badgeRevoked' => $lang->sL($ll . 'admin.passkeys.status.revoked'),
+                ],
             ]);
             $resultArray['javaScriptModules'] = $jsModules;
         }

--- a/Classes/Middleware/PasskeySetupInterstitial.php
+++ b/Classes/Middleware/PasskeySetupInterstitial.php
@@ -18,6 +18,7 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Backend\Routing\Route;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Http\RedirectResponse;
@@ -43,6 +44,11 @@ final class PasskeySetupInterstitial implements MiddlewareInterface
      */
     private const EXEMPT_ROUTE_PREFIXES = [
         'ajax_',
+        // 'user_setup' is the real User Settings module identifier (where passkey
+        // registration lives); it MUST be exempt so users forced into setup by the
+        // interstitial can actually reach the registration panel. 'setup' covers the
+        // standalone setup_mfa route.
+        'user_setup',
         'setup',
         'logout',
         'passkeys_manage_',
@@ -55,6 +61,7 @@ final class PasskeySetupInterstitial implements MiddlewareInterface
 
     public function __construct(
         private readonly EnforcementService $enforcementService,
+        private readonly UriBuilder $uriBuilder,
         private readonly LoggerInterface $logger,
     ) {}
 
@@ -223,6 +230,12 @@ final class PasskeySetupInterstitial implements MiddlewareInterface
         $escapedBackendPath = \htmlspecialchars($backendPath, ENT_QUOTES, 'UTF-8');
         $escapedNonce = \htmlspecialchars($nonce, ENT_QUOTES, 'UTF-8');
 
+        // Link to the real User Settings module (identifier "user_setup") where the
+        // passkey registration panel is rendered. The module is exempt from this
+        // middleware (see EXEMPT_ROUTE_PREFIXES) so the user can actually reach it.
+        $setupUrl = (string) $this->uriBuilder->buildUriFromRoute('user_setup');
+        $escapedSetupUrl = \htmlspecialchars($setupUrl, ENT_QUOTES, 'UTF-8');
+
         $title = $this->translate('interstitial.title', 'Set up your passkey');
         $description = $this->translate('interstitial.description', 'Passkeys provide a more secure and convenient way to sign in without passwords. They use your device\'s built-in biometric sensors or security keys to verify your identity, making your account resistant to phishing attacks.');
         $setupLabel = $this->translate('interstitial.button.setup', 'Set up now');
@@ -353,7 +366,7 @@ HTML;
         <p class="description">{$escapedDescription}</p>
         <div class="grace-period">{$escapedGraceMessage}</div>
         <div class="actions">
-            <a href="{$escapedBackendPath}setup/" class="btn-setup" autofocus>{$escapedSetupLabel}</a>
+            <a href="{$escapedSetupUrl}" class="btn-setup" autofocus>{$escapedSetupLabel}</a>
             {$skipButton}
         </div>
     </main>

--- a/Classes/Middleware/PasskeySetupInterstitial.php
+++ b/Classes/Middleware/PasskeySetupInterstitial.php
@@ -266,11 +266,11 @@ final class PasskeySetupInterstitial implements MiddlewareInterface
                         <form method="post" action="{$escapedBackendPath}" style="display:inline">
                             <input type="hidden" name="passkey_setup_skip" value="1" />
                             <input type="hidden" name="passkey_setup_nonce" value="{$escapedNonce}" />
-                            <button type="submit" style="
+                            <button type="submit" class="btn-skip" style="
                                 padding: 10px 24px;
                                 background: transparent;
-                                color: #b0b0b0;
-                                border: 1px solid #555;
+                                color: #c9c9c9;
+                                border: 1px solid #8a8a8a;
                                 border-radius: 4px;
                                 font-size: 14px;
                                 cursor: pointer;
@@ -357,6 +357,11 @@ HTML;
         }
         .btn-setup:hover {
             background: #106ebe;
+        }
+        .btn-setup:focus-visible,
+        .btn-skip:focus-visible {
+            outline: 2px solid #ffffff;
+            outline-offset: 2px;
         }
     </style>
 </head>

--- a/Classes/Middleware/PasskeySetupInterstitial.php
+++ b/Classes/Middleware/PasskeySetupInterstitial.php
@@ -38,6 +38,14 @@ final class PasskeySetupInterstitial implements MiddlewareInterface
     private const SESSION_KEY = 'tx_nrpasskeysbe';
 
     /**
+     * How long (seconds) a "no interstitial needed" decision is cached in the
+     * session to avoid re-running the enforcement queries (credential count +
+     * group enforcement) on every backend request. Kept short so an admin's
+     * enforcement change takes effect quickly.
+     */
+    private const ENFORCEMENT_CACHE_TTL = 60;
+
+    /**
      * Route identifier prefixes that are exempt from the interstitial.
      *
      * @var list<string>
@@ -128,10 +136,30 @@ final class PasskeySetupInterstitial implements MiddlewareInterface
             }
         }
 
+        // PERF-1 / ONB-3: reuse a recent "no interstitial needed" decision instead of
+        // re-querying the database on every backend request. The short TTL bounds how
+        // long a stale decision (e.g. enforcement raised, or passkeys revoked) can
+        // suppress the interstitial, so it cannot be permanently suppressed.
+        $now = \time();
+        $decidedAt = $sessionArray['enforcement_ok_at'] ?? 0;
+        if (\is_int($decidedAt) && $decidedAt > 0 && ($now - $decidedAt) < self::ENFORCEMENT_CACHE_TTL) {
+            return $handler->handle($request);
+        }
+
         $status = $this->enforcementService->getStatus($userRow);
 
         if (!$status->requiresInterstitial()) {
+            // Cache the clear decision so subsequent requests skip the queries.
+            $sessionArray['enforcement_ok_at'] = $now;
+            $backendUser->setAndSaveSessionData(self::SESSION_KEY, $sessionArray);
+
             return $handler->handle($request);
+        }
+
+        // No longer compliant — drop any cached "ok" decision so it is not reused.
+        if (isset($sessionArray['enforcement_ok_at'])) {
+            unset($sessionArray['enforcement_ok_at']);
+            $backendUser->setAndSaveSessionData(self::SESSION_KEY, $sessionArray);
         }
 
         // Start grace period on first intercept — construct updated status

--- a/Classes/Service/RateLimiterService.php
+++ b/Classes/Service/RateLimiterService.php
@@ -130,9 +130,17 @@ final class RateLimiterService
     /**
      * Record a failed authentication attempt.
      *
-     * Increments both per-IP+username and per-username counters atomically.
+     * Always increments the per-IP+username counter. The cross-IP per-username
+     * counter is incremented only when $countUserLockout is true.
+     *
+     * Passkey assertion failures pass false: a WebAuthn assertion cannot be forged
+     * without the authenticator's private key, so a cross-IP per-username lockout
+     * provides no real brute-force protection for passkeys but would let an
+     * unauthenticated attacker lock a victim out of passkey login by spamming
+     * failures for their username (account-lockout DoS). The per-IP+username
+     * counter still throttles a single abusive source.
      */
-    public function recordFailure(string $username, string $ip): void
+    public function recordFailure(string $username, string $ip, bool $countUserLockout = true): void
     {
         $config = $this->configService->getConfiguration();
         $duration = $config->getLockoutDurationSeconds();
@@ -142,9 +150,11 @@ final class RateLimiterService
         $ipKey = $this->buildLockoutKey($username, $ip);
         $this->atomicIncrement($ipKey, [$tag], $duration);
 
-        // Increment per-username counter
-        $userKey = $this->buildUserLockoutKey($username);
-        $this->atomicIncrement($userKey, [$tag], $duration);
+        // Increment per-username counter only when requested (see method docblock)
+        if ($countUserLockout) {
+            $userKey = $this->buildUserLockoutKey($username);
+            $this->atomicIncrement($userKey, [$tag], $duration);
+        }
     }
 
     /**

--- a/Classes/Service/WebAuthnService.php
+++ b/Classes/Service/WebAuthnService.php
@@ -253,6 +253,49 @@ final class WebAuthnService
     }
 
     /**
+     * Create *decoy* assertion options for an unknown username.
+     *
+     * Returns options structurally identical to a real user's so the public
+     * login-options endpoint cannot be used to enumerate valid backend usernames.
+     * The decoy allowCredentials are derived deterministically from the username
+     * (HMAC over an HKDF-derived key from the extension encryption key), so repeated
+     * requests for the same unknown username yield stable, unguessable credential
+     * descriptors. A subsequent assertion against a decoy fails verification exactly
+     * as a wrong passkey would, keeping known and unknown users indistinguishable.
+     */
+    public function createDecoyAssertionOptions(string $username): AssertionOptions
+    {
+        $rpId = $this->configService->getEffectiveRpId();
+        $challenge = $this->challengeService->generateChallenge();
+        $challengeToken = $this->challengeService->createChallengeToken($challenge);
+
+        $key = $this->configService->getEncryptionKey();
+        $derivedKey = \hash_hkdf('sha256', $key, 32, 'nr_passkeys_be_decoy');
+        $decoyId = \hash_hmac('sha256', $username, $derivedKey, true);
+
+        $allowCredentials = [
+            PublicKeyCredentialDescriptor::create(
+                type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+                id: $decoyId,
+                transports: [],
+            ),
+        ];
+
+        $options = PublicKeyCredentialRequestOptions::create(
+            challenge: $challenge,
+            rpId: $rpId,
+            allowCredentials: $allowCredentials,
+            userVerification: $this->configService->getConfiguration()->getUserVerification(),
+            timeout: 60000,
+        );
+
+        return new AssertionOptions(
+            options: $options,
+            challengeToken: $challengeToken,
+        );
+    }
+
+    /**
      * Resolve the backend user UID from a passkey assertion response.
      *
      * Used for discoverable (usernameless) login where the credential ID

--- a/Classes/UserSettings/PasskeySettingsPanel.php
+++ b/Classes/UserSettings/PasskeySettingsPanel.php
@@ -138,7 +138,7 @@ final class PasskeySettingsPanel
      data-remove-url="{$removeUrl}">
     <h4>{$title} <span class="badge {$countBadgeClass}" id="passkey-count">{$passkeyCount}</span></h4>
     <p class="text-body-secondary">{$description}</p>
-    <div id="passkey-single-warning" class="alert alert-warning d-none">{$singleKeyWarning}</div>
+    <div id="passkey-single-warning" class="alert alert-warning d-none" role="status" aria-live="polite">{$singleKeyWarning}</div>
     <div class="mb-3">
         <div class="d-flex align-items-center gap-2">
             <input type="text" id="passkey-name-input" class="form-control form-control-sm passkey-name-input" value="Passkey" maxlength="128" placeholder="{$nameLabel}" aria-label="{$nameLabel}" aria-describedby="passkey-name-help" />
@@ -146,7 +146,7 @@ final class PasskeySettingsPanel
         </div>
         <small id="passkey-name-help" class="form-text text-body-secondary">{$nameHelp}</small>
     </div>
-    <div id="passkey-empty" class="alert alert-info d-none">{$noPasskeys}</div>
+    <div id="passkey-empty" class="alert alert-info d-none" role="status" aria-live="polite">{$noPasskeys}</div>
     <table class="table table-hover" id="passkey-list-table">
         <thead>
             <tr>

--- a/Classes/UserSettings/PasskeySettingsPanel.php
+++ b/Classes/UserSettings/PasskeySettingsPanel.php
@@ -66,6 +66,10 @@ final class PasskeySettingsPanel
 
         $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
         $pageRenderer->loadJavaScriptModule('@netresearch/nr-passkeys-be/PasskeyManagement.js');
+        $pageRenderer->addInlineLanguageLabelFile(
+            'EXT:nr_passkeys_be/Resources/Private/Language/locallang.xlf',
+            'js.',
+        );
 
         $credentialRepository = GeneralUtility::makeInstance(CredentialRepository::class);
         $passkeyCount = $credentialRepository->countByBeUser($userId);

--- a/Classes/UserSettings/PasskeySettingsPanelElement.php
+++ b/Classes/UserSettings/PasskeySettingsPanelElement.php
@@ -85,6 +85,10 @@ final class PasskeySettingsPanelElement extends AbstractFormElement
         }
 
         $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-passkeys-be/PasskeyManagement.js');
+        $this->pageRenderer->addInlineLanguageLabelFile(
+            'EXT:nr_passkeys_be/Resources/Private/Language/locallang.xlf',
+            'js.',
+        );
 
         $passkeyCount = $this->credentialRepository->countByBeUser($userId);
 

--- a/Documentation/Administration/Enforcement.rst
+++ b/Documentation/Administration/Enforcement.rst
@@ -46,7 +46,11 @@ passkey.
           During the grace period, users can click :guilabel:`Skip for now` to
           dismiss the interstitial for the remainder of their session. After the
           grace period expires, the interstitial becomes mandatory and cannot be
-          skipped.
+          skipped. In addition, once the grace period has expired, **password
+          login is refused for users who already have a passkey** -- they must
+          authenticate with their passkey (the same behaviour as **Enforced**
+          for those users). If such a user loses access to their authenticator,
+          see *Recovery procedures* below.
 
     *   - **Enforced**
         - 3

--- a/Documentation/Administration/Enforcement.rst
+++ b/Documentation/Administration/Enforcement.rst
@@ -255,6 +255,32 @@ broken YubiKey):
 
       {"beUserUid": 123, "username": "johndoe"}
 
+Command-line recovery
+---------------------
+
+If **all** administrators are locked out -- for example a group was set to
+**Enforced** and every member lost access to their authenticator -- recovery is
+still possible from the server shell, without a backend login, using the
+``passkeys:recovery`` command:
+
+..  code-block:: bash
+    :caption: Emergency recovery from the CLI
+
+    # List all groups and their enforcement level
+    vendor/bin/typo3 passkeys:recovery --list
+
+    # Disable passkey enforcement for one group (by UID)
+    vendor/bin/typo3 passkeys:recovery --disable-group=5
+
+    # Disable passkey enforcement for ALL groups
+    vendor/bin/typo3 passkeys:recovery --disable-all
+
+    # Reset the login lockout for a specific account
+    vendor/bin/typo3 passkeys:recovery --unlock=johndoe
+
+After enforcement is disabled, affected users can log in with their password
+again and re-register a passkey.
+
 4. The user logs in with their password (if password login is still available)
    and registers a new passkey.
 

--- a/Documentation/Troubleshooting/Index.rst
+++ b/Documentation/Troubleshooting/Index.rst
@@ -72,6 +72,92 @@ Browsers block ``navigator.credentials.create()`` and
     but other HTTP origins are not.
 
 
+"Account temporarily locked" or "Too many requests" (HTTP 429)
+==============================================================
+
+**Symptoms**
+
+The login screen shows *"Account temporarily locked. Please contact your
+administrator."* or *"Too many attempts. Please try again later."* and the
+login endpoints return HTTP 429.
+
+**Cause**
+
+After too many failed attempts the account is locked for a configurable
+duration (per-IP and per-account counters). Rate limiting additionally throttles
+bursts of requests per IP. The "locked" message indicates the account lockout;
+"too many attempts" indicates transient rate limiting.
+
+**Fix**
+
+-   Wait for the lockout/rate-limit window to expire (``lockoutDurationSeconds``
+    / ``rateLimitWindowSeconds`` in the extension configuration), then retry.
+-   An administrator can clear a lockout immediately from the be_users record
+    (:guilabel:`Reset login lock`), the admin API, or the CLI:
+    ``vendor/bin/typo3 passkeys:recovery --unlock=USERNAME``.
+
+
+"Authentication was cancelled or no passkey found for this site"
+================================================================
+
+**Symptoms**
+
+The browser passkey dialog opens and immediately fails, or never offers the
+registered passkey, with a ``NotAllowedError``.
+
+**Cause**
+
+This is usually an **RP ID / origin mismatch**: a passkey is bound to the
+Relying Party ID (the registrable domain) it was created for. If the backend is
+reached on a different host than when the passkey was registered (e.g. a bare
+domain vs ``www``, a different subdomain, or a reverse-proxy host), the browser
+will not surface the credential. It can also mean no passkey is registered yet.
+
+**Fix**
+
+-   Ensure the backend is always reached on the same host the passkey was
+    registered on. Pin a stable ``rpId``/``origin`` in the extension
+    configuration if auto-detection picks the wrong host (see
+    :ref:`Security deployment <security-deployment>`).
+-   Confirm the user actually has a registered, non-revoked passkey
+    (:guilabel:`Admin Tools > Passkey Management`).
+
+
+"Your browser does not support Passkeys (WebAuthn)"
+===================================================
+
+**Symptoms**
+
+The passkey button is disabled and a notice states the browser is unsupported.
+
+**Cause**
+
+The browser does not expose ``window.PublicKeyCredential`` (very old browsers,
+or hardened environments where the WebAuthn API is disabled).
+
+**Fix**
+
+Use a current browser (recent Chrome, Edge, Firefox or Safari). Password login
+remains available unless an administrator has enforced passwordless login.
+
+
+Lost or broken authenticator (no access to a passkey)
+=====================================================
+
+**Symptoms**
+
+A user can no longer authenticate because their device/security key is lost or
+broken, and — under **Enforced** or expired **Required** enforcement — password
+login is refused.
+
+**Fix**
+
+See :ref:`Recovery procedures <enforcement>` in the enforcement chapter: an
+administrator revokes the lost credential and/or lowers the group enforcement,
+or — if all administrators are locked out — recovers from the CLI with
+``vendor/bin/typo3 passkeys:recovery``.
+
+
 Extension log location
 ======================
 

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -93,9 +93,13 @@ page:
 
 ..  note::
 
-    Passkeys work alongside TYPO3's built-in multi-factor authentication
-    (MFA). If MFA is enabled, you will complete MFA verification after
-    passkey authentication.
+    A passkey is itself multi-factor (device possession plus a biometric or
+    PIN), so by default the extension **skips** TYPO3's additional MFA challenge
+    after a successful passkey login. This is controlled by the
+    ``skipMfaOnPasskeyAuth`` setting, which is enabled by default. If an
+    administrator disables it, you will also complete TYPO3's MFA verification
+    after passkey authentication. Password logins are unaffected and always
+    follow TYPO3's MFA configuration.
 
 Managing your passkeys
 ======================

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -35,6 +35,30 @@
             <trans-unit id="login.error.locked" resname="login.error.locked">
                 <source>Account temporarily locked. Please contact your administrator.</source>
             </trans-unit>
+            <trans-unit id="login.error.notAllowed" resname="login.error.notAllowed">
+                <source>Authentication was cancelled or no passkey found for this site. Have you registered a passkey?</source>
+            </trans-unit>
+            <trans-unit id="login.error.security" resname="login.error.security">
+                <source>Security error. Please check your connection.</source>
+            </trans-unit>
+            <trans-unit id="login.error.usernameRequired" resname="login.error.usernameRequired">
+                <source>Please enter your username.</source>
+            </trans-unit>
+            <trans-unit id="login.error.verifyFailed" resname="login.error.verifyFailed">
+                <source>Passkey authentication failed. Your passkey was not accepted. Please try again or sign in with your password.</source>
+            </trans-unit>
+            <trans-unit id="login.divider.or" resname="login.divider.or">
+                <source>or</source>
+            </trans-unit>
+            <trans-unit id="login.help.title" resname="login.help.title">
+                <source>What are passkeys?</source>
+            </trans-unit>
+            <trans-unit id="login.help.content" resname="login.help.content">
+                <source>Passkeys are a modern replacement for passwords. They use your device’s biometric sensors (fingerprint, face) or security keys to verify your identity. They’re faster and more secure than passwords because they can’t be phished or stolen.</source>
+            </trans-unit>
+            <trans-unit id="login.help.learnMore" resname="login.help.learnMore">
+                <source>Learn more about passkeys</source>
+            </trans-unit>
             <trans-unit id="manage.title" resname="manage.title">
                 <source>Passkeys</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -341,6 +341,18 @@
             <trans-unit id="js.enforcement.failed" resname="js.enforcement.failed">
                 <source>Update failed</source>
             </trans-unit>
+            <trans-unit id="js.enforcement.confirm.title" resname="js.enforcement.confirm.title">
+                <source>Confirm enforcement change</source>
+            </trans-unit>
+            <trans-unit id="js.enforcement.confirm.body" resname="js.enforcement.confirm.body">
+                <source>Setting this group to "%s" can block backend login for its members until they register a passkey. Continue?</source>
+            </trans-unit>
+            <trans-unit id="js.enforcement.confirm.ok" resname="js.enforcement.confirm.ok">
+                <source>Yes, change enforcement</source>
+            </trans-unit>
+            <trans-unit id="js.button.cancel" resname="js.button.cancel">
+                <source>Cancel</source>
+            </trans-unit>
             <trans-unit id="js.unlock.progress" resname="js.unlock.progress">
                 <source>Resetting...</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -353,6 +353,93 @@
             <trans-unit id="js.button.cancel" resname="js.button.cancel">
                 <source>Cancel</source>
             </trans-unit>
+            <trans-unit id="js.manage.unsupported.title" resname="js.manage.unsupported.title">
+                <source>WebAuthn not supported</source>
+            </trans-unit>
+            <trans-unit id="js.manage.unsupported.body" resname="js.manage.unsupported.body">
+                <source>Your browser does not support Passkeys (WebAuthn).</source>
+            </trans-unit>
+            <trans-unit id="js.manage.https.title" resname="js.manage.https.title">
+                <source>HTTPS required</source>
+            </trans-unit>
+            <trans-unit id="js.manage.https.body" resname="js.manage.https.body">
+                <source>Passkeys require a secure connection (HTTPS).</source>
+            </trans-unit>
+            <trans-unit id="js.manage.load.failed" resname="js.manage.load.failed">
+                <source>Load failed</source>
+            </trans-unit>
+            <trans-unit id="js.manage.load.failedBody" resname="js.manage.load.failedBody">
+                <source>Failed to load passkeys.</source>
+            </trans-unit>
+            <trans-unit id="js.manage.unnamed" resname="js.manage.unnamed">
+                <source>Unnamed</source>
+            </trans-unit>
+            <trans-unit id="js.manage.never" resname="js.manage.never">
+                <source>Never</source>
+            </trans-unit>
+            <trans-unit id="js.manage.rename" resname="js.manage.rename">
+                <source>Rename</source>
+            </trans-unit>
+            <trans-unit id="js.manage.remove" resname="js.manage.remove">
+                <source>Remove</source>
+            </trans-unit>
+            <trans-unit id="js.manage.add" resname="js.manage.add">
+                <source>Add Passkey</source>
+            </trans-unit>
+            <trans-unit id="js.manage.adding" resname="js.manage.adding">
+                <source>Registering...</source>
+            </trans-unit>
+            <trans-unit id="js.manage.register.success.title" resname="js.manage.register.success.title">
+                <source>Passkey registered</source>
+            </trans-unit>
+            <trans-unit id="js.manage.register.success.body" resname="js.manage.register.success.body">
+                <source>Passkey registered successfully.</source>
+            </trans-unit>
+            <trans-unit id="js.manage.register.failed.title" resname="js.manage.register.failed.title">
+                <source>Registration failed</source>
+            </trans-unit>
+            <trans-unit id="js.manage.register.failed.body" resname="js.manage.register.failed.body">
+                <source>Registration failed.</source>
+            </trans-unit>
+            <trans-unit id="js.manage.register.failed.body2" resname="js.manage.register.failed.body2">
+                <source>Failed to register passkey.</source>
+            </trans-unit>
+            <trans-unit id="js.manage.register.cancelled.title" resname="js.manage.register.cancelled.title">
+                <source>Cancelled</source>
+            </trans-unit>
+            <trans-unit id="js.manage.register.cancelled.body" resname="js.manage.register.cancelled.body">
+                <source>Registration was cancelled.</source>
+            </trans-unit>
+            <trans-unit id="js.manage.rename.success.title" resname="js.manage.rename.success.title">
+                <source>Passkey renamed</source>
+            </trans-unit>
+            <trans-unit id="js.manage.rename.success.body" resname="js.manage.rename.success.body">
+                <source>Passkey renamed successfully.</source>
+            </trans-unit>
+            <trans-unit id="js.manage.rename.failed.title" resname="js.manage.rename.failed.title">
+                <source>Rename failed</source>
+            </trans-unit>
+            <trans-unit id="js.manage.rename.failed.body" resname="js.manage.rename.failed.body">
+                <source>Failed to rename passkey.</source>
+            </trans-unit>
+            <trans-unit id="js.manage.remove.confirm.title" resname="js.manage.remove.confirm.title">
+                <source>Remove passkey</source>
+            </trans-unit>
+            <trans-unit id="js.manage.remove.confirm.body" resname="js.manage.remove.confirm.body">
+                <source>Are you sure you want to remove the passkey "%s"?</source>
+            </trans-unit>
+            <trans-unit id="js.manage.remove.success.title" resname="js.manage.remove.success.title">
+                <source>Passkey removed</source>
+            </trans-unit>
+            <trans-unit id="js.manage.remove.success.body" resname="js.manage.remove.success.body">
+                <source>Passkey removed successfully.</source>
+            </trans-unit>
+            <trans-unit id="js.manage.remove.failed.title" resname="js.manage.remove.failed.title">
+                <source>Remove failed</source>
+            </trans-unit>
+            <trans-unit id="js.manage.remove.failed.body" resname="js.manage.remove.failed.body">
+                <source>Failed to remove passkey.</source>
+            </trans-unit>
             <trans-unit id="js.unlock.progress" resname="js.unlock.progress">
                 <source>Resetting...</source>
             </trans-unit>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -170,6 +170,27 @@
             <trans-unit id="admin.passkeys.status.revoked" resname="admin.passkeys.status.revoked">
                 <source>Revoked</source>
             </trans-unit>
+            <trans-unit id="admin.passkeys.notification.revoked" resname="admin.passkeys.notification.revoked">
+                <source>Passkey revoked</source>
+            </trans-unit>
+            <trans-unit id="admin.passkeys.notification.revokeFailed" resname="admin.passkeys.notification.revokeFailed">
+                <source>Failed to revoke passkey</source>
+            </trans-unit>
+            <trans-unit id="admin.passkeys.notification.revokeAllDone" resname="admin.passkeys.notification.revokeAllDone">
+                <source>All passkeys revoked</source>
+            </trans-unit>
+            <trans-unit id="admin.passkeys.notification.revokeAllFailed" resname="admin.passkeys.notification.revokeAllFailed">
+                <source>Failed to revoke passkeys</source>
+            </trans-unit>
+            <trans-unit id="admin.passkeys.notification.unlockDone" resname="admin.passkeys.notification.unlockDone">
+                <source>Login lock reset</source>
+            </trans-unit>
+            <trans-unit id="admin.passkeys.notification.unlockFailed" resname="admin.passkeys.notification.unlockFailed">
+                <source>Failed to reset login lock</source>
+            </trans-unit>
+            <trans-unit id="admin.passkeys.notification.requestFailed" resname="admin.passkeys.notification.requestFailed">
+                <source>Request failed</source>
+            </trans-unit>
             <trans-unit id="admin.passkeys.created" resname="admin.passkeys.created">
                 <source>Created</source>
             </trans-unit>

--- a/Resources/Private/Templates/AdminModule/Dashboard.html
+++ b/Resources/Private/Templates/AdminModule/Dashboard.html
@@ -228,6 +228,7 @@
                                         <div class="btn-group" role="group" aria-label="{f:translate(key: 'dashboard.usersWithout.actions', extensionName: 'NrPasskeysBe')}">
                                             <button type="button"
                                                     class="btn btn-default btn-sm passkey-send-reminder"
+                                                    aria-live="polite"
                                                     data-user-uid="{user.uid}"
                                                     data-username="{user.username}"
                                                     title="{f:translate(key: 'dashboard.usersWithout.sendReminder', extensionName: 'NrPasskeysBe')}">
@@ -237,6 +238,7 @@
                                             <f:if condition="{user.hasActiveNudge}">
                                                 <button type="button"
                                                         class="btn btn-default btn-sm passkey-clear-nudge"
+                                                        aria-live="polite"
                                                         data-user-uid="{user.uid}"
                                                         data-username="{user.username}"
                                                         title="{f:translate(key: 'dashboard.usersWithout.clearNudge', extensionName: 'NrPasskeysBe')}">
@@ -246,6 +248,7 @@
                                             </f:if>
                                             <button type="button"
                                                     class="btn btn-default btn-sm passkey-unlock-user"
+                                                    aria-live="polite"
                                                     data-user-uid="{user.uid}"
                                                     data-username="{user.username}"
                                                     title="{f:translate(key: 'dashboard.usersWithout.unlock', extensionName: 'NrPasskeysBe')}">

--- a/Resources/Private/Templates/AdminModule/Dashboard.html
+++ b/Resources/Private/Templates/AdminModule/Dashboard.html
@@ -123,6 +123,7 @@
                                     <td>{group.title}</td>
                                     <td>
                                         <select class="form-select form-select-sm passkey-enforcement-select"
+                                                aria-label="{f:translate(key: 'dashboard.groups.enforcement', extensionName: 'NrPasskeysBe')}: {group.title}"
                                                 data-group-uid="{group.uid}"
                                                 data-original-value="{group.enforcement}">
                                             <f:for each="{enforcementLevels}" as="label" key="value">

--- a/Resources/Public/JavaScript/PasskeyAdminInfo.js
+++ b/Resources/Public/JavaScript/PasskeyAdminInfo.js
@@ -14,6 +14,7 @@ import { sudoModeInterceptor } from '@typo3/backend/security/sudo-mode-intercept
 class PasskeyAdminInfo {
   constructor(selector, options) {
     this.options = options || {};
+    this.labels = this.options.labels || {};
     this.fullElement = null;
     this.request = null;
 
@@ -152,15 +153,15 @@ class PasskeyAdminInfo {
       .then(async (response) => {
         const data = await response.resolve();
         if (data.status === 'ok') {
-          Notification.success('Passkey revoked');
+          Notification.success(this.labels.revoked || 'Passkey revoked');
           this.markItemAsRevoked(credentialUid);
           this.updateStatusAfterRevoke();
         } else {
-          Notification.error('Failed to revoke passkey', data.error || '');
+          Notification.error(this.labels.revokeFailed || 'Failed to revoke passkey', data.error || '');
         }
       })
       .catch(() => {
-        Notification.error('Request failed');
+        Notification.error(this.labels.requestFailed || 'Request failed');
       })
       .finally(() => {
         this.request = null;
@@ -181,14 +182,14 @@ class PasskeyAdminInfo {
       .then(async (response) => {
         const data = await response.resolve();
         if (data.status === 'ok') {
-          Notification.success('All passkeys revoked (' + data.revokedCount + ')');
+          Notification.success((this.labels.revokeAllDone || 'All passkeys revoked') + ' (' + data.revokedCount + ')');
           this.markAllItemsAsRevoked();
         } else {
-          Notification.error('Failed to revoke passkeys', data.error || '');
+          Notification.error(this.labels.revokeAllFailed || 'Failed to revoke passkeys', data.error || '');
         }
       })
       .catch(() => {
-        Notification.error('Request failed');
+        Notification.error(this.labels.requestFailed || 'Request failed');
       })
       .finally(() => {
         this.request = null;
@@ -208,13 +209,13 @@ class PasskeyAdminInfo {
       .then(async (response) => {
         const data = await response.resolve();
         if (data.status === 'ok') {
-          Notification.success('Login lock reset');
+          Notification.success(this.labels.unlockDone || 'Login lock reset');
         } else {
-          Notification.error('Failed to reset login lock', data.error || '');
+          Notification.error(this.labels.unlockFailed || 'Failed to reset login lock', data.error || '');
         }
       })
       .catch(() => {
-        Notification.error('Request failed');
+        Notification.error(this.labels.requestFailed || 'Request failed');
       })
       .finally(() => {
         this.request = null;
@@ -231,7 +232,7 @@ class PasskeyAdminInfo {
     if (activeBadge) {
       activeBadge.classList.remove('badge-success');
       activeBadge.classList.add('badge-danger');
-      activeBadge.textContent = 'Revoked';
+      activeBadge.textContent = this.labels.badgeRevoked || 'Revoked';
     }
     // Remove the per-item revoke button
     const revokeBtn = item.querySelector('.t3js-passkey-revoke-button');
@@ -267,7 +268,7 @@ class PasskeyAdminInfo {
       if (activeBadge) {
         activeBadge.classList.remove('badge-success');
         activeBadge.classList.add('badge-danger');
-        activeBadge.textContent = 'Revoked';
+        activeBadge.textContent = this.labels.badgeRevoked || 'Revoked';
       }
       const revokeBtn = item.querySelector('.t3js-passkey-revoke-button');
       if (revokeBtn) {

--- a/Resources/Public/JavaScript/PasskeyDashboard.js
+++ b/Resources/Public/JavaScript/PasskeyDashboard.js
@@ -10,6 +10,8 @@
 import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 import Notification from '@typo3/backend/notification.js';
 import DocumentService from '@typo3/core/document-service.js';
+import Modal from '@typo3/backend/modal.js';
+import { SeverityEnum } from '@typo3/backend/enum/severity.js';
 
 class PasskeyDashboard {
   constructor() {
@@ -73,12 +75,52 @@ class PasskeyDashboard {
     });
   }
 
-  async handleEnforcementChange(event) {
+  handleEnforcementChange(event) {
     const select = event.target;
     const groupUid = parseInt(select.dataset.groupUid, 10);
     const enforcement = select.value;
     const originalValue = select.dataset.originalValue;
 
+    // Escalating to a level that can block backend login (Required/Enforced) is a
+    // lockout risk for everyone in the group, so require explicit confirmation
+    // before applying. Off/Encourage apply immediately.
+    if ((enforcement === 'required' || enforcement === 'enforced') && enforcement !== originalValue) {
+      Modal.show(
+        this.translate('js.enforcement.confirm.title', 'Confirm enforcement change'),
+        this.translate(
+          'js.enforcement.confirm.body',
+          'Setting this group to "%s" can block backend login for its members until they register a passkey. Continue?',
+        ).replace('%s', enforcement),
+        SeverityEnum.warning,
+        [
+          {
+            text: this.translate('js.button.cancel', 'Cancel'),
+            active: true,
+            btnClass: 'btn-default',
+            name: 'cancel',
+            trigger: (e, modal) => {
+              select.value = originalValue;
+              modal.hideModal();
+            },
+          },
+          {
+            text: this.translate('js.enforcement.confirm.ok', 'Yes, change enforcement'),
+            btnClass: 'btn-warning',
+            name: 'confirm',
+            trigger: (e, modal) => {
+              modal.hideModal();
+              this.performEnforcementChange(select, groupUid, enforcement, originalValue);
+            },
+          },
+        ],
+      );
+      return;
+    }
+
+    this.performEnforcementChange(select, groupUid, enforcement, originalValue);
+  }
+
+  async performEnforcementChange(select, groupUid, enforcement, originalValue) {
     select.disabled = true;
 
     try {

--- a/Resources/Public/JavaScript/PasskeyLogin.js
+++ b/Resources/Public/JavaScript/PasskeyLogin.js
@@ -19,11 +19,14 @@
     var config = window.NrPasskeysBeConfig;
     if (!config || !config.loginOptionsUrl) return;
 
+    // Server-translated UI labels (with English fallbacks if injection is absent).
+    var L = config.labels || {};
+
     var loginForm = document.getElementById('typo3-login-form');
     if (!loginForm) return;
 
     // Build and inject passkey UI below the login button with an "or" divider
-    var container = buildPasskeyUI();
+    var container = buildPasskeyUI(L);
     var submitSection = document.getElementById('t3-login-submit-section');
     if (submitSection) {
       submitSection.parentNode.insertBefore(container, submitSection.nextSibling);
@@ -42,14 +45,14 @@
 
     // Check WebAuthn support
     if (!window.PublicKeyCredential) {
-      showError('Your browser does not support Passkeys (WebAuthn).');
+      showError(L.errorUnsupported || 'Your browser does not support Passkeys (WebAuthn).');
       if (loginBtn) loginBtn.disabled = true;
       return;
     }
 
     // Check secure context
     if (!window.isSecureContext) {
-      showError('Passkeys require a secure connection (HTTPS).');
+      showError(L.errorInsecure || 'Passkeys require a secure connection (HTTPS).');
       if (loginBtn) loginBtn.disabled = true;
       return;
     }
@@ -68,7 +71,7 @@
           // Still on the login page after a passkey submission = auth failed.
           // TYPO3 does a POST-Redirect-GET after failed login, so the generic
           // error div (#t3-login-error) may not be present on the redirected page.
-          showError('Passkey authentication failed. Your passkey was not accepted. Please try again or sign in with your password.');
+          showError(L.errorVerifyFailed || 'Passkey authentication failed. Your passkey was not accepted. Please try again or sign in with your password.');
           // Hide generic TYPO3 error if it exists
           var typo3Error = document.getElementById('t3-login-error');
           if (typo3Error) {
@@ -85,7 +88,7 @@
       var username = usernameInput ? usernameInput.value.trim() : '';
 
       if (!username && !config.discoverableEnabled) {
-        showError('Please enter your username.');
+        showError(L.errorUsernameRequired || 'Please enter your username.');
         if (usernameInput) usernameInput.focus();
         return;
       }
@@ -105,9 +108,9 @@
         if (!optionsResponse.ok) {
           var data = await optionsResponse.json().catch(function () { return {}; });
           if (optionsResponse.status === 429) {
-            showError('Too many attempts. Please try again later.');
+            showError(L.errorRateLimit || 'Too many attempts. Please try again later.');
           } else {
-            showError(data.error || 'Authentication failed. Please try again.');
+            showError(data.error || L.errorGeneric || 'Authentication failed. Please try again.');
           }
           setLoading(false);
           return;
@@ -195,13 +198,13 @@
         setLoading(false);
 
         if (err.name === 'NotAllowedError') {
-          showError('Authentication was cancelled or no passkey found for this site. Have you registered a passkey?');
+          showError(L.errorNotAllowed || 'Authentication was cancelled or no passkey found for this site. Have you registered a passkey?');
         } else if (err.name === 'SecurityError') {
-          showError('Security error. Please check your connection.');
+          showError(L.errorSecurity || 'Security error. Please check your connection.');
         } else if (err.name === 'AbortError') {
-          showError('Authentication was cancelled.');
+          showError(L.errorCancelled || 'Authentication was cancelled.');
         } else {
-          showError('Authentication failed: ' + (err.message || 'Please try again.'));
+          showError(L.errorGeneric || 'Authentication failed. Please try again.');
           console.error('Passkey login error:', err);
         }
       }
@@ -215,8 +218,11 @@
 
     function showError(message) {
       if (errorEl) {
-        errorEl.textContent = message;
+        // Make the live region visible/in the a11y tree BEFORE injecting text so
+        // the aria-live="assertive" announcement fires reliably (NVDA/JAWS/VoiceOver
+        // do not consistently announce text set on a display:none node).
         errorEl.classList.remove('d-none');
+        errorEl.textContent = message;
       }
     }
 
@@ -240,8 +246,8 @@
     '28.5-11.5T780-440q0-17-11.5-28.5T740-480q-17 0-28.5 11.5T700-440q0 ' +
     '17 11.5 28.5T740-400Z"/></svg>';
 
-  function buildPasskeyUI() {
-    // All content is static/hardcoded — no user input in this markup
+  function buildPasskeyUI(labels) {
+    labels = labels || {};
     var divider = document.createElement('div');
     divider.className = 'passkey-divider mb-2 mt-2';
     divider.setAttribute('style', 'display:flex;align-items:center;gap:8px');
@@ -249,7 +255,7 @@
     hrLeft.setAttribute('style', 'flex:1;border:none;border-top:1px solid #ccc;margin:0');
     var orLabel = document.createElement('span');
     orLabel.setAttribute('style', 'color:#999;font-size:12px;text-transform:uppercase;letter-spacing:1px');
-    orLabel.textContent = 'or';
+    orLabel.textContent = labels.dividerOr || 'or';
     var hrRight = document.createElement('hr');
     hrRight.setAttribute('style', 'flex:1;border:none;border-top:1px solid #ccc;margin:0');
     divider.appendChild(hrLeft);
@@ -276,7 +282,7 @@
     iconSpan.innerHTML = PASSKEY_ICON; // eslint-disable-line -- static SVG constant
     var textSpan = document.createElement('span');
     textSpan.id = 'passkey-btn-text';
-    textSpan.textContent = 'Sign in with a passkey';
+    textSpan.textContent = labels.signIn || 'Sign in with a passkey';
     var loadingSpan = document.createElement('span');
     loadingSpan.id = 'passkey-btn-loading';
     loadingSpan.className = 'd-none';
@@ -284,7 +290,7 @@
     spinner.className = 'spinner-border spinner-border-sm me-2';
     spinner.setAttribute('role', 'status');
     loadingSpan.appendChild(spinner);
-    loadingSpan.appendChild(document.createTextNode('Authenticating\u2026'));
+    loadingSpan.appendChild(document.createTextNode(labels.loading || 'Authenticating\u2026'));
 
     btn.appendChild(iconSpan);
     btn.appendChild(textSpan);
@@ -297,14 +303,14 @@
     var helpContent = document.createElement('div');
     helpContent.id = 'passkey-help-content';
     helpContent.className = 'alert alert-light small d-none mb-2';
-    helpContent.textContent = 'Passkeys are a modern replacement for passwords. They use your device\u2019s biometric sensors (fingerprint, face) or security keys to verify your identity. They\u2019re faster and more secure than passwords because they can\u2019t be phished or stolen.';
+    helpContent.textContent = labels.helpContent || 'Passkeys are a modern replacement for passwords. They use your device\u2019s biometric sensors (fingerprint, face) or security keys to verify your identity. They\u2019re faster and more secure than passwords because they can\u2019t be phished or stolen.';
 
     var learnMore = document.createElement('a');
     learnMore.href = 'https://passkeys.dev';
     learnMore.target = '_blank';
     learnMore.rel = 'noopener noreferrer';
     learnMore.className = 'small d-block mt-1';
-    learnMore.textContent = 'Learn more about passkeys';
+    learnMore.textContent = labels.helpLearnMore || 'Learn more about passkeys';
     helpContent.appendChild(document.createElement('br'));
     helpContent.appendChild(learnMore);
 
@@ -312,7 +318,7 @@
     helpLink.href = '#';
     helpLink.id = 'passkey-help-link';
     helpLink.className = 'passkey-help-link small text-muted d-block text-center mb-2';
-    helpLink.textContent = 'What are passkeys?';
+    helpLink.textContent = labels.helpTitle || 'What are passkeys?';
     helpLink.addEventListener('click', function (e) {
       e.preventDefault();
       helpContent.classList.toggle('d-none');
@@ -325,6 +331,9 @@
     errorDiv.id = 'passkey-error';
     errorDiv.className = 'alert alert-danger d-none mb-2';
     errorDiv.setAttribute('role', 'alert');
+    // Announce async WebAuthn errors to screen readers (A11Y-1).
+    errorDiv.setAttribute('aria-live', 'assertive');
+    errorDiv.setAttribute('aria-atomic', 'true');
     container.appendChild(errorDiv);
 
     var assertionInput = document.createElement('input');

--- a/Resources/Public/JavaScript/PasskeyLogin.js
+++ b/Resources/Public/JavaScript/PasskeyLogin.js
@@ -108,7 +108,9 @@
         if (!optionsResponse.ok) {
           var data = await optionsResponse.json().catch(function () { return {}; });
           if (optionsResponse.status === 429) {
-            showError(L.errorRateLimit || 'Too many attempts. Please try again later.');
+            showError(data.locked
+              ? (L.errorLocked || 'Account temporarily locked. Please contact your administrator.')
+              : (L.errorRateLimit || 'Too many attempts. Please try again later.'));
           } else {
             showError(data.error || L.errorGeneric || 'Authentication failed. Please try again.');
           }

--- a/Resources/Public/JavaScript/PasskeyManagement.js
+++ b/Resources/Public/JavaScript/PasskeyManagement.js
@@ -81,7 +81,7 @@ class PasskeyManagement {
       const data = await response.resolve();
       this.renderList(data.credentials, data.enforcementEnabled);
     } catch (error) {
-      Notification.error('Load failed', 'Failed to load passkeys.');
+      Notification.error('Load failed', await this.resolveErrorMessage(error, 'Failed to load passkeys.'));
     }
   }
 
@@ -239,7 +239,7 @@ class PasskeyManagement {
       if (error.name === 'NotAllowedError' || error.name === 'AbortError') {
         Notification.info('Cancelled', 'Registration was cancelled.');
       } else {
-        Notification.error('Registration failed', error.message || 'Failed to register passkey.');
+        Notification.error('Registration failed', await this.resolveErrorMessage(error, 'Failed to register passkey.'));
       }
     }
 
@@ -280,7 +280,7 @@ class PasskeyManagement {
         }
       } catch (error) {
         labelSpan.textContent = currentLabel;
-        Notification.error('Rename failed', error.message || 'Failed to rename passkey.');
+        Notification.error('Rename failed', await this.resolveErrorMessage(error, 'Failed to rename passkey.'));
       }
     };
 
@@ -329,7 +329,7 @@ class PasskeyManagement {
                 Notification.error('Remove failed', data.error || 'Failed to remove passkey.');
               }
             } catch (error) {
-              Notification.error('Remove failed', error.message || 'Failed to remove passkey.');
+              Notification.error('Remove failed', await this.resolveErrorMessage(error, 'Failed to remove passkey.'));
             }
             modal.hideModal();
           },
@@ -361,6 +361,33 @@ class PasskeyManagement {
     const el = document.createElement('span');
     el.textContent = text;
     return el.innerHTML;
+  }
+
+  /**
+   * Extract a human-readable error message from a caught error.
+   *
+   * TYPO3's AjaxRequest throws an AjaxResponse (which has no `.message`) on any
+   * non-2xx response, so `error.message` was always undefined and every failure
+   * showed the generic fallback — including the important last-passkey 409. The
+   * server's `{ "error": "..." }` body lives on the wrapped fetch Response, so we
+   * read it from there first, then fall back to a DOMException/Error message, then
+   * the provided default.
+   */
+  async resolveErrorMessage(error, fallback) {
+    if (error && error.response && typeof error.response.json === 'function') {
+      try {
+        const body = await error.response.json();
+        if (body && body.error) {
+          return body.error;
+        }
+      } catch (e) {
+        // Response body was not JSON — fall through to the generic handling.
+      }
+    }
+    if (error && typeof error.message === 'string' && error.message !== '') {
+      return error.message;
+    }
+    return fallback;
   }
 
   // Base64URL utilities

--- a/Resources/Public/JavaScript/PasskeyManagement.js
+++ b/Resources/Public/JavaScript/PasskeyManagement.js
@@ -52,7 +52,11 @@ class PasskeyManagement {
 
     // Check WebAuthn support
     if (!window.PublicKeyCredential) {
-      Notification.warning('WebAuthn not supported', 'Your browser does not support Passkeys (WebAuthn).', 0);
+      Notification.warning(
+        this.translate('js.manage.unsupported.title', 'WebAuthn not supported'),
+        this.translate('js.manage.unsupported.body', 'Your browser does not support Passkeys (WebAuthn).'),
+        0,
+      );
       if (this.addBtn) {
         this.addBtn.disabled = true;
       }
@@ -61,7 +65,11 @@ class PasskeyManagement {
 
     // Check secure context (HTTPS required for WebAuthn)
     if (window.isSecureContext === false) {
-      Notification.warning('HTTPS required', 'Passkeys require a secure connection (HTTPS).', 0);
+      Notification.warning(
+        this.translate('js.manage.https.title', 'HTTPS required'),
+        this.translate('js.manage.https.body', 'Passkeys require a secure connection (HTTPS).'),
+        0,
+      );
       if (this.addBtn) {
         this.addBtn.disabled = true;
       }
@@ -81,7 +89,10 @@ class PasskeyManagement {
       const data = await response.resolve();
       this.renderList(data.credentials, data.enforcementEnabled);
     } catch (error) {
-      Notification.error('Load failed', await this.resolveErrorMessage(error, 'Failed to load passkeys.'));
+      Notification.error(
+        this.translate('js.manage.load.failed', 'Load failed'),
+        await this.resolveErrorMessage(error, this.translate('js.manage.load.failedBody', 'Failed to load passkeys.')),
+      );
     }
   }
 
@@ -124,7 +135,7 @@ class PasskeyManagement {
       const labelCell = document.createElement('td');
       const labelSpan = document.createElement('span');
       labelSpan.className = 'passkey-label';
-      labelSpan.textContent = cred.label || 'Unnamed';
+      labelSpan.textContent = cred.label || this.translate('js.manage.unnamed', 'Unnamed');
       labelSpan.dataset.uid = cred.uid;
       labelSpan.addEventListener('dblclick', () => this.startRename(labelSpan, cred.uid));
       labelCell.appendChild(labelSpan);
@@ -137,7 +148,7 @@ class PasskeyManagement {
 
       // Last used cell
       const lastUsedCell = document.createElement('td');
-      lastUsedCell.textContent = cred.lastUsedAt ? this.formatTimestamp(cred.lastUsedAt) : 'Never';
+      lastUsedCell.textContent = cred.lastUsedAt ? this.formatTimestamp(cred.lastUsedAt) : this.translate('js.manage.never', 'Never');
       row.appendChild(lastUsedCell);
 
       // Actions cell
@@ -145,13 +156,13 @@ class PasskeyManagement {
 
       const renameBtn = document.createElement('button');
       renameBtn.className = 'btn btn-sm btn-outline-secondary me-1';
-      renameBtn.textContent = 'Rename';
+      renameBtn.textContent = this.translate('js.manage.rename', 'Rename');
       renameBtn.addEventListener('click', () => this.startRename(labelSpan, cred.uid));
       actionsCell.appendChild(renameBtn);
 
       const removeBtn = document.createElement('button');
       removeBtn.className = 'btn btn-sm btn-outline-danger';
-      removeBtn.textContent = 'Remove';
+      removeBtn.textContent = this.translate('js.manage.remove', 'Remove');
       removeBtn.addEventListener('click', () => this.handleRemove(cred.uid, cred.label));
       actionsCell.appendChild(removeBtn);
 
@@ -226,20 +237,32 @@ class PasskeyManagement {
         });
       const verifyData = await verifyResponse.resolve();
       if (verifyData.status === 'ok') {
-        Notification.success('Passkey registered', 'Passkey registered successfully.');
+        Notification.success(
+          this.translate('js.manage.register.success.title', 'Passkey registered'),
+          this.translate('js.manage.register.success.body', 'Passkey registered successfully.'),
+        );
         const nameInput = document.getElementById('passkey-name-input');
         if (nameInput) {
           nameInput.value = 'Passkey';
         }
         this.loadPasskeys();
       } else {
-        Notification.error('Registration failed', verifyData.error || 'Registration failed.');
+        Notification.error(
+          this.translate('js.manage.register.failed.title', 'Registration failed'),
+          verifyData.error || this.translate('js.manage.register.failed.body', 'Registration failed.'),
+        );
       }
     } catch (error) {
       if (error.name === 'NotAllowedError' || error.name === 'AbortError') {
-        Notification.info('Cancelled', 'Registration was cancelled.');
+        Notification.info(
+          this.translate('js.manage.register.cancelled.title', 'Cancelled'),
+          this.translate('js.manage.register.cancelled.body', 'Registration was cancelled.'),
+        );
       } else {
-        Notification.error('Registration failed', await this.resolveErrorMessage(error, 'Failed to register passkey.'));
+        Notification.error(
+          this.translate('js.manage.register.failed.title', 'Registration failed'),
+          await this.resolveErrorMessage(error, this.translate('js.manage.register.failed.body2', 'Failed to register passkey.')),
+        );
       }
     }
 
@@ -273,14 +296,23 @@ class PasskeyManagement {
         const data = await response.resolve();
         if (data.status === 'ok') {
           labelSpan.textContent = newLabel;
-          Notification.success('Passkey renamed', 'Passkey renamed successfully.');
+          Notification.success(
+            this.translate('js.manage.rename.success.title', 'Passkey renamed'),
+            this.translate('js.manage.rename.success.body', 'Passkey renamed successfully.'),
+          );
         } else {
           labelSpan.textContent = currentLabel;
-          Notification.error('Rename failed', data.error || 'Failed to rename passkey.');
+          Notification.error(
+            this.translate('js.manage.rename.failed.title', 'Rename failed'),
+            data.error || this.translate('js.manage.rename.failed.body', 'Failed to rename passkey.'),
+          );
         }
       } catch (error) {
         labelSpan.textContent = currentLabel;
-        Notification.error('Rename failed', await this.resolveErrorMessage(error, 'Failed to rename passkey.'));
+        Notification.error(
+          this.translate('js.manage.rename.failed.title', 'Rename failed'),
+          await this.resolveErrorMessage(error, this.translate('js.manage.rename.failed.body', 'Failed to rename passkey.')),
+        );
       }
     };
 
@@ -297,14 +329,14 @@ class PasskeyManagement {
   }
 
   handleRemove(uid, label) {
-    const safeLabel = this.escapeHtml(label || 'Unnamed');
+    const safeLabel = this.escapeHtml(label || this.translate('js.manage.unnamed', 'Unnamed'));
     Modal.show(
-      'Remove passkey',
-      'Are you sure you want to remove the passkey "' + safeLabel + '"?',
+      this.translate('js.manage.remove.confirm.title', 'Remove passkey'),
+      this.translate('js.manage.remove.confirm.body', 'Are you sure you want to remove the passkey "%s"?').replace('%s', safeLabel),
       SeverityEnum.warning,
       [
         {
-          text: 'Cancel',
+          text: this.translate('js.button.cancel', 'Cancel'),
           active: true,
           btnClass: 'btn-default',
           name: 'cancel',
@@ -313,7 +345,7 @@ class PasskeyManagement {
           },
         },
         {
-          text: 'Remove',
+          text: this.translate('js.manage.remove', 'Remove'),
           btnClass: 'btn-danger',
           name: 'remove',
           trigger: async (event, modal) => {
@@ -323,13 +355,22 @@ class PasskeyManagement {
                 .post({ uid: uid });
               const data = await response.resolve();
               if (data.status === 'ok') {
-                Notification.success('Passkey removed', 'Passkey removed successfully.');
+                Notification.success(
+                  this.translate('js.manage.remove.success.title', 'Passkey removed'),
+                  this.translate('js.manage.remove.success.body', 'Passkey removed successfully.'),
+                );
                 this.loadPasskeys();
               } else {
-                Notification.error('Remove failed', data.error || 'Failed to remove passkey.');
+                Notification.error(
+                  this.translate('js.manage.remove.failed.title', 'Remove failed'),
+                  data.error || this.translate('js.manage.remove.failed.body', 'Failed to remove passkey.'),
+                );
               }
             } catch (error) {
-              Notification.error('Remove failed', await this.resolveErrorMessage(error, 'Failed to remove passkey.'));
+              Notification.error(
+                this.translate('js.manage.remove.failed.title', 'Remove failed'),
+                await this.resolveErrorMessage(error, this.translate('js.manage.remove.failed.body', 'Failed to remove passkey.')),
+              );
             }
             modal.hideModal();
           },
@@ -341,7 +382,9 @@ class PasskeyManagement {
   setAddLoading(loading) {
     if (this.addBtn) {
       this.addBtn.disabled = loading;
-      this.addBtn.textContent = loading ? 'Registering...' : 'Add Passkey';
+      this.addBtn.textContent = loading
+        ? this.translate('js.manage.adding', 'Registering...')
+        : this.translate('js.manage.add', 'Add Passkey');
     }
     const nameInput = document.getElementById('passkey-name-input');
     if (nameInput) {
@@ -361,6 +404,17 @@ class PasskeyManagement {
     const el = document.createElement('span');
     el.textContent = text;
     return el.innerHTML;
+  }
+
+  /**
+   * Translate a key from the TYPO3 inline language labels with an English fallback.
+   *
+   * @param {string} key
+   * @param {string} fallback
+   * @returns {string}
+   */
+  translate(key, fallback) {
+    return (typeof TYPO3 !== 'undefined' && TYPO3.lang && TYPO3.lang[key]) || fallback;
   }
 
   /**

--- a/Tests/Architecture/ArchitectureTest.php
+++ b/Tests/Architecture/ArchitectureTest.php
@@ -220,4 +220,27 @@ final class ArchitectureTest
             ->should()->beFinal()
             ->because('UserSettings panel is a leaf class — composition over inheritance');
     }
+
+    public function test_authentication_is_final(): Rule
+    {
+        // PasskeyAuthenticationService is the one documented exception — it extends the
+        // TYPO3 AbstractAuthenticationService base class and is wired into the auth
+        // chain. Any *other* class added here must still be final.
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NS . 'Authentication'))
+            ->excluding(Selector::classname(self::NS . 'Authentication\\PasskeyAuthenticationService'))
+            ->should()->beFinal()
+            ->because('Authentication classes are leaf classes — composition over inheritance');
+    }
+
+    public function test_form_is_final(): Rule
+    {
+        // PasskeyInfoElement is the one documented exception — it extends the FormEngine
+        // AbstractFormElement base class. Any *other* class added here must still be final.
+        return PHPat::rule()
+            ->classes(Selector::inNamespace(self::NS . 'Form'))
+            ->excluding(Selector::classname(self::NS . 'Form\\Element\\PasskeyInfoElement'))
+            ->should()->beFinal()
+            ->because('Form classes are leaf classes — composition over inheritance');
+    }
 }

--- a/Tests/E2E/api-endpoints.spec.ts
+++ b/Tests/E2E/api-endpoints.spec.ts
@@ -94,15 +94,20 @@ test.describe('Login API - Validated with Session', () => {
         expect(body.options.allowCredentials).toEqual([]);
     });
 
-    test('login options returns 401 for non-existent user', async ({ page }) => {
+    test('login options returns indistinguishable decoy options for a non-existent user', async ({ page }) => {
+        // Anti-enumeration (SEC-1): an unknown username must NOT be distinguishable
+        // from a known one. The endpoint returns 200 with decoy assertion options +
+        // a challengeToken, exactly like a real user, rather than a 401.
         const response = await page.request.post('/typo3/passkeys/login/options', {
             headers: { 'Content-Type': 'application/json' },
             data: { username: 'nonexistent_user_xyz_12345' },
         });
 
-        expect(response.status()).toBe(401);
+        expect(response.status()).toBe(200);
         const body = await response.json();
-        expect(body.error).toContain('failed');
+        expect(body.options).toBeDefined();
+        expect(body.challengeToken).toBeDefined();
+        expect(body.error).toBeUndefined();
     });
 
     test('login verify rejects missing fields with 400', async ({ page }) => {

--- a/Tests/Unit/Authentication/PasskeyAuthenticationServiceTest.php
+++ b/Tests/Unit/Authentication/PasskeyAuthenticationServiceTest.php
@@ -254,6 +254,33 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     }
 
     #[Test]
+    public function authUserFailsOpenWhenEnforcementCheckThrows(): void
+    {
+        // OPS-2: a database/enforcement failure must NOT lock every backend user out
+        // of password login. On error the service logs and falls through (returns 100).
+        GeneralUtility::purgeInstances();
+
+        $configService = $this->createMock(ExtensionConfigurationService::class);
+        $configService->method('getConfiguration')->willReturn(new ExtensionConfiguration(disablePasswordLogin: false));
+
+        $enforcementService = $this->createMock(EnforcementService::class);
+        $enforcementService->method('getStatus')->willThrowException(new RuntimeException('database unavailable'));
+
+        GeneralUtility::addInstance(ExtensionConfigurationService::class, $configService);
+        GeneralUtility::addInstance(EnforcementService::class, $enforcementService);
+
+        $subject = new PasskeyAuthenticationService();
+        $this->injectLogger($subject, $this->logger);
+        $subject->pObj = $this->pObj;
+        // No passkey payload -> password path -> enforcement check throws -> fail open.
+        $subject->login = ['uname' => 'admin', 'uident' => 'regularPassword123'];
+
+        $result = $subject->authUser(['uid' => 42, 'username' => 'admin']);
+
+        self::assertSame(100, $result, 'Enforcement-check failure must fail open (allow password auth)');
+    }
+
+    #[Test]
     public function authUserWithInvalidPasskeyDataReturns0(): void
     {
         $this->subject->login = [

--- a/Tests/Unit/Command/RecoveryCommandTest.php
+++ b/Tests/Unit/Command/RecoveryCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Tests\Unit\Command;
+
+use Netresearch\NrPasskeysBe\Command\RecoveryCommand;
+use Netresearch\NrPasskeysBe\Service\RateLimiterService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+#[CoversClass(RecoveryCommand::class)]
+final class RecoveryCommandTest extends TestCase
+{
+    private ConnectionPool&MockObject $connectionPool;
+
+    private RateLimiterService&MockObject $rateLimiterService;
+
+    private CommandTester $tester;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->connectionPool = $this->createMock(ConnectionPool::class);
+        $this->rateLimiterService = $this->createMock(RateLimiterService::class);
+        $this->tester = new CommandTester(
+            new RecoveryCommand($this->connectionPool, $this->rateLimiterService),
+        );
+    }
+
+    #[Test]
+    public function unlockResetsTheLockoutForTheGivenUsername(): void
+    {
+        $this->rateLimiterService
+            ->expects(self::once())
+            ->method('resetLockout')
+            ->with('admin');
+
+        $exitCode = $this->tester->execute(['--unlock' => 'admin']);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('Login lockout reset', $this->tester->getDisplay());
+    }
+
+    #[Test]
+    public function returnsInvalidWhenNoActionRequested(): void
+    {
+        $this->rateLimiterService->expects(self::never())->method('resetLockout');
+
+        $exitCode = $this->tester->execute([]);
+
+        self::assertSame(Command::INVALID, $exitCode);
+        self::assertStringContainsString('Nothing to do', $this->tester->getDisplay());
+    }
+}

--- a/Tests/Unit/Controller/AdminModuleControllerTest.php
+++ b/Tests/Unit/Controller/AdminModuleControllerTest.php
@@ -25,6 +25,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Backend\Template\Components\ButtonBar;
 use TYPO3\CMS\Backend\Template\Components\Buttons\LinkButton;
+use TYPO3\CMS\Backend\Template\Components\ComponentFactory;
 use TYPO3\CMS\Backend\Template\Components\DocHeaderComponent;
 use TYPO3\CMS\Backend\Template\Components\Menu\Menu;
 use TYPO3\CMS\Backend\Template\Components\Menu\MenuItem;
@@ -36,6 +37,7 @@ use TYPO3\CMS\Core\Imaging\Icon;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Page\PageRenderer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 #[CoversClass(AdminModuleController::class)]
 final class AdminModuleControllerTest extends TestCase
@@ -105,6 +107,18 @@ final class AdminModuleControllerTest extends TestCase
         $buttonBar = $this->createMock(ButtonBar::class);
         $buttonBar->method('makeLinkButton')->willReturn($linkButton);
 
+        // TYPO3 v14+: the controller resolves the docheader components via
+        // ComponentFactory (GeneralUtility::makeInstance). Queue a mock returning the
+        // same component doubles. On v12/v13 the class is absent and the make* mocks
+        // above are used instead.
+        if (\class_exists(ComponentFactory::class)) {
+            $componentFactory = $this->createMock(ComponentFactory::class);
+            $componentFactory->method('createMenu')->willReturn($menu);
+            $componentFactory->method('createMenuItem')->willReturn($menuItem);
+            $componentFactory->method('createLinkButton')->willReturn($linkButton);
+            GeneralUtility::addInstance(ComponentFactory::class, $componentFactory);
+        }
+
         $docHeader = $this->createMock(DocHeaderComponent::class);
         $docHeader->method('getMenuRegistry')->willReturn($menuRegistry);
         $docHeader->method('getButtonBar')->willReturn($buttonBar);
@@ -118,6 +132,7 @@ final class AdminModuleControllerTest extends TestCase
     protected function tearDown(): void
     {
         unset($GLOBALS['LANG']);
+        GeneralUtility::purgeInstances();
         parent::tearDown();
     }
 

--- a/Tests/Unit/Controller/LoginControllerTest.php
+++ b/Tests/Unit/Controller/LoginControllerTest.php
@@ -159,16 +159,37 @@ final class LoginControllerTest extends TestCase
     }
 
     #[Test]
-    public function optionsActionWithUnknownUser(): void
+    public function optionsActionWithUnknownUserReturnsDecoyOptionsToPreventEnumeration(): void
     {
         $request = $this->createJsonRequest(['username' => 'unknown']);
         $this->setUpFindBeUser('unknown', null);
 
+        $options = PublicKeyCredentialRequestOptions::create(
+            challenge: \random_bytes(32),
+            rpId: 'example.com',
+        );
+        $this->webAuthnService
+            ->expects(self::once())
+            ->method('createDecoyAssertionOptions')
+            ->with('unknown')
+            ->willReturn(new AssertionOptions(
+                options: $options,
+                challengeToken: 'ct_decoy',
+            ));
+        $this->webAuthnService
+            ->expects(self::once())
+            ->method('serializeRequestOptions')
+            ->with($options)
+            ->willReturn('{"challenge":"abc","rpId":"example.com","allowCredentials":[{"type":"public-key","id":"decoy"}]}');
+
         $response = $this->subject->optionsAction($request);
 
-        self::assertSame(401, $response->getStatusCode());
+        // Same shape and status (200) as a real user -> no enumeration oracle.
+        self::assertSame(200, $response->getStatusCode());
         $body = $this->decodeResponse($response);
-        self::assertSame('Authentication failed', $body['error']);
+        self::assertArrayHasKey('options', $body);
+        self::assertSame('ct_decoy', $body['challengeToken']);
+        self::assertArrayNotHasKey('error', $body);
     }
 
     #[Test]

--- a/Tests/Unit/Controller/LoginControllerTest.php
+++ b/Tests/Unit/Controller/LoginControllerTest.php
@@ -205,7 +205,8 @@ final class LoginControllerTest extends TestCase
 
         self::assertSame(429, $response->getStatusCode());
         $body = $this->decodeResponse($response);
-        self::assertSame('Too many requests', $body['error']);
+        self::assertSame('Too many requests. Please try again later.', $body['error']);
+        self::assertFalse($body['locked']);
     }
 
     #[Test]
@@ -296,7 +297,8 @@ final class LoginControllerTest extends TestCase
 
         self::assertSame(429, $response->getStatusCode());
         $body = $this->decodeResponse($response);
-        self::assertSame('Too many requests', $body['error']);
+        self::assertSame('Too many requests. Please try again later.', $body['error']);
+        self::assertFalse($body['locked']);
     }
 
     #[Test]
@@ -414,13 +416,15 @@ final class LoginControllerTest extends TestCase
 
         $this->rateLimiterService
             ->method('checkLockout')
-            ->willThrowException(new RuntimeException('Account locked out', 1700000020));
+            ->willThrowException(new RuntimeException('Account locked out', 1700000011));
 
         $response = $this->subject->optionsAction($request);
 
         self::assertSame(429, $response->getStatusCode());
         $body = $this->decodeResponse($response);
-        self::assertSame('Too many requests', $body['error']);
+        // UX-3: a lockout (code 1700000011) is reported distinctly from rate limiting.
+        self::assertSame('Account temporarily locked. Please contact your administrator.', $body['error']);
+        self::assertTrue($body['locked']);
     }
 
     #[Test]
@@ -456,7 +460,9 @@ final class LoginControllerTest extends TestCase
 
         self::assertSame(429, $response->getStatusCode());
         $body = $this->decodeResponse($response);
-        self::assertSame('Too many requests', $body['error']);
+        // UX-3: lockout reported distinctly from rate limiting.
+        self::assertSame('Account temporarily locked. Please contact your administrator.', $body['error']);
+        self::assertTrue($body['locked']);
     }
 
     #[Test]

--- a/Tests/Unit/EventListener/InjectPasskeyLoginFieldsTest.php
+++ b/Tests/Unit/EventListener/InjectPasskeyLoginFieldsTest.php
@@ -179,6 +179,38 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
     }
 
     #[Test]
+    public function invokeInjectsTranslatedUiLabels(): void
+    {
+        $this->setUpConfigService();
+
+        $this->pageRenderer->method('addJsFile');
+
+        $this->pageRenderer
+            ->expects(self::once())
+            ->method('addJsInlineCode')
+            ->with(
+                'nr-passkeys-be-config',
+                self::callback(static function (string $code): bool {
+                    $jsonPart = \rtrim(\str_replace('window.NrPasskeysBeConfig = ', '', $code), ';');
+                    $decoded = \json_decode($jsonPart, true);
+                    self::assertIsArray($decoded);
+                    // Login screen is pre-auth, so UI strings are injected as labels
+                    // (with English fallbacks) rather than via TYPO3.lang (I18N-1/L10N-1).
+                    self::assertArrayHasKey('labels', $decoded);
+                    self::assertIsArray($decoded['labels']);
+                    foreach (['signIn', 'errorUnsupported', 'errorRateLimit', 'errorNotAllowed', 'helpTitle'] as $key) {
+                        self::assertArrayHasKey($key, $decoded['labels']);
+                        self::assertNotSame('', $decoded['labels'][$key]);
+                    }
+
+                    return true;
+                }),
+            );
+
+        ($this->subject)($this->createEvent());
+    }
+
+    #[Test]
     public function invokeUsesEffectiveRpIdFromConfigService(): void
     {
         $this->setUpConfigService(rpId: 'fallback.example.com');

--- a/Tests/Unit/Middleware/PasskeySetupInterstitialTest.php
+++ b/Tests/Unit/Middleware/PasskeySetupInterstitialTest.php
@@ -20,10 +20,12 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Http\Response;
+use TYPO3\CMS\Core\Http\Uri;
 use TYPO3\CMS\Core\Localization\LanguageService;
 use TYPO3\CMS\Core\Localization\Locale;
 
@@ -38,8 +40,11 @@ final class PasskeySetupInterstitialTest extends TestCase
         parent::setUp();
 
         $this->enforcementService = $this->createMock(EnforcementService::class);
+        $uriBuilder = $this->createMock(UriBuilder::class);
+        $uriBuilder->method('buildUriFromRoute')->willReturn(new Uri('/typo3/module/user/setup'));
         $this->subject = new PasskeySetupInterstitial(
             $this->enforcementService,
+            $uriBuilder,
             $this->createMock(LoggerInterface::class),
         );
     }
@@ -140,7 +145,7 @@ final class PasskeySetupInterstitialTest extends TestCase
     }
 
     #[Test]
-    public function passesThroughForExemptSetupRoute(): void
+    public function passesThroughForExemptUserSetupRoute(): void
     {
         $this->setUpBackendUser(1);
 
@@ -152,7 +157,7 @@ final class PasskeySetupInterstitialTest extends TestCase
         );
         $this->enforcementService->method('getStatus')->willReturn($status);
 
-        $request = $this->createMockRequest('setup');
+        $request = $this->createMockRequest('user_setup');
         $handler = $this->createMockHandler();
 
         $handler->expects(self::once())->method('handle')->with($request);
@@ -309,7 +314,7 @@ final class PasskeySetupInterstitialTest extends TestCase
         $response = $this->subject->process($request, $handler);
 
         $body = (string) $response->getBody();
-        self::assertStringContainsString('/typo3/setup/', $body);
+        self::assertStringContainsString('/typo3/module/user/setup', $body);
         self::assertStringContainsString('Set up now', $body);
     }
 
@@ -814,8 +819,10 @@ final class PasskeySetupInterstitialTest extends TestCase
 
         $response = $this->subject->process($request, $handler);
 
+        // The skip-form action uses the normalized backend path; the "Set up now"
+        // link is built from UriBuilder (user_setup route) and is asserted separately.
         $body = (string) $response->getBody();
-        self::assertStringContainsString('/subdir/typo3/setup/', $body);
+        self::assertStringContainsString('action="/subdir/typo3/"', $body);
     }
 
     #[Test]

--- a/Tests/Unit/Middleware/PasskeySetupInterstitialTest.php
+++ b/Tests/Unit/Middleware/PasskeySetupInterstitialTest.php
@@ -468,6 +468,55 @@ final class PasskeySetupInterstitialTest extends TestCase
     }
 
     #[Test]
+    public function reusesCachedOkDecisionWithoutQueryingEnforcement(): void
+    {
+        // PERF-1: a fresh "no interstitial needed" decision in the session must skip
+        // the enforcement query entirely on subsequent requests.
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1, 'usergroup' => '1'];
+        $backendUser->method('getSessionData')
+            ->with('tx_nrpasskeysbe')
+            ->willReturn(['enforcement_ok_at' => \time()]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $this->enforcementService->expects(self::never())->method('getStatus');
+
+        $request = $this->createMockRequest('main');
+        $handler = $this->createMockHandler();
+        $handler->expects(self::once())->method('handle')->with($request);
+
+        $this->subject->process($request, $handler);
+    }
+
+    #[Test]
+    public function requeriesEnforcementWhenCachedDecisionIsStale(): void
+    {
+        // An expired cache (> TTL) must re-run the enforcement query.
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
+        $backendUser->user = ['uid' => 1, 'usergroup' => '1'];
+        $backendUser->method('getSessionData')
+            ->with('tx_nrpasskeysbe')
+            ->willReturn(['enforcement_ok_at' => \time() - 3600]);
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        $this->enforcementService
+            ->expects(self::once())
+            ->method('getStatus')
+            ->willReturn(new EnforcementStatus(
+                level: EnforcementLevel::Off,
+                gracePeriodDays: 0,
+                gracePeriodStart: 0,
+                hasPasskeys: true,
+            ));
+
+        $request = $this->createMockRequest('main');
+        $handler = $this->createMockHandler();
+        $handler->expects(self::once())->method('handle')->with($request);
+
+        $this->subject->process($request, $handler);
+    }
+
+    #[Test]
     public function doesNotPassThroughWhenSessionSkipFlagSetButCannotSkip(): void
     {
         $backendUser = $this->createMock(BackendUserAuthentication::class);

--- a/Tests/Unit/Service/RateLimiterServiceTest.php
+++ b/Tests/Unit/Service/RateLimiterServiceTest.php
@@ -303,6 +303,28 @@ final class RateLimiterServiceTest extends TestCase
     }
 
     #[Test]
+    public function recordFailureWithoutUserLockoutOnlyIncrementsPerIpCounter(): void
+    {
+        // Passkey assertion failures pass countUserLockout=false so an attacker
+        // cannot trip the cross-IP per-username lockout (account-lockout DoS).
+        $this->rateLimitCacheMock
+            ->method('get')
+            ->willReturn(false);
+
+        $this->rateLimitCacheMock
+            ->expects(self::once())
+            ->method('set')
+            ->with(
+                self::isType('string'),
+                '1',
+                self::isType('array'),
+                900,
+            );
+
+        $this->subject->recordFailure('admin', '192.168.1.1', false);
+    }
+
+    #[Test]
     public function recordFailureIncrementsExistingFailures(): void
     {
         // Previous failures: 2

--- a/Tests/Unit/Service/WebAuthnServiceTest.php
+++ b/Tests/Unit/Service/WebAuthnServiceTest.php
@@ -873,22 +873,43 @@ final class WebAuthnServiceTest extends TestCase
     #[Test]
     public function verifyAssertionResponseThrowsForRevokedCredential(): void
     {
-        $config = new ExtensionConfiguration(rpId: 'example.com');
-        $this->configServiceMock->method('getConfiguration')->willReturn($config);
-        $this->configServiceMock->method('getEffectiveRpId')->willReturn('example.com');
-
+        // Build a real, deserializable assertion so we reach the revocation check
+        // (which runs after credential lookup and before signature validation).
+        $rpId = 'example.com';
+        $origin = 'https://example.com';
         $challenge = \random_bytes(32);
+        $challengeToken = 'token';
+
+        [$assertionJson, $credentialId] = $this->buildAssertionJson($rpId, $challenge, $origin);
+
+        $config = new ExtensionConfiguration(rpId: $rpId, allowedAlgorithms: 'ES256');
+        $this->configServiceMock->method('getConfiguration')->willReturn($config);
+        $this->configServiceMock->method('getEffectiveRpId')->willReturn($rpId);
+        $this->configServiceMock->method('getEffectiveOrigin')->willReturn($origin);
         $this->challengeServiceMock
             ->method('verifyChallengeToken')
+            ->with($challengeToken)
             ->willReturn($challenge);
 
-        // We cannot easily test the full deserialization flow because webauthn-lib classes are final.
-        // Instead, we test through the code path that checks credential revocation.
-        // The credential lookup happens after deserialization, so we need a different approach.
-        // We'll test this through the exception code.
-        $this->expectException(Throwable::class);
+        $revokedCredential = new Credential(
+            uid: 10,
+            beUser: 100,
+            credentialId: $credentialId,
+            publicKeyCose: 'cose-data',
+            transports: '[]',
+            label: 'Revoked Key',
+            revokedAt: 1700000000,
+        );
+        $this->credentialRepositoryMock
+            ->method('findByCredentialId')
+            ->with($credentialId)
+            ->willReturn($revokedCredential);
 
-        $this->subject->verifyAssertionResponse('{"invalid":"structure"}', 'token', 100);
+        // The revocation guard must fire with its dedicated code (1700000033).
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionCode(1700000033);
+
+        $this->subject->verifyAssertionResponse($assertionJson, $challengeToken, 100);
     }
 
     #[Test]

--- a/composer.json
+++ b/composer.json
@@ -80,8 +80,17 @@
         "ci:cgl": "php-cs-fixer fix --config Build/.php-cs-fixer.php",
         "ci:mutation": "infection --configuration=Build/infection.json5",
         "ci:test:php:all": [
+            "@ci:test:php:cgl",
+            "@ci:test:php:phpstan",
             "@ci:test:php:unit",
+            "@ci:test:php:fuzz",
             "@ci:test:php:functional"
+        ],
+        "ci:check": [
+            "@ci:test:php:cgl",
+            "@ci:test:php:phpstan",
+            "@ci:test:php:unit",
+            "@ci:test:php:fuzz"
         ],
         "ci:test:php:cgl": "php-cs-fixer fix --config Build/.php-cs-fixer.php --dry-run --diff",
         "ci:test:php:functional": "phpunit -c Build/phpunit.functional.xml",

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
     },
     "scripts": {
         "ci:cgl": "php-cs-fixer fix --config Build/.php-cs-fixer.php",
-        "ci:mutation": "infection --configuration=Build/infection.json5",
+        "ci:mutation": "infection --configuration=Build/infection.json5 --threads=max",
         "ci:test:php:all": [
             "@ci:test:php:cgl",
             "@ci:test:php:phpstan",

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -11,7 +11,7 @@ use Netresearch\NrPasskeysBe\UserSettings\PasskeySettingsPanel;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
-defined('TYPO3') or die();
+\defined('TYPO3') or die();
 
 // Register passkey management panel in User Settings (Setup module).
 // Must be in ext_tables.php because cms-setup/ext_tables.php initializes
@@ -25,25 +25,35 @@ defined('TYPO3') or die();
 $label = 'LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang.xlf:manage.title';
 
 if ((new Typo3Version())->getMajorVersion() >= 14) {
-    $GLOBALS['TCA']['be_users']['columns']['user_settings']['columns']['passkeys'] = [
-        'label' => $label,
-        'config' => [
-            'type' => 'user',
-            'renderType' => 'nrPasskeySettingsPanel',
+    // TYPO3 v14+: register via the TCA-based addUserSetting() API, which sets both
+    // the fake TCA column (with the required 'config' key) and the showitem entry.
+    // This replaces the manual $GLOBALS['TCA'] write + the deprecated
+    // addFieldsToUserSettings() call (deprecated since v14, removed in v15).
+    ExtensionManagementUtility::addUserSetting(
+        'passkeys',
+        [
+            'label' => $label,
+            'config' => [
+                'type' => 'user',
+                'renderType' => 'nrPasskeySettingsPanel',
+            ],
         ],
-    ];
+        'after:mfaProviders',
+    );
 } else {
+    // TYPO3 v12/v13: the legacy $GLOBALS['TYPO3_USER_SETTINGS'] format plus the
+    // addFieldsToUserSettings() helper (not deprecated on these versions).
     $GLOBALS['TYPO3_USER_SETTINGS']['columns']['passkeys'] = [
         'type' => 'user',
         'userFunc' => PasskeySettingsPanel::class . '->render',
         'label' => $label,
     ];
-}
 
-ExtensionManagementUtility::addFieldsToUserSettings(
-    'passkeys',
-    'after:mfaProviders',
-);
+    ExtensionManagementUtility::addFieldsToUserSettings(
+        'passkeys',
+        'after:mfaProviders',
+    );
+}
 
 // Register CSH (Context-Sensitive Help) for the passkeys field in be_users records.
 // addLLrefForTCAdescr() was removed in TYPO3 v13 — only call it on v12.


### PR DESCRIPTION
## Description

Acts on the findings of a comprehensive multi-scope review (19 independent
reviewers + adversarial verification, plus empirical build/test/lint/mutation runs
on PHP 8.5.7 / TYPO3 14.3.3).

This PR resolves **all critical and high-severity findings and the majority of the
medium ones** — security, the TYPO3 v14 deprecations, the critical onboarding
lockout, the interactive i18n/a11y surfaces, performance, architecture, an
out-of-band recovery CLI, and documentation. The branch is green at every commit.
Larger, lower-risk or infrastructure-dependent items are listed under *Remaining*.

## Type of Change
- [x] Bug fix · [x] Documentation update · [x] Test update · [x] New feature (recovery CLI) · [ ] Breaking change

## Changes Made (19 commits)

**Critical**
- `fix(onboarding)` `845a285` — interstitial dead-end (dead `/typo3/setup/` link +
  wrong route exemption) that locked Enforced / Required-after-grace users out of
  both registering and working. **ONB-1, ONB-2**

**Security** (Ask-First zone — explicitly approved)
- `fix(security)` `ca2180a` — username-enumeration oracle → indistinguishable decoy
  options; unauthenticated account-lockout DoS removed; enforcement check fails open.
  **SEC-1, SEC-2, OPS-2**
- `fix(ux)` `f6a0cd3` — login distinguishes account lockout from rate limiting. **UX-3**
- `feat(cli)` `df21c5b` — `passkeys:recovery` command (list / disable-group /
  disable-all / unlock) for when admins are locked out. **OPS-1**

**TYPO3 v14.3 deprecations** ("zero deprecations")
- `fix(compat)` `353443a` — `ComponentFactory` for docheader; `addUserSetting()`;
  removed the masking PHPStan suppression. **API-1/2/3/4, HYG-1**

**i18n / a11y / UX**
- `fix(i18n,a11y)` `1fb7dbc` — localized login screen + reliable `aria-live` errors. **I18N-1, L10N-1, A11Y-1**
- `fix(ux,a11y)` `e947edc` — management server errors reach the user (incl. last-passkey 409); panel state announced. **UX-1, A11Y-2**
- `fix(i18n)` `e3f519f` — localized the management panel JS. **I18N-2, L10N-2**
- `fix(i18n)` `5297e53` — localized PasskeyAdminInfo notifications. **I18N-3**
- `fix(admin-ux)` `9b1852e` — confirmation before escalating to Required/Enforced. **ADMIN-1**
- `fix(a11y)` `19b7249` — interstitial focus indicator + skip-button contrast. **A11Y-4, A11Y-5**
- `fix(a11y)` `ac03314` — dashboard action-button status announced. **A11Y-3**

**Performance / architecture / tests / DX / docs**
- `perf(interstitial)` `f89816c` — cache the per-request enforcement decision. **PERF-1, ONB-3**
- `perf(test)` `70533b3` — multi-threaded mutation testing. **PERF-1 (test)**
- `test(arch)` `a2e4e6e` — finality rules for Authentication/Form. **ARCH-1**
- `test(webauthn)` `e5dc080` — revoked-credential test now exercises its branch. **TEST-2**
- `chore(dx)` `c197b3f` — single full-gate composer scripts. **DX-1**
- `docs` `2eb9bbb` — MFA-skip note, Required password blocking, trait paths. **DOCUX-2, DOC-1, DX-2**
- `docs` `ad21026` — Troubleshooting: lockout/429, RP-ID mismatch, unsupported browser, lost device. **DOC-2**

## Verified already-correct (no change)
- **ONB-4**: TCA already clamps grace days to `[1,365]`, Required-only.
- **HYG-2 / "stale committed lock"**: `composer.lock` is gitignored; fresh installs are clean.

## Testing
- [x] Unit — `composer ci:test:php:unit` → **577 tests** (new coverage: decoy response,
  per-IP-only failure recording, fail-open, login labels, lockout messaging, interstitial
  cache, revoked branch, recovery command)
- [x] PHPStan L10, CGL (PER-CS3.0), Fuzz (131), JS/Vitest (63) — all green
- [x] v14.3 runtime deprecations from extension code: 4 → 3 (the remaining
  `ext_tables.php`-load / `ext_emconf.php` are inherent to supporting v12/v13 in one
  codebase — for the v15 migration)

## Remaining findings (proposed follow-ups, with rationale)
Deliberately scoped out to keep this PR green and reviewable, and to avoid risky
change at the tail of a large effort:

- **Static-content i18n** — Help.html (~50 strings) and the Dashboard quick-start
  infoboxes (rich embedded HTML). Admin-only static guidance; high fragmentation cost,
  low impact (the interactive/error i18n users hit during auth is done). **I18N-5, I18N-6**
- **ARCH-2** — split the ~520-line `WebAuthnService`. A refactor of working,
  security-critical code; best done deliberately with full MySQL+SQLite verification.
- **TEST-1** — point the Vitest suite at the shipped ES modules (needs `@typo3/*`
  import mocking) instead of re-implementations.
- **TEST-3** — `credential_id varbinary` → SQLite BLOB-affinity breaks lookups on
  SQLite (works on MySQL/MariaDB, the supported/CI DB). The binary-binding fix must be
  verified on **both** MySQL and SQLite before touching credential lookup; not done
  blindly. AGENTS.md already states functional tests require MySQL.
- **DOCUX-1** — replace the 4 placeholder screenshots (needs a live TYPO3 backend capture).
- **ADMIN-2/3/4** — unlock confirmation, sudo-mode consistency, user-list pagination.
- **L10N-3** — CSH help is v12-only (the v13/v14 API was removed); current behaviour is
  correct graceful degradation.
- **PERF-2/3** — functional per-class schema rebuild and CI matrix exclusions depend on
  the shared `typo3-ci-workflows` reusable workflow, not this repo.

## Checklist
- [x] PER-CS3.0 · [x] tests added · [x] docs updated · [x] conventional, signed + signed-off commits · [x] based on latest `main`
