### PR TITLE
refactor(service): split WebAuthnService into attestation + assertion ceremonies (ARCH-2)

### DIFF
--- a/Classes/Service/AssertionService.php
+++ b/Classes/Service/AssertionService.php
@@ -1,0 +1,295 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Service;
+
+use Netresearch\NrPasskeysBe\Domain\Dto\AssertionOptions;
+use Netresearch\NrPasskeysBe\Domain\Dto\VerifiedAssertion;
+use Netresearch\NrPasskeysBe\Domain\Model\Credential;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Symfony\Component\Uid\Uuid;
+use Throwable;
+use Webauthn\AuthenticatorAssertionResponse;
+use Webauthn\AuthenticatorAssertionResponseValidator;
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\TrustPath\EmptyTrustPath;
+
+/**
+ * WebAuthn assertion (authentication) ceremony: building request options for the
+ * username-first, discoverable, and decoy login variants, resolving the backend
+ * user from a discoverable assertion, and verifying the browser's assertion response.
+ */
+final class AssertionService
+{
+    public function __construct(
+        private readonly ExtensionConfigurationService $configService,
+        private readonly ChallengeService $challengeService,
+        private readonly CredentialRepository $credentialRepository,
+        private readonly LoggerInterface $logger,
+        private readonly WebAuthnCeremonyFactory $ceremonyFactory,
+    ) {}
+
+    /**
+     * Create assertion options for login (Variant A: username-first).
+     */
+    public function createAssertionOptions(string $username, int $beUserUid): AssertionOptions
+    {
+        $rpId = $this->configService->getEffectiveRpId();
+        $challenge = $this->challengeService->generateChallenge();
+        $challengeToken = $this->challengeService->createChallengeToken($challenge);
+
+        $credentials = $this->credentialRepository->findByBeUser($beUserUid);
+        $allowCredentials = \array_map(
+            static fn(Credential $cred): PublicKeyCredentialDescriptor => PublicKeyCredentialDescriptor::create(
+                type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+                id: $cred->getCredentialId(),
+                transports: $cred->getTransportsArray(),
+            ),
+            $credentials,
+        );
+
+        $options = PublicKeyCredentialRequestOptions::create(
+            challenge: $challenge,
+            rpId: $rpId,
+            allowCredentials: $allowCredentials,
+            userVerification: $this->configService->getConfiguration()->getUserVerification(),
+            timeout: 60000,
+        );
+
+        return new AssertionOptions(
+            options: $options,
+            challengeToken: $challengeToken,
+        );
+    }
+
+    /**
+     * Create assertion options for discoverable login (Variant B: identifierless).
+     */
+    public function createDiscoverableAssertionOptions(): AssertionOptions
+    {
+        $rpId = $this->configService->getEffectiveRpId();
+        $challenge = $this->challengeService->generateChallenge();
+        $challengeToken = $this->challengeService->createChallengeToken($challenge);
+
+        $options = PublicKeyCredentialRequestOptions::create(
+            challenge: $challenge,
+            rpId: $rpId,
+            allowCredentials: [],
+            userVerification: $this->configService->getConfiguration()->getUserVerification(),
+            timeout: 60000,
+        );
+
+        return new AssertionOptions(
+            options: $options,
+            challengeToken: $challengeToken,
+        );
+    }
+
+    /**
+     * Create *decoy* assertion options for an unknown username.
+     *
+     * Returns options structurally identical to a real user's so the public
+     * login-options endpoint cannot be used to enumerate valid backend usernames.
+     * The decoy allowCredentials are derived deterministically from the username
+     * (HMAC over an HKDF-derived key from the extension encryption key), so repeated
+     * requests for the same unknown username yield stable, unguessable credential
+     * descriptors. A subsequent assertion against a decoy fails verification exactly
+     * as a wrong passkey would, keeping known and unknown users indistinguishable.
+     */
+    public function createDecoyAssertionOptions(string $username): AssertionOptions
+    {
+        $rpId = $this->configService->getEffectiveRpId();
+        $challenge = $this->challengeService->generateChallenge();
+        $challengeToken = $this->challengeService->createChallengeToken($challenge);
+
+        $key = $this->configService->getEncryptionKey();
+        $derivedKey = \hash_hkdf('sha256', $key, 32, 'nr_passkeys_be_decoy');
+        $decoyId = \hash_hmac('sha256', $username, $derivedKey, true);
+
+        $allowCredentials = [
+            PublicKeyCredentialDescriptor::create(
+                type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+                id: $decoyId,
+                transports: [],
+            ),
+        ];
+
+        $options = PublicKeyCredentialRequestOptions::create(
+            challenge: $challenge,
+            rpId: $rpId,
+            allowCredentials: $allowCredentials,
+            userVerification: $this->configService->getConfiguration()->getUserVerification(),
+            timeout: 60000,
+        );
+
+        return new AssertionOptions(
+            options: $options,
+            challengeToken: $challengeToken,
+        );
+    }
+
+    /**
+     * Resolve the backend user UID from a passkey assertion response.
+     *
+     * Used for discoverable (usernameless) login where the credential ID
+     * in the assertion identifies the user without requiring a username.
+     */
+    public function findBeUserUidFromAssertion(string $responseJson): ?int
+    {
+        try {
+            $publicKeyCredential = $this->ceremonyFactory->getSerializer()->deserialize(
+                $responseJson,
+                PublicKeyCredential::class,
+                'json',
+            );
+
+            if (!$publicKeyCredential instanceof PublicKeyCredential) {
+                return null;
+            }
+
+            $credential = $this->credentialRepository->findByCredentialId($publicKeyCredential->rawId);
+            if ($credential === null || $credential->isRevoked()) {
+                return null;
+            }
+
+            return $credential->getBeUser();
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Verify an assertion response for login.
+     *
+     * @throws RuntimeException on verification failure
+     */
+    public function verifyAssertionResponse(
+        string $responseJson,
+        string $challengeToken,
+        int $beUserUid,
+    ): VerifiedAssertion {
+        $challenge = $this->challengeService->verifyChallengeToken($challengeToken);
+        $rpId = $this->configService->getEffectiveRpId();
+
+        // Deserialize the browser response
+        $publicKeyCredential = $this->ceremonyFactory->getSerializer()->deserialize(
+            $responseJson,
+            PublicKeyCredential::class,
+            'json',
+        );
+
+        if (!$publicKeyCredential instanceof PublicKeyCredential) {
+            throw new RuntimeException('Failed to deserialize assertion response', 1700000030);
+        }
+
+        $response = $publicKeyCredential->response;
+        if (!$response instanceof AuthenticatorAssertionResponse) {
+            throw new RuntimeException('Expected assertion response', 1700000031);
+        }
+
+        // Find the credential by its ID
+        $credentialId = $publicKeyCredential->rawId;
+        $credential = $this->credentialRepository->findByCredentialId($credentialId);
+
+        if ($credential === null) {
+            $this->logger->warning('Assertion with unknown credential ID', [
+                'be_user_uid' => $beUserUid,
+            ]);
+            throw new RuntimeException('Unknown credential', 1700000032);
+        }
+
+        if ($credential->isRevoked()) {
+            throw new RuntimeException('Credential has been revoked', 1700000033);
+        }
+
+        if ($credential->getBeUser() !== $beUserUid) {
+            $this->logger->warning('Credential does not belong to the claimed user', [
+                'be_user_uid' => $beUserUid,
+                'credential_be_user' => $credential->getBeUser(),
+            ]);
+            throw new RuntimeException('Credential mismatch', 1700000034);
+        }
+
+        $storedSource = $this->credentialToSource($credential);
+
+        $requestOptions = PublicKeyCredentialRequestOptions::create(
+            challenge: $challenge,
+            rpId: $rpId,
+            userVerification: $this->configService->getConfiguration()->getUserVerification(),
+        );
+
+        $factory = $this->ceremonyFactory->createCeremonyFactory();
+        $ceremonyManager = $factory->requestCeremony();
+        $validator = AuthenticatorAssertionResponseValidator::create($ceremonyManager);
+
+        try {
+            $updatedSource = $validator->check(
+                credentialRecord: $storedSource,
+                authenticatorAssertionResponse: $response,
+                publicKeyCredentialRequestOptions: $requestOptions,
+                host: $rpId,
+                userHandle: $credential->getUserHandle() !== '' ? $credential->getUserHandle() : null,
+            );
+        } catch (Throwable $e) {
+            $this->logger->error('Passkey assertion verification failed', [
+                'be_user_uid' => $beUserUid,
+                'error' => $e->getMessage(),
+            ]);
+            throw new RuntimeException(
+                'Assertion verification failed: ' . $e->getMessage(),
+                1700000035,
+                $e,
+            );
+        }
+
+        $this->credentialRepository->updateSignCount($credential->getUid(), $updatedSource->counter);
+        $this->credentialRepository->updateLastUsed($credential->getUid());
+
+        $this->logger->info('Passkey login successful', [
+            'be_user_uid' => $beUserUid,
+            'credential_uid' => $credential->getUid(),
+        ]);
+
+        return new VerifiedAssertion(
+            credential: $credential,
+            source: $updatedSource,
+        );
+    }
+
+    /**
+     * Serialize PublicKeyCredentialRequestOptions to JSON for the browser.
+     */
+    public function serializeRequestOptions(PublicKeyCredentialRequestOptions $options): string
+    {
+        return $this->ceremonyFactory->getSerializer()->serialize($options, 'json');
+    }
+
+    private function credentialToSource(Credential $credential): CredentialRecord
+    {
+        $aaguid = $credential->getAaguid() !== ''
+            ? Uuid::fromString($credential->getAaguid())
+            : Uuid::v4();
+
+        return CredentialRecord::create(
+            publicKeyCredentialId: $credential->getCredentialId(),
+            type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+            transports: $credential->getTransportsArray(),
+            attestationType: 'none',
+            trustPath: new EmptyTrustPath(),
+            aaguid: $aaguid,
+            credentialPublicKey: $credential->getPublicKeyCose(),
+            userHandle: $credential->getUserHandle(),
+            counter: $credential->getSignCount(),
+        );
+    }
+}

--- a/Classes/Service/AttestationService.php
+++ b/Classes/Service/AttestationService.php
@@ -1,0 +1,245 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Service;
+
+use Netresearch\NrPasskeysBe\Domain\Dto\RegistrationOptions;
+use Netresearch\NrPasskeysBe\Domain\Model\Credential;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
+use Webauthn\AuthenticatorAttestationResponse;
+use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\AuthenticatorSelectionCriteria;
+use Webauthn\CredentialRecord;
+use Webauthn\PublicKeyCredential;
+use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialDescriptor;
+use Webauthn\PublicKeyCredentialParameters;
+use Webauthn\PublicKeyCredentialRpEntity;
+use Webauthn\PublicKeyCredentialUserEntity;
+
+/**
+ * WebAuthn attestation (registration) ceremony: building creation options,
+ * verifying the browser's attestation response, and persisting the credential.
+ */
+final class AttestationService
+{
+    private const ALGORITHM_MAP = [
+        'ES256' => -7,
+        'ES384' => -35,
+        'ES512' => -36,
+        'RS256' => -257,
+    ];
+
+    public function __construct(
+        private readonly ExtensionConfigurationService $configService,
+        private readonly ChallengeService $challengeService,
+        private readonly CredentialRepository $credentialRepository,
+        private readonly LoggerInterface $logger,
+        private readonly WebAuthnCeremonyFactory $ceremonyFactory,
+    ) {}
+
+    /**
+     * Create registration options for a backend user.
+     */
+    public function createRegistrationOptions(int $beUserUid, string $username, string $displayName): RegistrationOptions
+    {
+        $rpId = $this->configService->getEffectiveRpId();
+        $rpName = $this->configService->getConfiguration()->getRpName();
+
+        $rp = PublicKeyCredentialRpEntity::create(
+            name: $rpName,
+            id: $rpId,
+        );
+
+        $userHandle = $this->createUserHandle($beUserUid);
+
+        $user = PublicKeyCredentialUserEntity::create(
+            name: $username,
+            id: $userHandle,
+            displayName: $displayName,
+        );
+
+        $challenge = $this->challengeService->generateChallenge();
+        $challengeToken = $this->challengeService->createChallengeToken($challenge);
+
+        $existingCredentials = $this->credentialRepository->findByBeUser($beUserUid);
+        $excludeCredentials = \array_map(
+            static fn(Credential $cred): PublicKeyCredentialDescriptor => PublicKeyCredentialDescriptor::create(
+                type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
+                id: $cred->getCredentialId(),
+                transports: $cred->getTransportsArray(),
+            ),
+            $existingCredentials,
+        );
+
+        $authenticatorSelection = AuthenticatorSelectionCriteria::create(
+            userVerification: $this->configService->getConfiguration()->getUserVerification(),
+            residentKey: AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_PREFERRED,
+        );
+
+        $options = PublicKeyCredentialCreationOptions::create(
+            rp: $rp,
+            user: $user,
+            challenge: $challenge,
+            pubKeyCredParams: $this->getPublicKeyCredentialParameters(),
+            authenticatorSelection: $authenticatorSelection,
+            attestation: PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+            excludeCredentials: $excludeCredentials,
+            timeout: 60000,
+        );
+
+        return new RegistrationOptions(
+            options: $options,
+            challengeToken: $challengeToken,
+        );
+    }
+
+    /**
+     * Verify a registration response from the browser.
+     *
+     * The $responseJson is the JSON-serialized PublicKeyCredential from the browser,
+     * already base64url-encoded as per the WebAuthn spec.
+     *
+     * @throws RuntimeException on verification failure
+     */
+    public function verifyRegistrationResponse(
+        string $responseJson,
+        string $challengeToken,
+        int $beUserUid,
+        string $username,
+        string $displayName,
+    ): CredentialRecord {
+        $challenge = $this->challengeService->verifyChallengeToken($challengeToken);
+
+        $rpId = $this->configService->getEffectiveRpId();
+        $rpName = $this->configService->getConfiguration()->getRpName();
+        $userHandle = $this->createUserHandle($beUserUid);
+
+        $rp = PublicKeyCredentialRpEntity::create(name: $rpName, id: $rpId);
+        $user = PublicKeyCredentialUserEntity::create(
+            name: $username,
+            id: $userHandle,
+            displayName: $displayName,
+        );
+
+        $creationOptions = PublicKeyCredentialCreationOptions::create(
+            rp: $rp,
+            user: $user,
+            challenge: $challenge,
+            pubKeyCredParams: $this->getPublicKeyCredentialParameters(),
+            attestation: PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
+        );
+
+        // Deserialize the browser response
+        $publicKeyCredential = $this->ceremonyFactory->getSerializer()->deserialize(
+            $responseJson,
+            PublicKeyCredential::class,
+            'json',
+        );
+
+        if (!$publicKeyCredential instanceof PublicKeyCredential) {
+            throw new RuntimeException('Failed to deserialize credential response', 1700000020);
+        }
+
+        $response = $publicKeyCredential->response;
+        if (!$response instanceof AuthenticatorAttestationResponse) {
+            throw new RuntimeException('Expected attestation response', 1700000021);
+        }
+
+        $factory = $this->ceremonyFactory->createCeremonyFactory();
+        $ceremonyManager = $factory->creationCeremony();
+        $validator = AuthenticatorAttestationResponseValidator::create($ceremonyManager);
+
+        try {
+            $source = $validator->check(
+                authenticatorAttestationResponse: $response,
+                publicKeyCredentialCreationOptions: $creationOptions,
+                host: $rpId,
+            );
+        } catch (Throwable $e) {
+            $this->logger->error('Passkey registration verification failed', [
+                'be_user_uid' => $beUserUid,
+                'error' => $e->getMessage(),
+            ]);
+            throw new RuntimeException(
+                'Registration verification failed: ' . $e->getMessage(),
+                1700000022,
+                $e,
+            );
+        }
+
+        $this->logger->info('Passkey registered successfully', [
+            'be_user_uid' => $beUserUid,
+            'username' => $username,
+        ]);
+
+        return $source;
+    }
+
+    /**
+     * Store a verified registration result as a Credential.
+     */
+    public function storeCredential(
+        CredentialRecord $source,
+        int $beUserUid,
+        string $label,
+    ): Credential {
+        $credential = new Credential(
+            beUser: $beUserUid,
+            credentialId: $source->publicKeyCredentialId,
+            publicKeyCose: $source->credentialPublicKey,
+            signCount: $source->counter,
+            userHandle: $source->userHandle,
+            aaguid: $source->aaguid->toString(),
+            transports: \json_encode($source->transports, JSON_THROW_ON_ERROR),
+            label: $label,
+        );
+
+        $uid = $this->credentialRepository->save($credential);
+        $credential->setUid($uid);
+
+        return $credential;
+    }
+
+    /**
+     * Serialize PublicKeyCredentialCreationOptions to JSON for the browser.
+     */
+    public function serializeCreationOptions(PublicKeyCredentialCreationOptions $options): string
+    {
+        return $this->ceremonyFactory->getSerializer()->serialize($options, 'json');
+    }
+
+    /**
+     * @return list<PublicKeyCredentialParameters>
+     */
+    private function getPublicKeyCredentialParameters(): array
+    {
+        $algorithms = $this->configService->getConfiguration()->getAllowedAlgorithmsList();
+        $params = [];
+
+        foreach ($algorithms as $algo) {
+            $algoId = self::ALGORITHM_MAP[\strtoupper(\trim($algo))] ?? null;
+            if ($algoId !== null) {
+                $params[] = PublicKeyCredentialParameters::createPk($algoId);
+            }
+        }
+
+        return $params;
+    }
+
+    private function createUserHandle(int $beUserUid): string
+    {
+        $key = $this->configService->getEncryptionKey();
+        $derivedKey = \hash_hkdf('sha256', $key, 32, 'nr_passkeys_be_user_handle');
+
+        return \hash_hmac('sha256', (string) $beUserUid, $derivedKey, true);
+    }
+}

--- a/Classes/Service/WebAuthnCeremonyFactory.php
+++ b/Classes/Service/WebAuthnCeremonyFactory.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Service;
+
+use Cose\Algorithm\Manager as AlgorithmManager;
+use Cose\Algorithm\Signature\ECDSA\ES256;
+use Cose\Algorithm\Signature\ECDSA\ES384;
+use Cose\Algorithm\Signature\ECDSA\ES512;
+use Cose\Algorithm\Signature\RSA\RS256;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Serializer\SerializerInterface;
+use Webauthn\AttestationStatement\AttestationStatementSupportManager;
+use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
+use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
+use Webauthn\Denormalizer\WebauthnSerializerFactory;
+
+/**
+ * Shared WebAuthn library plumbing used by both the attestation (registration)
+ * and assertion (authentication) ceremonies.
+ *
+ * Centralises construction of the (cached) serializer and the ceremony-step
+ * manager factory so the attestation and assertion services stay focused on
+ * their respective ceremony logic.
+ */
+final class WebAuthnCeremonyFactory
+{
+    private ?SerializerInterface $serializer = null;
+
+    public function __construct(
+        private readonly ExtensionConfigurationService $configService,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function getSerializer(): SerializerInterface
+    {
+        if ($this->serializer === null) {
+            $attestationManager = $this->createAttestationStatementSupportManager();
+            $factory = new WebauthnSerializerFactory($attestationManager);
+            $this->serializer = $factory->create();
+        }
+
+        return $this->serializer;
+    }
+
+    public function createCeremonyFactory(): CeremonyStepManagerFactory
+    {
+        $factory = new CeremonyStepManagerFactory();
+
+        $origin = $this->configService->getEffectiveOrigin();
+        $factory->setAllowedOrigins([$origin]);
+
+        $algorithmManager = $this->createAlgorithmManager();
+        $factory->setAlgorithmManager($algorithmManager);
+
+        $factory->setAttestationStatementSupportManager($this->createAttestationStatementSupportManager());
+
+        return $factory;
+    }
+
+    private function createAttestationStatementSupportManager(): AttestationStatementSupportManager
+    {
+        $manager = new AttestationStatementSupportManager();
+        $manager->add(new NoneAttestationStatementSupport());
+
+        return $manager;
+    }
+
+    private function createAlgorithmManager(): AlgorithmManager
+    {
+        $algorithms = $this->configService->getConfiguration()->getAllowedAlgorithmsList();
+        $manager = AlgorithmManager::create();
+
+        foreach ($algorithms as $algo) {
+            match (\strtoupper(\trim($algo))) {
+                'ES256' => $manager->add(ES256::create()),
+                'ES384' => $manager->add(ES384::create()),
+                'ES512' => $manager->add(ES512::create()),
+                'RS256' => $manager->add(RS256::create()),
+                default => $this->logger->warning('Unknown algorithm configured', ['algorithm' => $algo]),
+            };
+        }
+
+        return $manager;
+    }
+}

--- a/Classes/Service/WebAuthnService.php
+++ b/Classes/Service/WebAuthnService.php
@@ -9,53 +9,29 @@ declare(strict_types=1);
 
 namespace Netresearch\NrPasskeysBe\Service;
 
-use Cose\Algorithm\Manager as AlgorithmManager;
-use Cose\Algorithm\Signature\ECDSA\ES256;
-use Cose\Algorithm\Signature\ECDSA\ES384;
-use Cose\Algorithm\Signature\ECDSA\ES512;
-use Cose\Algorithm\Signature\RSA\RS256;
 use Netresearch\NrPasskeysBe\Domain\Dto\AssertionOptions;
 use Netresearch\NrPasskeysBe\Domain\Dto\RegistrationOptions;
 use Netresearch\NrPasskeysBe\Domain\Dto\VerifiedAssertion;
 use Netresearch\NrPasskeysBe\Domain\Model\Credential;
-use Psr\Log\LoggerInterface;
 use RuntimeException;
-use Symfony\Component\Serializer\SerializerInterface;
-use Throwable;
-use Webauthn\AttestationStatement\AttestationStatementSupportManager;
-use Webauthn\AttestationStatement\NoneAttestationStatementSupport;
-use Webauthn\AuthenticatorAssertionResponseValidator;
-use Webauthn\AuthenticatorAttestationResponse;
-use Webauthn\AuthenticatorAttestationResponseValidator;
-use Webauthn\AuthenticatorSelectionCriteria;
-use Webauthn\CeremonyStep\CeremonyStepManagerFactory;
 use Webauthn\CredentialRecord;
-use Webauthn\Denormalizer\WebauthnSerializerFactory;
-use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialCreationOptions;
-use Webauthn\PublicKeyCredentialDescriptor;
-use Webauthn\PublicKeyCredentialParameters;
 use Webauthn\PublicKeyCredentialRequestOptions;
-use Webauthn\PublicKeyCredentialRpEntity;
-use Webauthn\PublicKeyCredentialUserEntity;
-use Webauthn\TrustPath\EmptyTrustPath;
 
+/**
+ * Facade over the WebAuthn attestation (registration) and assertion
+ * (authentication) ceremonies.
+ *
+ * Keeps a single, stable entry point for the controllers and the authentication
+ * service while delegating the ceremony logic to the focused {@see AttestationService}
+ * and {@see AssertionService}. This preserves the public surface used across the
+ * extension; the ceremony detail lives in the dedicated services.
+ */
 final class WebAuthnService
 {
-    private const ALGORITHM_MAP = [
-        'ES256' => -7,
-        'ES384' => -35,
-        'ES512' => -36,
-        'RS256' => -257,
-    ];
-
-    private ?SerializerInterface $serializer = null;
-
     public function __construct(
-        private readonly ExtensionConfigurationService $configService,
-        private readonly ChallengeService $challengeService,
-        private readonly CredentialRepository $credentialRepository,
-        private readonly LoggerInterface $logger,
+        private readonly AttestationService $attestationService,
+        private readonly AssertionService $assertionService,
     ) {}
 
     /**
@@ -63,62 +39,11 @@ final class WebAuthnService
      */
     public function createRegistrationOptions(int $beUserUid, string $username, string $displayName): RegistrationOptions
     {
-        $rpId = $this->configService->getEffectiveRpId();
-        $rpName = $this->configService->getConfiguration()->getRpName();
-
-        $rp = PublicKeyCredentialRpEntity::create(
-            name: $rpName,
-            id: $rpId,
-        );
-
-        $userHandle = $this->createUserHandle($beUserUid);
-
-        $user = PublicKeyCredentialUserEntity::create(
-            name: $username,
-            id: $userHandle,
-            displayName: $displayName,
-        );
-
-        $challenge = $this->challengeService->generateChallenge();
-        $challengeToken = $this->challengeService->createChallengeToken($challenge);
-
-        $existingCredentials = $this->credentialRepository->findByBeUser($beUserUid);
-        $excludeCredentials = \array_map(
-            static fn(Credential $cred): PublicKeyCredentialDescriptor => PublicKeyCredentialDescriptor::create(
-                type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
-                id: $cred->getCredentialId(),
-                transports: $cred->getTransportsArray(),
-            ),
-            $existingCredentials,
-        );
-
-        $authenticatorSelection = AuthenticatorSelectionCriteria::create(
-            userVerification: $this->configService->getConfiguration()->getUserVerification(),
-            residentKey: AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_PREFERRED,
-        );
-
-        $options = PublicKeyCredentialCreationOptions::create(
-            rp: $rp,
-            user: $user,
-            challenge: $challenge,
-            pubKeyCredParams: $this->getPublicKeyCredentialParameters(),
-            authenticatorSelection: $authenticatorSelection,
-            attestation: PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
-            excludeCredentials: $excludeCredentials,
-            timeout: 60000,
-        );
-
-        return new RegistrationOptions(
-            options: $options,
-            challengeToken: $challengeToken,
-        );
+        return $this->attestationService->createRegistrationOptions($beUserUid, $username, $displayName);
     }
 
     /**
      * Verify a registration response from the browser.
-     *
-     * The $responseJson is the JSON-serialized PublicKeyCredential from the browser,
-     * already base64url-encoded as per the WebAuthn spec.
      *
      * @throws RuntimeException on verification failure
      */
@@ -129,71 +54,13 @@ final class WebAuthnService
         string $username,
         string $displayName,
     ): CredentialRecord {
-        $challenge = $this->challengeService->verifyChallengeToken($challengeToken);
-
-        $rpId = $this->configService->getEffectiveRpId();
-        $rpName = $this->configService->getConfiguration()->getRpName();
-        $userHandle = $this->createUserHandle($beUserUid);
-
-        $rp = PublicKeyCredentialRpEntity::create(name: $rpName, id: $rpId);
-        $user = PublicKeyCredentialUserEntity::create(
-            name: $username,
-            id: $userHandle,
-            displayName: $displayName,
-        );
-
-        $creationOptions = PublicKeyCredentialCreationOptions::create(
-            rp: $rp,
-            user: $user,
-            challenge: $challenge,
-            pubKeyCredParams: $this->getPublicKeyCredentialParameters(),
-            attestation: PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
-        );
-
-        // Deserialize the browser response
-        $publicKeyCredential = $this->getSerializer()->deserialize(
+        return $this->attestationService->verifyRegistrationResponse(
             $responseJson,
-            PublicKeyCredential::class,
-            'json',
+            $challengeToken,
+            $beUserUid,
+            $username,
+            $displayName,
         );
-
-        if (!$publicKeyCredential instanceof PublicKeyCredential) {
-            throw new RuntimeException('Failed to deserialize credential response', 1700000020);
-        }
-
-        $response = $publicKeyCredential->response;
-        if (!$response instanceof AuthenticatorAttestationResponse) {
-            throw new RuntimeException('Expected attestation response', 1700000021);
-        }
-
-        $factory = $this->createCeremonyFactory();
-        $ceremonyManager = $factory->creationCeremony();
-        $validator = AuthenticatorAttestationResponseValidator::create($ceremonyManager);
-
-        try {
-            $source = $validator->check(
-                authenticatorAttestationResponse: $response,
-                publicKeyCredentialCreationOptions: $creationOptions,
-                host: $rpId,
-            );
-        } catch (Throwable $e) {
-            $this->logger->error('Passkey registration verification failed', [
-                'be_user_uid' => $beUserUid,
-                'error' => $e->getMessage(),
-            ]);
-            throw new RuntimeException(
-                'Registration verification failed: ' . $e->getMessage(),
-                1700000022,
-                $e,
-            );
-        }
-
-        $this->logger->info('Passkey registered successfully', [
-            'be_user_uid' => $beUserUid,
-            'username' => $username,
-        ]);
-
-        return $source;
     }
 
     /**
@@ -201,32 +68,7 @@ final class WebAuthnService
      */
     public function createAssertionOptions(string $username, int $beUserUid): AssertionOptions
     {
-        $rpId = $this->configService->getEffectiveRpId();
-        $challenge = $this->challengeService->generateChallenge();
-        $challengeToken = $this->challengeService->createChallengeToken($challenge);
-
-        $credentials = $this->credentialRepository->findByBeUser($beUserUid);
-        $allowCredentials = \array_map(
-            static fn(Credential $cred): PublicKeyCredentialDescriptor => PublicKeyCredentialDescriptor::create(
-                type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
-                id: $cred->getCredentialId(),
-                transports: $cred->getTransportsArray(),
-            ),
-            $credentials,
-        );
-
-        $options = PublicKeyCredentialRequestOptions::create(
-            challenge: $challenge,
-            rpId: $rpId,
-            allowCredentials: $allowCredentials,
-            userVerification: $this->configService->getConfiguration()->getUserVerification(),
-            timeout: 60000,
-        );
-
-        return new AssertionOptions(
-            options: $options,
-            challengeToken: $challengeToken,
-        );
+        return $this->assertionService->createAssertionOptions($username, $beUserUid);
     }
 
     /**
@@ -234,95 +76,23 @@ final class WebAuthnService
      */
     public function createDiscoverableAssertionOptions(): AssertionOptions
     {
-        $rpId = $this->configService->getEffectiveRpId();
-        $challenge = $this->challengeService->generateChallenge();
-        $challengeToken = $this->challengeService->createChallengeToken($challenge);
-
-        $options = PublicKeyCredentialRequestOptions::create(
-            challenge: $challenge,
-            rpId: $rpId,
-            allowCredentials: [],
-            userVerification: $this->configService->getConfiguration()->getUserVerification(),
-            timeout: 60000,
-        );
-
-        return new AssertionOptions(
-            options: $options,
-            challengeToken: $challengeToken,
-        );
+        return $this->assertionService->createDiscoverableAssertionOptions();
     }
 
     /**
-     * Create *decoy* assertion options for an unknown username.
-     *
-     * Returns options structurally identical to a real user's so the public
-     * login-options endpoint cannot be used to enumerate valid backend usernames.
-     * The decoy allowCredentials are derived deterministically from the username
-     * (HMAC over an HKDF-derived key from the extension encryption key), so repeated
-     * requests for the same unknown username yield stable, unguessable credential
-     * descriptors. A subsequent assertion against a decoy fails verification exactly
-     * as a wrong passkey would, keeping known and unknown users indistinguishable.
+     * Create *decoy* assertion options for an unknown username (user-enumeration defence).
      */
     public function createDecoyAssertionOptions(string $username): AssertionOptions
     {
-        $rpId = $this->configService->getEffectiveRpId();
-        $challenge = $this->challengeService->generateChallenge();
-        $challengeToken = $this->challengeService->createChallengeToken($challenge);
-
-        $key = $this->configService->getEncryptionKey();
-        $derivedKey = \hash_hkdf('sha256', $key, 32, 'nr_passkeys_be_decoy');
-        $decoyId = \hash_hmac('sha256', $username, $derivedKey, true);
-
-        $allowCredentials = [
-            PublicKeyCredentialDescriptor::create(
-                type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
-                id: $decoyId,
-                transports: [],
-            ),
-        ];
-
-        $options = PublicKeyCredentialRequestOptions::create(
-            challenge: $challenge,
-            rpId: $rpId,
-            allowCredentials: $allowCredentials,
-            userVerification: $this->configService->getConfiguration()->getUserVerification(),
-            timeout: 60000,
-        );
-
-        return new AssertionOptions(
-            options: $options,
-            challengeToken: $challengeToken,
-        );
+        return $this->assertionService->createDecoyAssertionOptions($username);
     }
 
     /**
-     * Resolve the backend user UID from a passkey assertion response.
-     *
-     * Used for discoverable (usernameless) login where the credential ID
-     * in the assertion identifies the user without requiring a username.
+     * Resolve the backend user UID from a passkey assertion response (discoverable login).
      */
     public function findBeUserUidFromAssertion(string $responseJson): ?int
     {
-        try {
-            $publicKeyCredential = $this->getSerializer()->deserialize(
-                $responseJson,
-                PublicKeyCredential::class,
-                'json',
-            );
-
-            if (!$publicKeyCredential instanceof PublicKeyCredential) {
-                return null;
-            }
-
-            $credential = $this->credentialRepository->findByCredentialId($publicKeyCredential->rawId);
-            if ($credential === null || $credential->isRevoked()) {
-                return null;
-            }
-
-            return $credential->getBeUser();
-        } catch (Throwable) {
-            return null;
-        }
+        return $this->assertionService->findBeUserUidFromAssertion($responseJson);
     }
 
     /**
@@ -335,92 +105,7 @@ final class WebAuthnService
         string $challengeToken,
         int $beUserUid,
     ): VerifiedAssertion {
-        $challenge = $this->challengeService->verifyChallengeToken($challengeToken);
-        $rpId = $this->configService->getEffectiveRpId();
-
-        // Deserialize the browser response
-        $publicKeyCredential = $this->getSerializer()->deserialize(
-            $responseJson,
-            PublicKeyCredential::class,
-            'json',
-        );
-
-        if (!$publicKeyCredential instanceof PublicKeyCredential) {
-            throw new RuntimeException('Failed to deserialize assertion response', 1700000030);
-        }
-
-        $response = $publicKeyCredential->response;
-        if (!$response instanceof \Webauthn\AuthenticatorAssertionResponse) {
-            throw new RuntimeException('Expected assertion response', 1700000031);
-        }
-
-        // Find the credential by its ID
-        $credentialId = $publicKeyCredential->rawId;
-        $credential = $this->credentialRepository->findByCredentialId($credentialId);
-
-        if ($credential === null) {
-            $this->logger->warning('Assertion with unknown credential ID', [
-                'be_user_uid' => $beUserUid,
-            ]);
-            throw new RuntimeException('Unknown credential', 1700000032);
-        }
-
-        if ($credential->isRevoked()) {
-            throw new RuntimeException('Credential has been revoked', 1700000033);
-        }
-
-        if ($credential->getBeUser() !== $beUserUid) {
-            $this->logger->warning('Credential does not belong to the claimed user', [
-                'be_user_uid' => $beUserUid,
-                'credential_be_user' => $credential->getBeUser(),
-            ]);
-            throw new RuntimeException('Credential mismatch', 1700000034);
-        }
-
-        $storedSource = $this->credentialToSource($credential);
-
-        $requestOptions = PublicKeyCredentialRequestOptions::create(
-            challenge: $challenge,
-            rpId: $rpId,
-            userVerification: $this->configService->getConfiguration()->getUserVerification(),
-        );
-
-        $factory = $this->createCeremonyFactory();
-        $ceremonyManager = $factory->requestCeremony();
-        $validator = AuthenticatorAssertionResponseValidator::create($ceremonyManager);
-
-        try {
-            $updatedSource = $validator->check(
-                credentialRecord: $storedSource,
-                authenticatorAssertionResponse: $response,
-                publicKeyCredentialRequestOptions: $requestOptions,
-                host: $rpId,
-                userHandle: $credential->getUserHandle() !== '' ? $credential->getUserHandle() : null,
-            );
-        } catch (Throwable $e) {
-            $this->logger->error('Passkey assertion verification failed', [
-                'be_user_uid' => $beUserUid,
-                'error' => $e->getMessage(),
-            ]);
-            throw new RuntimeException(
-                'Assertion verification failed: ' . $e->getMessage(),
-                1700000035,
-                $e,
-            );
-        }
-
-        $this->credentialRepository->updateSignCount($credential->getUid(), $updatedSource->counter);
-        $this->credentialRepository->updateLastUsed($credential->getUid());
-
-        $this->logger->info('Passkey login successful', [
-            'be_user_uid' => $beUserUid,
-            'credential_uid' => $credential->getUid(),
-        ]);
-
-        return new VerifiedAssertion(
-            credential: $credential,
-            source: $updatedSource,
-        );
+        return $this->assertionService->verifyAssertionResponse($responseJson, $challengeToken, $beUserUid);
     }
 
     /**
@@ -431,21 +116,7 @@ final class WebAuthnService
         int $beUserUid,
         string $label,
     ): Credential {
-        $credential = new Credential(
-            beUser: $beUserUid,
-            credentialId: $source->publicKeyCredentialId,
-            publicKeyCose: $source->credentialPublicKey,
-            signCount: $source->counter,
-            userHandle: $source->userHandle,
-            aaguid: $source->aaguid->toString(),
-            transports: \json_encode($source->transports, JSON_THROW_ON_ERROR),
-            label: $label,
-        );
-
-        $uid = $this->credentialRepository->save($credential);
-        $credential->setUid($uid);
-
-        return $credential;
+        return $this->attestationService->storeCredential($source, $beUserUid, $label);
     }
 
     /**
@@ -453,7 +124,7 @@ final class WebAuthnService
      */
     public function serializeCreationOptions(PublicKeyCredentialCreationOptions $options): string
     {
-        return $this->getSerializer()->serialize($options, 'json');
+        return $this->attestationService->serializeCreationOptions($options);
     }
 
     /**
@@ -461,103 +132,6 @@ final class WebAuthnService
      */
     public function serializeRequestOptions(PublicKeyCredentialRequestOptions $options): string
     {
-        return $this->getSerializer()->serialize($options, 'json');
-    }
-
-    private function getSerializer(): SerializerInterface
-    {
-        if ($this->serializer === null) {
-            $attestationManager = $this->createAttestationStatementSupportManager();
-            $factory = new WebauthnSerializerFactory($attestationManager);
-            $this->serializer = $factory->create();
-        }
-
-        return $this->serializer;
-    }
-
-    private function createAttestationStatementSupportManager(): AttestationStatementSupportManager
-    {
-        $manager = new AttestationStatementSupportManager();
-        $manager->add(new NoneAttestationStatementSupport());
-
-        return $manager;
-    }
-
-    private function createCeremonyFactory(): CeremonyStepManagerFactory
-    {
-        $factory = new CeremonyStepManagerFactory();
-
-        $origin = $this->configService->getEffectiveOrigin();
-        $factory->setAllowedOrigins([$origin]);
-
-        $algorithmManager = $this->createAlgorithmManager();
-        $factory->setAlgorithmManager($algorithmManager);
-
-        $factory->setAttestationStatementSupportManager($this->createAttestationStatementSupportManager());
-
-        return $factory;
-    }
-
-    private function createAlgorithmManager(): AlgorithmManager
-    {
-        $algorithms = $this->configService->getConfiguration()->getAllowedAlgorithmsList();
-        $manager = AlgorithmManager::create();
-
-        foreach ($algorithms as $algo) {
-            match (\strtoupper(\trim($algo))) {
-                'ES256' => $manager->add(ES256::create()),
-                'ES384' => $manager->add(ES384::create()),
-                'ES512' => $manager->add(ES512::create()),
-                'RS256' => $manager->add(RS256::create()),
-                default => $this->logger->warning('Unknown algorithm configured', ['algorithm' => $algo]),
-            };
-        }
-
-        return $manager;
-    }
-
-    /**
-     * @return list<PublicKeyCredentialParameters>
-     */
-    private function getPublicKeyCredentialParameters(): array
-    {
-        $algorithms = $this->configService->getConfiguration()->getAllowedAlgorithmsList();
-        $params = [];
-
-        foreach ($algorithms as $algo) {
-            $algoId = self::ALGORITHM_MAP[\strtoupper(\trim($algo))] ?? null;
-            if ($algoId !== null) {
-                $params[] = PublicKeyCredentialParameters::createPk($algoId);
-            }
-        }
-
-        return $params;
-    }
-
-    private function createUserHandle(int $beUserUid): string
-    {
-        $key = $this->configService->getEncryptionKey();
-        $derivedKey = \hash_hkdf('sha256', $key, 32, 'nr_passkeys_be_user_handle');
-
-        return \hash_hmac('sha256', (string) $beUserUid, $derivedKey, true);
-    }
-
-    private function credentialToSource(Credential $credential): CredentialRecord
-    {
-        $aaguid = $credential->getAaguid() !== ''
-            ? \Symfony\Component\Uid\Uuid::fromString($credential->getAaguid())
-            : \Symfony\Component\Uid\Uuid::v4();
-
-        return CredentialRecord::create(
-            publicKeyCredentialId: $credential->getCredentialId(),
-            type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
-            transports: $credential->getTransportsArray(),
-            attestationType: 'none',
-            trustPath: new EmptyTrustPath(),
-            aaguid: $aaguid,
-            credentialPublicKey: $credential->getPublicKeyCose(),
-            userHandle: $credential->getUserHandle(),
-            counter: $credential->getSignCount(),
-        );
+        return $this->assertionService->serializeRequestOptions($options);
     }
 }

--- a/Tests/Unit/Service/WebAuthnServiceTest.php
+++ b/Tests/Unit/Service/WebAuthnServiceTest.php
@@ -15,9 +15,12 @@ use Netresearch\NrPasskeysBe\Domain\Dto\AssertionOptions;
 use Netresearch\NrPasskeysBe\Domain\Dto\RegistrationOptions;
 use Netresearch\NrPasskeysBe\Domain\Dto\VerifiedAssertion;
 use Netresearch\NrPasskeysBe\Domain\Model\Credential;
+use Netresearch\NrPasskeysBe\Service\AssertionService;
+use Netresearch\NrPasskeysBe\Service\AttestationService;
 use Netresearch\NrPasskeysBe\Service\ChallengeService;
 use Netresearch\NrPasskeysBe\Service\CredentialRepository;
 use Netresearch\NrPasskeysBe\Service\ExtensionConfigurationService;
+use Netresearch\NrPasskeysBe\Service\WebAuthnCeremonyFactory;
 use Netresearch\NrPasskeysBe\Service\WebAuthnService;
 use OpenSSLAsymmetricKey;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -34,12 +37,18 @@ use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialRequestOptions;
 
 #[CoversClass(WebAuthnService::class)]
+#[CoversClass(AttestationService::class)]
+#[CoversClass(AssertionService::class)]
+#[CoversClass(WebAuthnCeremonyFactory::class)]
 final class WebAuthnServiceTest extends TestCase
 {
     private ExtensionConfigurationService&MockObject $configServiceMock;
     private ChallengeService&MockObject $challengeServiceMock;
     private CredentialRepository&MockObject $credentialRepositoryMock;
     private LoggerInterface&MockObject $loggerMock;
+    private WebAuthnCeremonyFactory $ceremonyFactory;
+    private AttestationService $attestationService;
+    private AssertionService $assertionService;
     private WebAuthnService $subject;
 
     protected function setUp(): void
@@ -55,11 +64,27 @@ final class WebAuthnServiceTest extends TestCase
         $this->credentialRepositoryMock = $this->createMock(CredentialRepository::class);
         $this->loggerMock = $this->createMock(LoggerInterface::class);
 
-        $this->subject = new WebAuthnService(
+        $this->ceremonyFactory = new WebAuthnCeremonyFactory(
+            $this->configServiceMock,
+            $this->loggerMock,
+        );
+        $this->attestationService = new AttestationService(
             $this->configServiceMock,
             $this->challengeServiceMock,
             $this->credentialRepositoryMock,
             $this->loggerMock,
+            $this->ceremonyFactory,
+        );
+        $this->assertionService = new AssertionService(
+            $this->configServiceMock,
+            $this->challengeServiceMock,
+            $this->credentialRepositoryMock,
+            $this->loggerMock,
+            $this->ceremonyFactory,
+        );
+        $this->subject = new WebAuthnService(
+            $this->attestationService,
+            $this->assertionService,
         );
     }
 
@@ -741,11 +766,22 @@ final class WebAuthnServiceTest extends TestCase
         $this->challengeServiceMock->method('createChallengeToken')->willReturn('token');
         $this->credentialRepositoryMock->method('findByBeUser')->willReturn([]);
 
+        $ceremonyFactory = new WebAuthnCeremonyFactory($configServiceMock, $this->loggerMock);
         $subject = new WebAuthnService(
-            $configServiceMock,
-            $this->challengeServiceMock,
-            $this->credentialRepositoryMock,
-            $this->loggerMock,
+            new AttestationService(
+                $configServiceMock,
+                $this->challengeServiceMock,
+                $this->credentialRepositoryMock,
+                $this->loggerMock,
+                $ceremonyFactory,
+            ),
+            new AssertionService(
+                $configServiceMock,
+                $this->challengeServiceMock,
+                $this->credentialRepositoryMock,
+                $this->loggerMock,
+                $ceremonyFactory,
+            ),
         );
 
         $result1 = $subject->createRegistrationOptions($beUserUid, 'user', 'User');
@@ -865,9 +901,9 @@ final class WebAuthnServiceTest extends TestCase
             ->with('Unknown algorithm configured', ['algorithm' => 'UNKNOWN_ALGO']);
 
         // Use reflection to call the private createAlgorithmManager method directly
-        $reflection = new ReflectionMethod($this->subject, 'createAlgorithmManager');
+        $reflection = new ReflectionMethod($this->ceremonyFactory, 'createAlgorithmManager');
 
-        $reflection->invoke($this->subject);
+        $reflection->invoke($this->ceremonyFactory);
     }
 
     #[Test]
@@ -1489,10 +1525,10 @@ final class WebAuthnServiceTest extends TestCase
         $this->configServiceMock->method('getEffectiveRpId')->willReturn('example.com');
         $this->configServiceMock->method('getEffectiveOrigin')->willReturn('https://example.com');
 
-        $reflection = new ReflectionMethod($this->subject, 'createAlgorithmManager');
+        $reflection = new ReflectionMethod($this->ceremonyFactory, 'createAlgorithmManager');
 
         /** @var AlgorithmManager $manager */
-        $manager = $reflection->invoke($this->subject);
+        $manager = $reflection->invoke($this->ceremonyFactory);
 
         self::assertInstanceOf(AlgorithmManager::class, $manager);
 
@@ -1524,10 +1560,10 @@ final class WebAuthnServiceTest extends TestCase
             aaguid: '',
         );
 
-        $reflection = new ReflectionMethod($this->subject, 'credentialToSource');
+        $reflection = new ReflectionMethod($this->assertionService, 'credentialToSource');
 
         /** @var CredentialRecord $source */
-        $source = $reflection->invoke($this->subject, $credential);
+        $source = $reflection->invoke($this->assertionService, $credential);
 
         self::assertInstanceOf(CredentialRecord::class, $source);
         self::assertSame('cred-id-123', $source->publicKeyCredentialId);
@@ -1561,10 +1597,10 @@ final class WebAuthnServiceTest extends TestCase
             aaguid: $fixedAaguid,
         );
 
-        $reflection = new ReflectionMethod($this->subject, 'credentialToSource');
+        $reflection = new ReflectionMethod($this->assertionService, 'credentialToSource');
 
         /** @var CredentialRecord $source */
-        $source = $reflection->invoke($this->subject, $credential);
+        $source = $reflection->invoke($this->assertionService, $credential);
 
         self::assertSame($fixedAaguid, $source->aaguid->toString());
     }


### PR DESCRIPTION
ARCH-2 from the review (tracked in #73). The ~560-line `WebAuthnService` mixed the attestation (registration) and assertion (authentication) ceremonies plus the shared WebAuthn library plumbing in one class.

## Change

Extracts three focused collaborators **behind the unchanged public surface**:

- **`WebAuthnCeremonyFactory`** — shared serializer (cached) + ceremony-step manager factory (origin, algorithm manager, attestation-statement support)
- **`AttestationService`** — registration options, attestation verification, credential storage
- **`AssertionService`** — assertion options (username-first / discoverable / decoy), discoverable-login user resolution, assertion verification

`WebAuthnService` becomes a thin **facade** delegating to the two services. The controllers (`LoginController`, `ManagementController`) and `PasskeyAuthenticationService` keep their existing entry point, and DI is unchanged — all three new services autowire.

**No behaviour change.** Every method body was transplanted verbatim; only the shared plumbing calls now route through the injected factory.

## Verification

- 577 unit tests pass (the existing `WebAuthnServiceTest` now builds the facade from the real collaborators, so the full delegation chain is exercised; the private-method reflection tests target the owning service)
- PHPStan level 10 + phpat architecture rules (finality + layering) clean
- PHP-CS-Fixer clean
- DI container compiles on a live TYPO3 v13.4 backend (login page returns 200)
- CI runs the functional matrix + e2e, which exercise the `makeInstance(WebAuthnService)` auth path and the full login ceremony

Closes ARCH-2 in #73.