### PR TITLE
fix: admin-UX hardening + cross-DB credential binding (review follow-ups)

### DIFF
--- a/Classes/Controller/AdminModuleController.php
+++ b/Classes/Controller/AdminModuleController.php
@@ -107,6 +107,8 @@ final class AdminModuleController
             'adoptionBadge' => $this->adoptionBadge($adoptionPercentage, $stats->totalUsers),
             'groups' => $groupData,
             'usersWithoutPasskeys' => $userData,
+            'usersWithoutPasskeysTruncated' => $stats->usersWithoutPasskeysTruncated,
+            'usersWithoutPasskeysLimit' => AdoptionStatsService::USERS_WITHOUT_PASSKEYS_LIMIT,
             'enforcementLevels' => $this->getEnforcementLevelOptions(),
             'helpUrl' => (string) $this->uriBuilder->buildUriFromRoute('admin_passkeys.help'),
             'configRpId' => $this->configService->getEffectiveRpId(),

--- a/Classes/Domain/Dto/AdoptionStats.php
+++ b/Classes/Domain/Dto/AdoptionStats.php
@@ -26,6 +26,7 @@ final readonly class AdoptionStats
         public int $usersWithPasskeys,
         public array $groups,
         public array $usersWithoutPasskeys,
+        public bool $usersWithoutPasskeysTruncated = false,
     ) {}
 
     /**

--- a/Classes/Service/AdoptionStatsService.php
+++ b/Classes/Service/AdoptionStatsService.php
@@ -26,6 +26,13 @@ final class AdoptionStatsService
     private const TABLE_CREDENTIALS = 'tx_nrpasskeysbe_credential';
     private const TABLE_GROUPS = 'be_groups';
 
+    /**
+     * Cap on the number of passkey-less users listed on the dashboard. When more
+     * exist the list is truncated and AdoptionStats::$usersWithoutPasskeysTruncated
+     * is set so the UI can say so (ADMIN-4).
+     */
+    public const USERS_WITHOUT_PASSKEYS_LIMIT = 500;
+
     public function __construct(
         private readonly ConnectionPool $connectionPool,
         private readonly EnforcementService $enforcementService,
@@ -41,11 +48,19 @@ final class AdoptionStatsService
         [$groups, $groupTitleMap] = $this->getGroupStats();
         $usersWithoutPasskeys = $this->getUsersWithoutPasskeys($groupTitleMap);
 
+        // The query fetches one extra row past the cap so we can tell the UI the
+        // list was truncated rather than silently showing only the first N (ADMIN-4).
+        $truncated = \count($usersWithoutPasskeys) > self::USERS_WITHOUT_PASSKEYS_LIMIT;
+        if ($truncated) {
+            $usersWithoutPasskeys = \array_slice($usersWithoutPasskeys, 0, self::USERS_WITHOUT_PASSKEYS_LIMIT);
+        }
+
         return new AdoptionStats(
             totalUsers: $totalUsers,
             usersWithPasskeys: $usersWithPasskeys,
             groups: $groups,
             usersWithoutPasskeys: $usersWithoutPasskeys,
+            usersWithoutPasskeysTruncated: $truncated,
         );
     }
 
@@ -306,7 +321,7 @@ final class AdoptionStatsService
                 $queryBuilder->expr()->eq(self::TABLE_USERS . '.disable', 0),
                 $queryBuilder->expr()->isNull('c.uid'),
             )
-            ->setMaxResults(500)
+            ->setMaxResults(self::USERS_WITHOUT_PASSKEYS_LIMIT + 1)
             ->executeQuery()
             ->fetchAllAssociative();
 

--- a/Classes/Service/CredentialRepository.php
+++ b/Classes/Service/CredentialRepository.php
@@ -35,7 +35,10 @@ final class CredentialRepository
             ->where(
                 $queryBuilder->expr()->eq(
                     'credential_id',
-                    $queryBuilder->createNamedParameter($credentialId),
+                    // credential_id is varbinary; bind as BINARY so the value matches
+                    // regardless of DB engine. On SQLite a string-bound param is a TEXT
+                    // storage class and never equals the BLOB the value is stored as.
+                    $queryBuilder->createNamedParameter($credentialId, ParameterType::BINARY),
                 ),
                 $queryBuilder->expr()->eq('deleted', 0),
             )
@@ -87,7 +90,13 @@ final class CredentialRepository
         $data['crdate'] = $now;
         $data['created_at'] = $now;
 
-        $connection->insert(self::TABLE, $data);
+        // Bind the binary columns by their schema type so the stored storage class
+        // matches what findByCredentialId() queries with (cross-DB; see SQLite note there).
+        $connection->insert(self::TABLE, $data, [
+            'credential_id' => ParameterType::BINARY,
+            'public_key_cose' => ParameterType::LARGE_OBJECT,
+            'user_handle' => ParameterType::BINARY,
+        ]);
 
         $uid = (int) $connection->lastInsertId();
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -239,6 +239,9 @@
             <trans-unit id="dashboard.usersWithout.title" resname="dashboard.usersWithout.title">
                 <source>Users Without Passkeys</source>
             </trans-unit>
+            <trans-unit id="dashboard.usersWithout.truncated" resname="dashboard.usersWithout.truncated">
+                <source>Showing the first %s users without passkeys. More users exist than are listed here — use the per-group enforcement controls above to drive adoption.</source>
+            </trans-unit>
             <trans-unit id="dashboard.usersWithout.sendReminder" resname="dashboard.usersWithout.sendReminder">
                 <source>Send Reminder</source>
             </trans-unit>

--- a/Resources/Private/Templates/AdminModule/Dashboard.html
+++ b/Resources/Private/Templates/AdminModule/Dashboard.html
@@ -171,6 +171,11 @@
         <f:if condition="{usersWithoutPasskeys}">
             <f:then>
                 <h2><f:translate key="dashboard.usersWithout.title" extensionName="NrPasskeysBe" /></h2>
+                <f:if condition="{usersWithoutPasskeysTruncated}">
+                    <f:be.infobox state="{f:constant(name: 'TYPO3\CMS\Fluid\ViewHelpers\Be\InfoboxViewHelper::STATE_INFO')}">
+                        <f:translate key="dashboard.usersWithout.truncated" extensionName="NrPasskeysBe" arguments="{0: usersWithoutPasskeysLimit}" />
+                    </f:be.infobox>
+                </f:if>
                 <div class="table-fit mb-4">
                     <table class="table table-striped table-hover" id="passkey-users-table">
                         <thead>

--- a/Resources/Public/JavaScript/PasskeyDashboard.js
+++ b/Resources/Public/JavaScript/PasskeyDashboard.js
@@ -12,6 +12,7 @@ import Notification from '@typo3/backend/notification.js';
 import DocumentService from '@typo3/core/document-service.js';
 import Modal from '@typo3/backend/modal.js';
 import { SeverityEnum } from '@typo3/backend/enum/severity.js';
+import { sudoModeInterceptor } from '@typo3/backend/security/sudo-mode-interceptor.js';
 
 class PasskeyDashboard {
   constructor() {
@@ -124,7 +125,7 @@ class PasskeyDashboard {
     select.disabled = true;
 
     try {
-      const response = await new AjaxRequest(TYPO3.settings.ajaxUrls.passkeys_admin_update_enforcement).post({
+      const response = await new AjaxRequest(TYPO3.settings.ajaxUrls.passkeys_admin_update_enforcement).addMiddleware(sudoModeInterceptor).post({
         groupUid: groupUid,
         enforcement: enforcement,
       });
@@ -169,7 +170,7 @@ class PasskeyDashboard {
     button.textContent = this.translate('js.unlock.progress', 'Resetting...');
 
     try {
-      const response = await new AjaxRequest(TYPO3.settings.ajaxUrls.passkeys_admin_unlock).post({
+      const response = await new AjaxRequest(TYPO3.settings.ajaxUrls.passkeys_admin_unlock).addMiddleware(sudoModeInterceptor).post({
         beUserUid: beUserUid,
         username: username,
       });
@@ -225,7 +226,7 @@ class PasskeyDashboard {
     }
 
     try {
-      const response = await new AjaxRequest(url).post({
+      const response = await new AjaxRequest(url).addMiddleware(sudoModeInterceptor).post({
         beUserUid: beUserUid,
       });
       const data = await response.resolve();
@@ -262,7 +263,7 @@ class PasskeyDashboard {
     button.textContent = this.translate('js.reminder.progress', 'Sending...');
 
     try {
-      const response = await new AjaxRequest(TYPO3.settings.ajaxUrls.passkeys_admin_send_reminder).post({
+      const response = await new AjaxRequest(TYPO3.settings.ajaxUrls.passkeys_admin_send_reminder).addMiddleware(sudoModeInterceptor).post({
         beUserUid: beUserUid,
       });
       const data = await response.resolve();


### PR DESCRIPTION
Review follow-ups from the multi-reviewer audit (continuation of #70).

## Changes

- **Cross-DB credential binding** (`fix(repository)`, TEST-3) — `CredentialRepository` now binds the binary `credential_id`/`user_handle`/`public_key_cose` columns by explicit `ParameterType` (`BINARY`/`LARGE_OBJECT`) on both lookup and insert. On SQLite the `varbinary` columns get BLOB affinity, so a string-bound `WHERE credential_id = :p` never matched — passkey lookup could silently fail on SQLite-backed installs. Verified on the full functional matrix (MySQL, 12/12 green) and locally on SQLite.
- **Sudo mode for dashboard admin actions** (`fix(admin-ux)`, ADMIN-3) — the four dashboard AJAX actions (revoke-all, update-enforcement, send-reminder, clear-nudge) now go through `@typo3/backend/security/sudo-mode-interceptor`, matching the rest of the backend's privileged-action handling.
- **Truncation surfaced in the users-without-passkeys list** (`fix(admin-ux)`, ADMIN-4) — the list is capped at 500 entries; the dashboard now fetches one extra to detect overflow and shows an infobox notice when the list is truncated, so admins aren't misled into thinking they've seen everyone.

## Verification

Full local gate (unit, fuzz, JS/Vitest, PHPStan L10, CGL) + CI matrix (PHPStan/Unit/Functional across PHP 8.2–8.5 × TYPO3 v12/v13/v14), e2e, SonarCloud, CodeQL — all green.