### PR TITLE
ci: adopt canonical typo3-extension template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,41 +1,49 @@
-# .github/dependabot.yml
-# Automated dependency updates
-# Documentation: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates
-
+# Managed by netresearch/.github/templates/typo3-extension/
+#
+# Declares only the ecosystems every typo3-extension consumer is guaranteed to
+# have: composer (the extension's composer.json) and github-actions.
+#
+# npm is OPT-IN: an extension that actually ships a package.json (frontend
+# assets) adds the block below to its own dependabot.yml and lists
+# `.github/dependabot.yml` under `intentional-drift:` in .github/template.yaml
+# so the template sync stops managing the file. Declaring an ecosystem without
+# its manifest makes the Dependabot run fail with `dependency_file_not_found`.
+#
+# Opt-in npm:
+#   - package-ecosystem: npm
+#     directory: /
+#     schedule:
+#       interval: weekly
+#       day: monday
+#     open-pull-requests-limit: 5
+#     groups:
+#       npm:
+#         patterns: ['*']
+#     cooldown:
+#       default-days: 7
 version: 2
 updates:
-  # Composer dependencies
-  - package-ecosystem: "composer"
-    directory: "/"
+  - package-ecosystem: composer
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "Europe/Berlin"
-    groups:
-      dependencies:
-        patterns:
-          - "*"
-    commit-message:
-      prefix: "deps"
-    labels:
-      - "dependencies"
+      interval: weekly
+      day: monday
     open-pull-requests-limit: 10
+    versioning-strategy: increase-if-necessary
+    groups:
+      composer:
+        patterns: ['*']
+    cooldown:
+      default-days: 7
 
-  # GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "Europe/Berlin"
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
     groups:
       github-actions:
-        patterns:
-          - "*"
-    commit-message:
-      prefix: "ci"
-    labels:
-      - "dependencies"
-      - "github-actions"
+        patterns: ['*']
+    cooldown:
+      default-days: 7

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,17 @@
+# Label configuration for PR Labeler
+# https://github.com/actions/labeler
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: ['Documentation/**/*', '**/*.md']
+tests:
+  - changed-files:
+      - any-glob-to-any-file: ['Tests/**/*', 'Build/phpunit/**/*']
+ci:
+  - changed-files:
+      - any-glob-to-any-file: ['.github/**/*', 'Build/**/*']
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file: ['composer.json', 'composer.lock', 'package.json', 'package-lock.json', 'yarn.lock']
+configuration:
+  - changed-files:
+      - any-glob-to-any-file: ['Configuration/**/*', 'ext_*.php', 'composer.json']

--- a/.github/template.yaml
+++ b/.github/template.yaml
@@ -1,0 +1,15 @@
+# Managed by netresearch/.github/templates/typo3-extension/
+# Drift from the template is blocking CI in this repo (check-template-drift.yml).
+# Record explicit exceptions under intentional-drift[] to unblock.
+#
+# Split-file model: the security/quality jobs (elevated permissions) live in the
+# byte-identical, drift-enforced checks.yml. The two files below are
+# per-extension and are NOT byte-governed:
+#   - .github/workflows/ci.yml      — the test matrix `with:` block (php/typo3
+#     versions, matrix-exclude, functional-tests, db, remove-dev-deps, coverage)
+#   - .github/workflows/release.yml — archive-prefix / package-name / extension-key
+# Customize those two in-repo; everything else stays in sync with the template.
+template: typo3-extension
+intentional-drift:
+  - .github/workflows/ci.yml
+  - .github/workflows/release.yml

--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -1,8 +1,13 @@
 name: Auto-merge dependency PRs
+
 on:
-  pull_request_target:
-    types: [opened, synchronize, reopened]
+  # auto-merge only calls `gh pr merge` via the reusable with the base-repo
+  # token; it never checks out or runs PR head code, so pull_request_target
+  # (required for a write token on Dependabot/Renovate fork PRs) is safe here.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+
 permissions: {}
+
 jobs:
   auto-merge:
     uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main

--- a/.github/workflows/check-template-drift.yml
+++ b/.github/workflows/check-template-drift.yml
@@ -1,0 +1,18 @@
+name: Template Drift
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  merge_group:
+
+permissions: {}
+
+jobs:
+  drift:
+    uses: netresearch/.github/.github/workflows/check-template-drift.yml@main
+    with:
+      template: typo3-extension
+    permissions:
+      contents: read

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,70 @@
+name: Checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions: {}
+
+# Security + quality jobs with their explicit per-call-site permissions. This
+# file is byte-identical and drift-enforced across every typo3-extension — the
+# extension-specific test matrix lives in ci.yml (intentional-drift). Every
+# `uses:` job grants exactly the reusable's caller contract; no reliance on
+# default_workflow_permissions.
+jobs:
+  security:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
+    permissions:
+      contents: read
+      security-events: write
+
+  fuzz:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
+    permissions:
+      contents: read
+
+  license-check:
+    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
+    permissions:
+      contents: read
+
+  codeql:
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+  scorecard:
+    if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
+    permissions:
+      contents: read
+      security-events: write
+      id-token: write
+      actions: read
+
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+
+  pr-quality:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+
+  labeler:
+    if: github.event_name == 'pull_request'
+    uses: netresearch/.github/.github/workflows/labeler.yml@main
+    permissions:
+      contents: read
+      pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,35 +1,31 @@
 name: CI
+
 on:
   push:
     branches: [main]
   pull_request:
   merge_group:
-permissions: {}
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+# Per-extension test matrix (intentional-drift). Security/quality jobs are in checks.yml.
 jobs:
   ci:
     uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
     permissions:
       contents: read
-      actions: read
     with:
       php-versions: '["8.2", "8.3", "8.4", "8.5"]'
       typo3-versions: '["^12.4", "^13.4", "^14.3"]'
       typo3-packages: '["typo3/cms-core", "typo3/cms-backend", "typo3/cms-setup"]'
-      php-extensions: intl, mbstring, xml, openssl, pdo_mysql
+      php-extensions: 'intl, mbstring, xml, openssl, pdo_mysql'
       run-rector: false
       run-functional-tests: true
-      functional-test-db: mysql
+      functional-test-db: 'mysql'
       upload-coverage: false
-      # typo3-ci-workflows requires phpstan-typo3 ^2||^3 which needs TYPO3 ^13.4+
-      # Remove it for v12 builds; individual deps in composer.json cover v12
       remove-dev-deps: '[{"dep":"netresearch/typo3-ci-workflows","only-for":"^13.4|^14.3"}]'
-  e2e:
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    uses: netresearch/typo3-ci-workflows/.github/workflows/e2e.yml@main
-    permissions:
-      contents: read
-      actions: read
-    with:
-      php-version: '8.4'
-      test-command: 'npm run test:e2e'
-      artifact-path: 'Tests/E2E/'
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -1,0 +1,37 @@
+name: Community
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  issues:
+    types: [opened]
+  # greetings only posts a first-time contributor comment via the reusable; it
+  # never checks out or runs PR head code. pull_request_target is required to
+  # comment on fork PRs.
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
+    types: [opened]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  stale:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: netresearch/.github/.github/workflows/stale.yml@main
+    permissions:
+      issues: write
+      pull-requests: write
+
+  lock:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: netresearch/.github/.github/workflows/lock.yml@main
+    permissions:
+      issues: write
+      pull-requests: write
+
+  greetings:
+    if: github.event_name == 'issues' || github.event_name == 'pull_request_target'
+    uses: netresearch/.github/.github/workflows/greetings.yml@main
+    permissions:
+      issues: write
+      pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ jobs:
       id-token: write
       attestations: write
     with:
-      archive-prefix: nr-passkeys-be
-      package-name: netresearch/nr-passkeys-be
-      extension-key: nr_passkeys_be
+      archive-prefix: 'nr-passkeys-be'
+      package-name: 'netresearch/nr-passkeys-be'
+      extension-key: 'nr_passkeys_be'
     secrets:
       TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,2 @@
+# python.django.security.django-no-csrf-token false-positive: Fluid template misdetected as Django (--config auto). Not Django; TYPO3 Fluid.
+Resources/Private/Templates/Interstitial/Setup.html


### PR DESCRIPTION
Migrate CI to the canonical `typo3-extension` template (netresearch/.github): explicit per-call-site permissions on every reusable, drift-enforced. Security/quality jobs (checks.yml) are byte-governed; the test matrix (ci.yml) and release.yml are per-repo (intentional-drift, preserved from this repo).