### PR TITLE
refactor(js): share WebAuthn base64 helpers + modernize login to ES module (TEST-1)

### DIFF
--- a/Classes/EventListener/InjectPasskeyLoginFields.php
+++ b/Classes/EventListener/InjectPasskeyLoginFields.php
@@ -31,14 +31,11 @@ final readonly class InjectPasskeyLoginFields
     {
         $config = $this->configService->getConfiguration();
 
-        $this->pageRenderer->addJsFile(
-            'EXT:nr_passkeys_be/Resources/Public/JavaScript/PasskeyLogin.js',
-            'text/javascript',
-            false,
-            false,
-            '',
-            true,
-        );
+        // The backend login screen ships the importmap (JavaScriptModules.php), so the
+        // login module can be loaded as an ES module. window.NrPasskeysBeConfig is set
+        // below via a classic inline script, which runs before the deferred module — so
+        // the config is available by the time the module's init() runs.
+        $this->pageRenderer->loadJavaScriptModule('@netresearch/nr-passkeys-be/PasskeyLogin.js');
 
         $passkeyConfig = [
             'loginOptionsUrl' => (string) $this->uriBuilder->buildUriFromRoute('passkeys_login_options'),

--- a/Resources/Public/JavaScript/PasskeyLogin.js
+++ b/Resources/Public/JavaScript/PasskeyLogin.js
@@ -12,383 +12,386 @@
  * 4. Call navigator.credentials.get()
  * 5. Submit result via the standard TYPO3 login form (#typo3-login-form)
  */
-(function () {
-  'use strict';
+import { base64urlToBuffer, bufferToBase64url, bufferToBase64 } from '@netresearch/nr-passkeys-be/Util/Base64.js';
 
-  function init() {
-    var config = window.NrPasskeysBeConfig;
-    if (!config || !config.loginOptionsUrl) return;
+// Material Symbols "passkey" icon (Apache 2.0, google/material-design-icons)
+const PASSKEY_ICON = '<svg xmlns="http://www.w3.org/2000/svg" height="20" ' +
+  'viewBox="0 -960 960 960" width="20" fill="currentColor" ' +
+  'style="vertical-align:middle">' +
+  '<path d="M120-160v-112q0-34 17.5-62.5T184-378q62-31 126-46.5T440-440' +
+  'q20 0 40 1.5t40 4.5q-4 58 21 109.5t73 84.5v80H120ZM760-40l-60-60v-186' +
+  'q-44-13-72-49.5T600-420q0-58 41-99t99-41q58 0 99 41t41 99q0 45-25.5 ' +
+  '80T790-290l50 50-60 60 60 60-80 80ZM440-480q-66 0-113-47t-47-113q0-66' +
+  ' 47-113t113-47q66 0 113 47t47 113q0 66-47 113t-113 47Zm300 80q17 0 ' +
+  '28.5-11.5T780-440q0-17-11.5-28.5T740-480q-17 0-28.5 11.5T700-440q0 ' +
+  '17 11.5 28.5T740-400Z"/></svg>';
 
-    // Server-translated UI labels (with English fallbacks if injection is absent).
-    var L = config.labels || {};
+function init() {
+  const config = window.NrPasskeysBeConfig;
+  if (!config || !config.loginOptionsUrl) return;
 
-    var loginForm = document.getElementById('typo3-login-form');
-    if (!loginForm) return;
+  // Server-translated UI labels (with English fallbacks if injection is absent).
+  const L = config.labels || {};
 
-    // Build and inject passkey UI below the login button with an "or" divider
-    var container = buildPasskeyUI(L);
-    var submitSection = document.getElementById('t3-login-submit-section');
-    if (submitSection) {
-      submitSection.parentNode.insertBefore(container, submitSection.nextSibling);
-    } else {
-      loginForm.appendChild(container);
-    }
+  const loginForm = document.getElementById('typo3-login-form');
+  if (!loginForm) return;
 
-    var optionsUrl = config.loginOptionsUrl;
-    var usernameInput = document.getElementById('t3-username');
-    var loginBtn = document.getElementById('passkey-login-btn');
-    var btnText = document.getElementById('passkey-btn-text');
-    var btnLoading = document.getElementById('passkey-btn-loading');
-    var errorEl = document.getElementById('passkey-error');
-    var assertionField = document.getElementById('passkey-assertion');
-    var challengeTokenField = document.getElementById('passkey-challenge-token');
+  // Build and inject passkey UI below the login button with an "or" divider
+  const container = buildPasskeyUI(L);
+  const submitSection = document.getElementById('t3-login-submit-section');
+  if (submitSection) {
+    submitSection.parentNode.insertBefore(container, submitSection.nextSibling);
+  } else {
+    loginForm.appendChild(container);
+  }
 
-    // Check WebAuthn support
-    if (!window.PublicKeyCredential) {
-      showError(L.errorUnsupported || 'Your browser does not support Passkeys (WebAuthn).');
-      if (loginBtn) loginBtn.disabled = true;
-      return;
-    }
+  const optionsUrl = config.loginOptionsUrl;
+  const usernameInput = document.getElementById('t3-username');
+  const loginBtn = document.getElementById('passkey-login-btn');
+  const btnText = document.getElementById('passkey-btn-text');
+  const btnLoading = document.getElementById('passkey-btn-loading');
+  const errorEl = document.getElementById('passkey-error');
+  const assertionField = document.getElementById('passkey-assertion');
+  const challengeTokenField = document.getElementById('passkey-challenge-token');
 
-    // Check secure context
-    if (!window.isSecureContext) {
-      showError(L.errorInsecure || 'Passkeys require a secure connection (HTTPS).');
-      if (loginBtn) loginBtn.disabled = true;
-      return;
-    }
+  // Check WebAuthn support
+  if (!window.PublicKeyCredential) {
+    showError(L.errorUnsupported || 'Your browser does not support Passkeys (WebAuthn).');
+    if (loginBtn) loginBtn.disabled = true;
+    return;
+  }
 
-    // Detect failed passkey login from previous attempt
-    checkForFailedPasskeyLogin();
+  // Check secure context
+  if (!window.isSecureContext) {
+    showError(L.errorInsecure || 'Passkeys require a secure connection (HTTPS).');
+    if (loginBtn) loginBtn.disabled = true;
+    return;
+  }
 
-    if (loginBtn) {
-      loginBtn.addEventListener('click', handlePasskeyLogin);
-    }
+  // Detect failed passkey login from previous attempt
+  checkForFailedPasskeyLogin();
 
-    function checkForFailedPasskeyLogin() {
-      try {
-        if (sessionStorage.getItem('nr_passkey_attempt')) {
-          sessionStorage.removeItem('nr_passkey_attempt');
-          // Still on the login page after a passkey submission = auth failed.
-          // TYPO3 does a POST-Redirect-GET after failed login, so the generic
-          // error div (#t3-login-error) may not be present on the redirected page.
-          showError(L.errorVerifyFailed || 'Passkey authentication failed. Your passkey was not accepted. Please try again or sign in with your password.');
-          // Hide generic TYPO3 error if it exists
-          var typo3Error = document.getElementById('t3-login-error');
-          if (typo3Error) {
-            typo3Error.style.display = 'none';
-          }
+  if (loginBtn) {
+    loginBtn.addEventListener('click', handlePasskeyLogin);
+  }
+
+  function checkForFailedPasskeyLogin() {
+    try {
+      if (sessionStorage.getItem('nr_passkey_attempt')) {
+        sessionStorage.removeItem('nr_passkey_attempt');
+        // Still on the login page after a passkey submission = auth failed.
+        // TYPO3 does a POST-Redirect-GET after failed login, so the generic
+        // error div (#t3-login-error) may not be present on the redirected page.
+        showError(L.errorVerifyFailed || 'Passkey authentication failed. Your passkey was not accepted. Please try again or sign in with your password.');
+        // Hide generic TYPO3 error if it exists
+        const typo3Error = document.getElementById('t3-login-error');
+        if (typo3Error) {
+          typo3Error.style.display = 'none';
         }
-      } catch (e) {
-        // sessionStorage may be unavailable
       }
+    } catch (e) {
+      // sessionStorage may be unavailable
+    }
+  }
+
+  async function handlePasskeyLogin() {
+    hideError();
+    const username = usernameInput ? usernameInput.value.trim() : '';
+
+    if (!username && !config.discoverableEnabled) {
+      showError(L.errorUsernameRequired || 'Please enter your username.');
+      if (usernameInput) usernameInput.focus();
+      return;
     }
 
-    async function handlePasskeyLogin() {
-      hideError();
-      var username = usernameInput ? usernameInput.value.trim() : '';
+    setLoading(true);
 
-      if (!username && !config.discoverableEnabled) {
-        showError(L.errorUsernameRequired || 'Please enter your username.');
-        if (usernameInput) usernameInput.focus();
+    try {
+      // Step 1: Fetch assertion options from server
+      const optionsData = await fetchAssertionOptions(username);
+      if (!optionsData) {
+        // fetchAssertionOptions already surfaced the error to the user
+        setLoading(false);
         return;
       }
 
-      setLoading(true);
+      // Step 2: Prepare options and call the WebAuthn API
+      const publicKeyOptions = buildPublicKeyOptions(optionsData.options);
+      const assertion = await navigator.credentials.get({ publicKey: publicKeyOptions });
 
-      try {
-        // Step 1: Fetch assertion options from server
-        var optionsResponse = await fetch(optionsUrl, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({ username: username }),
-        });
-
-        if (!optionsResponse.ok) {
-          var data = await optionsResponse.json().catch(function () { return {}; });
-          if (optionsResponse.status === 429) {
-            showError(data.locked
-              ? (L.errorLocked || 'Account temporarily locked. Please contact your administrator.')
-              : (L.errorRateLimit || 'Too many attempts. Please try again later.'));
-          } else {
-            showError(data.error || L.errorGeneric || 'Authentication failed. Please try again.');
-          }
-          setLoading(false);
-          return;
-        }
-
-        var optionsData = await optionsResponse.json();
-        var options = optionsData.options;
-        var challengeToken = optionsData.challengeToken;
-
-        // Step 2: Prepare options for navigator.credentials.get()
-        var publicKeyOptions = {
-          challenge: base64urlToBuffer(options.challenge),
-          rpId: options.rpId,
-          timeout: options.timeout || 60000,
-          userVerification: options.userVerification || 'required',
-        };
-
-        if (options.allowCredentials && options.allowCredentials.length > 0) {
-          publicKeyOptions.allowCredentials = options.allowCredentials.map(function (cred) {
-            return {
-              type: cred.type,
-              id: base64urlToBuffer(cred.id),
-              transports: cred.transports || [],
-            };
-          });
-        }
-
-        // Step 3: Call WebAuthn API
-        var assertion = await navigator.credentials.get({
-          publicKey: publicKeyOptions,
-        });
-
-        // Step 4: Encode the response
-        var credentialResponse = {
-          id: bufferToBase64url(assertion.rawId),
-          rawId: bufferToBase64(assertion.rawId),
-          type: assertion.type,
-          response: {
-            clientDataJSON: bufferToBase64url(assertion.response.clientDataJSON),
-            authenticatorData: bufferToBase64url(assertion.response.authenticatorData),
-            signature: bufferToBase64url(assertion.response.signature),
-            userHandle: assertion.response.userHandle
-              ? bufferToBase64url(assertion.response.userHandle)
-              : null,
-          },
-        };
-
-        // Step 5: Submit via TYPO3 login form
-        // Pack assertion + challenge token into the userident field.
-        // TYPO3 auth services receive login data via $this->login['uident']
-        // which maps to the userident POST field. $GLOBALS['TYPO3_REQUEST']
-        // is not available during the auth service chain, so custom POST
-        // fields (passkey_assertion etc.) are inaccessible. Using userident
-        // is the standard TYPO3 way to pass authentication credentials.
-        var passkeyPayload = JSON.stringify({
-          _type: 'passkey',
-          assertion: credentialResponse,
-          challengeToken: challengeToken,
-        });
-
-        var useridentField = document.querySelector('.t3js-login-userident-field');
-        if (useridentField) {
-          useridentField.value = passkeyPayload;
-        }
-
-        // Also keep hidden fields populated for any middleware/hook inspection
-        if (assertionField) {
-          assertionField.value = JSON.stringify(credentialResponse);
-        }
-        if (challengeTokenField) {
-          challengeTokenField.value = challengeToken;
-        }
-
-        // Ensure the username field has the value
-        if (usernameInput) {
-          usernameInput.value = username;
-        }
-
-        // Flag this as a passkey attempt so we can show a specific error
-        // if the server-side verification fails and the page reloads
-        try { sessionStorage.setItem('nr_passkey_attempt', '1'); } catch (e) { /* ignore */ }
-
-        loginForm.submit();
-      } catch (err) {
-        setLoading(false);
-
-        if (err.name === 'NotAllowedError') {
-          showError(L.errorNotAllowed || 'Authentication was cancelled or no passkey found for this site. Have you registered a passkey?');
-        } else if (err.name === 'SecurityError') {
-          showError(L.errorSecurity || 'Security error. Please check your connection.');
-        } else if (err.name === 'AbortError') {
-          showError(L.errorCancelled || 'Authentication was cancelled.');
-        } else {
-          showError(L.errorGeneric || 'Authentication failed. Please try again.');
-          console.error('Passkey login error:', err);
-        }
-      }
-    }
-
-    function setLoading(loading) {
-      if (loginBtn) loginBtn.disabled = loading;
-      if (btnText) btnText.classList.toggle('d-none', loading);
-      if (btnLoading) btnLoading.classList.toggle('d-none', !loading);
-    }
-
-    function showError(message) {
-      if (errorEl) {
-        // Make the live region visible/in the a11y tree BEFORE injecting text so
-        // the aria-live="assertive" announcement fires reliably (NVDA/JAWS/VoiceOver
-        // do not consistently announce text set on a display:none node).
-        errorEl.classList.remove('d-none');
-        errorEl.textContent = message;
-      }
-    }
-
-    function hideError() {
-      if (errorEl) {
-        errorEl.classList.add('d-none');
-        errorEl.textContent = '';
-      }
+      // Step 3: Encode and submit the assertion via the TYPO3 login form
+      const credentialResponse = encodeAssertion(assertion);
+      submitAssertion(credentialResponse, optionsData.challengeToken, username);
+    } catch (err) {
+      setLoading(false);
+      handleAuthError(err);
     }
   }
 
-  // Material Symbols "passkey" icon (Apache 2.0, google/material-design-icons)
-  var PASSKEY_ICON = '<svg xmlns="http://www.w3.org/2000/svg" height="20" ' +
-    'viewBox="0 -960 960 960" width="20" fill="currentColor" ' +
-    'style="vertical-align:middle">' +
-    '<path d="M120-160v-112q0-34 17.5-62.5T184-378q62-31 126-46.5T440-440' +
-    'q20 0 40 1.5t40 4.5q-4 58 21 109.5t73 84.5v80H120ZM760-40l-60-60v-186' +
-    'q-44-13-72-49.5T600-420q0-58 41-99t99-41q58 0 99 41t41 99q0 45-25.5 ' +
-    '80T790-290l50 50-60 60 60 60-80 80ZM440-480q-66 0-113-47t-47-113q0-66' +
-    ' 47-113t113-47q66 0 113 47t47 113q0 66-47 113t-113 47Zm300 80q17 0 ' +
-    '28.5-11.5T780-440q0-17-11.5-28.5T740-480q-17 0-28.5 11.5T700-440q0 ' +
-    '17 11.5 28.5T740-400Z"/></svg>';
-
-  function buildPasskeyUI(labels) {
-    labels = labels || {};
-    var divider = document.createElement('div');
-    divider.className = 'passkey-divider mb-2 mt-2';
-    divider.setAttribute('style', 'display:flex;align-items:center;gap:8px');
-    var hrLeft = document.createElement('hr');
-    hrLeft.setAttribute('style', 'flex:1;border:none;border-top:1px solid #ccc;margin:0');
-    var orLabel = document.createElement('span');
-    orLabel.setAttribute('style', 'color:#999;font-size:12px;text-transform:uppercase;letter-spacing:1px');
-    orLabel.textContent = labels.dividerOr || 'or';
-    var hrRight = document.createElement('hr');
-    hrRight.setAttribute('style', 'flex:1;border:none;border-top:1px solid #ccc;margin:0');
-    divider.appendChild(hrLeft);
-    divider.appendChild(orLabel);
-    divider.appendChild(hrRight);
-
-    var container = document.createElement('div');
-    container.id = 'passkey-login-container';
-    container.className = 'passkey-login';
-    container.appendChild(divider);
-
-    var formGroup = document.createElement('div');
-    formGroup.className = 'form-group mb-2';
-    var grid = document.createElement('div');
-    grid.className = 'd-grid';
-    var btn = document.createElement('button');
-    btn.type = 'button';
-    btn.id = 'passkey-login-btn';
-    btn.className = 'btn btn-default btn-block w-100';
-
-    // Icon uses static SVG from Material Symbols (Apache 2.0, no user input)
-    var iconSpan = document.createElement('span');
-    iconSpan.className = 'passkey-icon me-2';
-    iconSpan.innerHTML = PASSKEY_ICON; // eslint-disable-line -- static SVG constant
-    var textSpan = document.createElement('span');
-    textSpan.id = 'passkey-btn-text';
-    textSpan.textContent = labels.signIn || 'Sign in with a passkey';
-    var loadingSpan = document.createElement('span');
-    loadingSpan.id = 'passkey-btn-loading';
-    loadingSpan.className = 'd-none';
-    var spinner = document.createElement('span');
-    spinner.className = 'spinner-border spinner-border-sm me-2';
-    spinner.setAttribute('role', 'status');
-    loadingSpan.appendChild(spinner);
-    loadingSpan.appendChild(document.createTextNode(labels.loading || 'Authenticating\u2026'));
-
-    btn.appendChild(iconSpan);
-    btn.appendChild(textSpan);
-    btn.appendChild(loadingSpan);
-    grid.appendChild(btn);
-    formGroup.appendChild(grid);
-    container.appendChild(formGroup);
-
-    // "What are passkeys?" help toggle
-    var helpContent = document.createElement('div');
-    helpContent.id = 'passkey-help-content';
-    helpContent.className = 'alert alert-light small d-none mb-2';
-    helpContent.textContent = labels.helpContent || 'Passkeys are a modern replacement for passwords. They use your device\u2019s biometric sensors (fingerprint, face) or security keys to verify your identity. They\u2019re faster and more secure than passwords because they can\u2019t be phished or stolen.';
-
-    var learnMore = document.createElement('a');
-    learnMore.href = 'https://passkeys.dev';
-    learnMore.target = '_blank';
-    learnMore.rel = 'noopener noreferrer';
-    learnMore.className = 'small d-block mt-1';
-    learnMore.textContent = labels.helpLearnMore || 'Learn more about passkeys';
-    helpContent.appendChild(document.createElement('br'));
-    helpContent.appendChild(learnMore);
-
-    var helpLink = document.createElement('a');
-    helpLink.href = '#';
-    helpLink.id = 'passkey-help-link';
-    helpLink.className = 'passkey-help-link small text-muted d-block text-center mb-2';
-    helpLink.textContent = labels.helpTitle || 'What are passkeys?';
-    helpLink.addEventListener('click', function (e) {
-      e.preventDefault();
-      helpContent.classList.toggle('d-none');
+  /**
+   * Fetch assertion options from the server. On an error response the user is
+   * informed and null is returned; otherwise the parsed options payload.
+   */
+  async function fetchAssertionOptions(username) {
+    const optionsResponse = await fetch(optionsUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ username: username }),
     });
 
-    container.appendChild(helpLink);
-    container.appendChild(helpContent);
-
-    var errorDiv = document.createElement('div');
-    errorDiv.id = 'passkey-error';
-    errorDiv.className = 'alert alert-danger d-none mb-2';
-    errorDiv.setAttribute('role', 'alert');
-    // Announce async WebAuthn errors to screen readers (A11Y-1).
-    errorDiv.setAttribute('aria-live', 'assertive');
-    errorDiv.setAttribute('aria-atomic', 'true');
-    container.appendChild(errorDiv);
-
-    var assertionInput = document.createElement('input');
-    assertionInput.type = 'hidden';
-    assertionInput.name = 'passkey_assertion';
-    assertionInput.id = 'passkey-assertion';
-    assertionInput.value = '';
-    container.appendChild(assertionInput);
-
-    var tokenInput = document.createElement('input');
-    tokenInput.type = 'hidden';
-    tokenInput.name = 'passkey_challenge_token';
-    tokenInput.id = 'passkey-challenge-token';
-    tokenInput.value = '';
-    container.appendChild(tokenInput);
-
-    return container;
-  }
-
-  // Base64URL encoding/decoding utilities
-  function base64urlToBuffer(base64url) {
-    var base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
-    var padLen = (4 - (base64.length % 4)) % 4;
-    var padded = base64 + '='.repeat(padLen);
-    var binary = atob(padded);
-    var buffer = new Uint8Array(binary.length);
-    for (var i = 0; i < binary.length; i++) {
-      buffer[i] = binary.charCodeAt(i);
+    if (optionsResponse.ok) {
+      return optionsResponse.json();
     }
-    return buffer.buffer;
-  }
 
-  function bufferToBase64url(buffer) {
-    var bytes = new Uint8Array(buffer);
-    var binary = '';
-    for (var i = 0; i < bytes.length; i++) {
-      binary += String.fromCharCode(bytes[i]);
+    const data = await optionsResponse.json().catch(function () { return {}; });
+    if (optionsResponse.status === 429) {
+      showError(data.locked
+        ? (L.errorLocked || 'Account temporarily locked. Please contact your administrator.')
+        : (L.errorRateLimit || 'Too many attempts. Please try again later.'));
+    } else {
+      showError(data.error || L.errorGeneric || 'Authentication failed. Please try again.');
     }
-    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+
+    return null;
   }
 
-  function bufferToBase64(buffer) {
-    var bytes = new Uint8Array(buffer);
-    var binary = '';
-    for (var i = 0; i < bytes.length; i++) {
-      binary += String.fromCharCode(bytes[i]);
+  /**
+   * Build the navigator.credentials.get() publicKey options from the server payload.
+   */
+  function buildPublicKeyOptions(options) {
+    const publicKeyOptions = {
+      challenge: base64urlToBuffer(options.challenge),
+      rpId: options.rpId,
+      timeout: options.timeout || 60000,
+      userVerification: options.userVerification || 'required',
+    };
+
+    if (options.allowCredentials && options.allowCredentials.length > 0) {
+      publicKeyOptions.allowCredentials = options.allowCredentials.map(function (cred) {
+        return {
+          type: cred.type,
+          id: base64urlToBuffer(cred.id),
+          transports: cred.transports || [],
+        };
+      });
     }
-    return btoa(binary);
+
+    return publicKeyOptions;
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
-  } else {
-    init();
+  /**
+   * Encode the authenticator assertion into the JSON structure the server expects.
+   */
+  function encodeAssertion(assertion) {
+    return {
+      id: bufferToBase64url(assertion.rawId),
+      rawId: bufferToBase64(assertion.rawId),
+      type: assertion.type,
+      response: {
+        clientDataJSON: bufferToBase64url(assertion.response.clientDataJSON),
+        authenticatorData: bufferToBase64url(assertion.response.authenticatorData),
+        signature: bufferToBase64url(assertion.response.signature),
+        userHandle: assertion.response.userHandle
+          ? bufferToBase64url(assertion.response.userHandle)
+          : null,
+      },
+    };
   }
-})();
+
+  /**
+   * Pack the assertion + challenge token into the standard TYPO3 login form and submit it.
+   *
+   * The assertion is passed via the userident field. TYPO3 auth services receive login
+   * data via $this->login['uident'] which maps to the userident POST field;
+   * $GLOBALS['TYPO3_REQUEST'] is not available during the auth service chain, so custom
+   * POST fields (passkey_assertion etc.) are inaccessible. Using userident is the standard
+   * TYPO3 way to pass authentication credentials.
+   */
+  function submitAssertion(credentialResponse, challengeToken, username) {
+    const passkeyPayload = JSON.stringify({
+      _type: 'passkey',
+      assertion: credentialResponse,
+      challengeToken: challengeToken,
+    });
+
+    const useridentField = document.querySelector('.t3js-login-userident-field');
+    if (useridentField) {
+      useridentField.value = passkeyPayload;
+    }
+
+    // Also keep hidden fields populated for any middleware/hook inspection
+    if (assertionField) {
+      assertionField.value = JSON.stringify(credentialResponse);
+    }
+    if (challengeTokenField) {
+      challengeTokenField.value = challengeToken;
+    }
+
+    // Ensure the username field has the value
+    if (usernameInput) {
+      usernameInput.value = username;
+    }
+
+    // Flag this as a passkey attempt so we can show a specific error
+    // if the server-side verification fails and the page reloads
+    try { sessionStorage.setItem('nr_passkey_attempt', '1'); } catch (e) { /* ignore */ }
+
+    loginForm.submit();
+  }
+
+  /**
+   * Map a navigator.credentials.get() rejection to a user-facing error message.
+   */
+  function handleAuthError(err) {
+    if (err.name === 'NotAllowedError') {
+      showError(L.errorNotAllowed || 'Authentication was cancelled or no passkey found for this site. Have you registered a passkey?');
+    } else if (err.name === 'SecurityError') {
+      showError(L.errorSecurity || 'Security error. Please check your connection.');
+    } else if (err.name === 'AbortError') {
+      showError(L.errorCancelled || 'Authentication was cancelled.');
+    } else {
+      showError(L.errorGeneric || 'Authentication failed. Please try again.');
+      console.error('Passkey login error:', err);
+    }
+  }
+
+  function setLoading(loading) {
+    if (loginBtn) loginBtn.disabled = loading;
+    if (btnText) btnText.classList.toggle('d-none', loading);
+    if (btnLoading) btnLoading.classList.toggle('d-none', !loading);
+  }
+
+  function showError(message) {
+    if (errorEl) {
+      // Make the live region visible/in the a11y tree BEFORE injecting text so
+      // the aria-live="assertive" announcement fires reliably (NVDA/JAWS/VoiceOver
+      // do not consistently announce text set on a display:none node).
+      errorEl.classList.remove('d-none');
+      errorEl.textContent = message;
+    }
+  }
+
+  function hideError() {
+    if (errorEl) {
+      errorEl.classList.add('d-none');
+      errorEl.textContent = '';
+    }
+  }
+}
+
+function buildPasskeyUI(labels) {
+  labels = labels || {};
+  const divider = document.createElement('div');
+  divider.className = 'passkey-divider mb-2 mt-2';
+  divider.setAttribute('style', 'display:flex;align-items:center;gap:8px');
+  const hrLeft = document.createElement('hr');
+  hrLeft.setAttribute('style', 'flex:1;border:none;border-top:1px solid #ccc;margin:0');
+  const orLabel = document.createElement('span');
+  orLabel.setAttribute('style', 'color:#999;font-size:12px;text-transform:uppercase;letter-spacing:1px');
+  orLabel.textContent = labels.dividerOr || 'or';
+  const hrRight = document.createElement('hr');
+  hrRight.setAttribute('style', 'flex:1;border:none;border-top:1px solid #ccc;margin:0');
+  divider.appendChild(hrLeft);
+  divider.appendChild(orLabel);
+  divider.appendChild(hrRight);
+
+  const container = document.createElement('div');
+  container.id = 'passkey-login-container';
+  container.className = 'passkey-login';
+  container.appendChild(divider);
+
+  const formGroup = document.createElement('div');
+  formGroup.className = 'form-group mb-2';
+  const grid = document.createElement('div');
+  grid.className = 'd-grid';
+  const btn = document.createElement('button');
+  btn.type = 'button';
+  btn.id = 'passkey-login-btn';
+  btn.className = 'btn btn-default btn-block w-100';
+
+  // Icon is a static SVG constant (Material Symbols, Apache 2.0, no user input).
+  // Parse it into a DOM node instead of assigning innerHTML so there is no XSS surface.
+  const iconSpan = document.createElement('span');
+  iconSpan.className = 'passkey-icon me-2';
+  const iconSvg = new DOMParser().parseFromString(PASSKEY_ICON, 'image/svg+xml').documentElement;
+  iconSpan.appendChild(document.importNode(iconSvg, true));
+  const textSpan = document.createElement('span');
+  textSpan.id = 'passkey-btn-text';
+  textSpan.textContent = labels.signIn || 'Sign in with a passkey';
+  const loadingSpan = document.createElement('span');
+  loadingSpan.id = 'passkey-btn-loading';
+  loadingSpan.className = 'd-none';
+  const spinner = document.createElement('span');
+  spinner.className = 'spinner-border spinner-border-sm me-2';
+  spinner.setAttribute('role', 'status');
+  loadingSpan.appendChild(spinner);
+  loadingSpan.appendChild(document.createTextNode(labels.loading || 'Authenticating…'));
+
+  btn.appendChild(iconSpan);
+  btn.appendChild(textSpan);
+  btn.appendChild(loadingSpan);
+  grid.appendChild(btn);
+  formGroup.appendChild(grid);
+  container.appendChild(formGroup);
+
+  // "What are passkeys?" help toggle
+  const helpContent = document.createElement('div');
+  helpContent.id = 'passkey-help-content';
+  helpContent.className = 'alert alert-light small d-none mb-2';
+  helpContent.textContent = labels.helpContent || 'Passkeys are a modern replacement for passwords. They use your device’s biometric sensors (fingerprint, face) or security keys to verify your identity. They’re faster and more secure than passwords because they can’t be phished or stolen.';
+
+  const learnMore = document.createElement('a');
+  learnMore.href = 'https://passkeys.dev';
+  learnMore.target = '_blank';
+  learnMore.rel = 'noopener noreferrer';
+  learnMore.className = 'small d-block mt-1';
+  learnMore.textContent = labels.helpLearnMore || 'Learn more about passkeys';
+  helpContent.appendChild(document.createElement('br'));
+  helpContent.appendChild(learnMore);
+
+  const helpLink = document.createElement('a');
+  helpLink.href = '#';
+  helpLink.id = 'passkey-help-link';
+  helpLink.className = 'passkey-help-link small text-muted d-block text-center mb-2';
+  helpLink.textContent = labels.helpTitle || 'What are passkeys?';
+  helpLink.addEventListener('click', function (e) {
+    e.preventDefault();
+    helpContent.classList.toggle('d-none');
+  });
+
+  container.appendChild(helpLink);
+  container.appendChild(helpContent);
+
+  const errorDiv = document.createElement('div');
+  errorDiv.id = 'passkey-error';
+  errorDiv.className = 'alert alert-danger d-none mb-2';
+  errorDiv.setAttribute('role', 'alert');
+  // Announce async WebAuthn errors to screen readers (A11Y-1).
+  errorDiv.setAttribute('aria-live', 'assertive');
+  errorDiv.setAttribute('aria-atomic', 'true');
+  container.appendChild(errorDiv);
+
+  const assertionInput = document.createElement('input');
+  assertionInput.type = 'hidden';
+  assertionInput.name = 'passkey_assertion';
+  assertionInput.id = 'passkey-assertion';
+  assertionInput.value = '';
+  container.appendChild(assertionInput);
+
+  const tokenInput = document.createElement('input');
+  tokenInput.type = 'hidden';
+  tokenInput.name = 'passkey_challenge_token';
+  tokenInput.id = 'passkey-challenge-token';
+  tokenInput.value = '';
+  container.appendChild(tokenInput);
+
+  return container;
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', init);
+} else {
+  init();
+}

--- a/Resources/Public/JavaScript/PasskeyManagement.js
+++ b/Resources/Public/JavaScript/PasskeyManagement.js
@@ -12,6 +12,7 @@ import Notification from '@typo3/backend/notification.js';
 import Modal from '@typo3/backend/modal.js';
 import { SeverityEnum } from '@typo3/backend/enum/severity.js';
 import { sudoModeInterceptor } from '@typo3/backend/security/sudo-mode-interceptor.js';
+import { base64urlToBuffer, bufferToBase64url, bufferToBase64 } from '@netresearch/nr-passkeys-be/Util/Base64.js';
 
 class PasskeyManagement {
   constructor() {
@@ -187,13 +188,13 @@ class PasskeyManagement {
 
       // Step 2: Create credential with browser
       const publicKeyOptions = {
-        challenge: this.base64urlToBuffer(options.challenge),
+        challenge: base64urlToBuffer(options.challenge),
         rp: {
           name: options.rp.name,
           id: options.rp.id,
         },
         user: {
-          id: this.base64urlToBuffer(options.user.id),
+          id: base64urlToBuffer(options.user.id),
           name: options.user.name,
           displayName: options.user.displayName,
         },
@@ -206,7 +207,7 @@ class PasskeyManagement {
       if (options.excludeCredentials) {
         publicKeyOptions.excludeCredentials = options.excludeCredentials.map((cred) => ({
           type: cred.type,
-          id: this.base64urlToBuffer(cred.id),
+          id: base64urlToBuffer(cred.id),
           transports: cred.transports || [],
         }));
       }
@@ -215,12 +216,12 @@ class PasskeyManagement {
 
       // Step 3: Encode and send to server (sudo mode protected)
       const credentialResponse = {
-        id: this.bufferToBase64url(credential.rawId),
-        rawId: this.bufferToBase64(credential.rawId),
+        id: bufferToBase64url(credential.rawId),
+        rawId: bufferToBase64(credential.rawId),
         type: credential.type,
         response: {
-          clientDataJSON: this.bufferToBase64url(credential.response.clientDataJSON),
-          attestationObject: this.bufferToBase64url(credential.response.attestationObject),
+          clientDataJSON: bufferToBase64url(credential.response.clientDataJSON),
+          attestationObject: bufferToBase64url(credential.response.attestationObject),
         },
       };
 
@@ -442,37 +443,6 @@ class PasskeyManagement {
       return error.message;
     }
     return fallback;
-  }
-
-  // Base64URL utilities
-  base64urlToBuffer(base64url) {
-    const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
-    const padLen = (4 - (base64.length % 4)) % 4;
-    const padded = base64 + '='.repeat(padLen);
-    const binary = atob(padded);
-    const buffer = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) {
-      buffer[i] = binary.charCodeAt(i);
-    }
-    return buffer.buffer;
-  }
-
-  bufferToBase64url(buffer) {
-    const bytes = new Uint8Array(buffer);
-    let binary = '';
-    for (let i = 0; i < bytes.length; i++) {
-      binary += String.fromCharCode(bytes[i]);
-    }
-    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-  }
-
-  bufferToBase64(buffer) {
-    const bytes = new Uint8Array(buffer);
-    let binary = '';
-    for (let i = 0; i < bytes.length; i++) {
-      binary += String.fromCharCode(bytes[i]);
-    }
-    return btoa(binary);
   }
 }
 

--- a/Resources/Public/JavaScript/Util/Base64.js
+++ b/Resources/Public/JavaScript/Util/Base64.js
@@ -1,0 +1,54 @@
+/**
+ * Base64URL / Base64 helpers for the WebAuthn ceremonies.
+ *
+ * Shared by PasskeyLogin.js and PasskeyManagement.js so the encoding/decoding
+ * is implemented (and unit-tested) exactly once.
+ */
+
+/**
+ * Decode a base64url string into an ArrayBuffer.
+ *
+ * @param {string} base64url
+ * @returns {ArrayBuffer}
+ */
+export function base64urlToBuffer(base64url) {
+  const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
+  const padLen = (4 - (base64.length % 4)) % 4;
+  const padded = base64 + '='.repeat(padLen);
+  const binary = atob(padded);
+  const buffer = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    buffer[i] = binary.charCodeAt(i);
+  }
+  return buffer.buffer;
+}
+
+/**
+ * Encode an ArrayBuffer as a (padding-stripped) base64url string.
+ *
+ * @param {ArrayBuffer} buffer
+ * @returns {string}
+ */
+export function bufferToBase64url(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+/**
+ * Encode an ArrayBuffer as a standard base64 string (with padding).
+ *
+ * @param {ArrayBuffer} buffer
+ * @returns {string}
+ */
+export function bufferToBase64(buffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}

--- a/Tests/JavaScript/PasskeyLogin.test.js
+++ b/Tests/JavaScript/PasskeyLogin.test.js
@@ -1,43 +1,12 @@
 /**
- * Unit tests for PasskeyLogin.js base64url encoding/decoding utilities.
+ * Unit tests for the passkey login WebAuthn base64 helpers.
  *
- * The IIFE in PasskeyLogin.js cannot be imported directly, so we test
- * the utility function logic independently. IIFE behavior (DOM interaction,
- * WebAuthn checks) is tested via Playwright E2E tests.
+ * These import the SHIPPED helpers from Util/Base64.js — the exact code the login
+ * module (PasskeyLogin.js) runs — so the tests exercise the real implementation, not
+ * a copy. Full DOM/WebAuthn behaviour is covered by the Playwright E2E tests.
  */
 import { describe, it, expect } from 'vitest';
-
-// --- Extracted utility functions (same logic as PasskeyLogin.js) ---
-
-function base64urlToBuffer(base64url) {
-    const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
-    const padLen = (4 - (base64.length % 4)) % 4;
-    const padded = base64 + '='.repeat(padLen);
-    const binary = atob(padded);
-    const buffer = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) {
-        buffer[i] = binary.charCodeAt(i);
-    }
-    return buffer.buffer;
-}
-
-function bufferToBase64url(buffer) {
-    const bytes = new Uint8Array(buffer);
-    let binary = '';
-    for (let i = 0; i < bytes.length; i++) {
-        binary += String.fromCharCode(bytes[i]);
-    }
-    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-}
-
-function bufferToBase64(buffer) {
-    const bytes = new Uint8Array(buffer);
-    let binary = '';
-    for (let i = 0; i < bytes.length; i++) {
-        binary += String.fromCharCode(bytes[i]);
-    }
-    return btoa(binary);
-}
+import { base64urlToBuffer, bufferToBase64url, bufferToBase64 } from '../../Resources/Public/JavaScript/Util/Base64.js';
 
 // --- Tests ---
 

--- a/Tests/JavaScript/PasskeyManagement.test.js
+++ b/Tests/JavaScript/PasskeyManagement.test.js
@@ -1,42 +1,12 @@
 /**
- * Unit tests for PasskeyManagement.js utility functions.
+ * Unit tests for the passkey management WebAuthn base64 helpers + formatTimestamp.
  *
- * Tests the extracted utility function logic. IIFE behavior and DOM
- * interaction is tested via Playwright E2E tests.
+ * The base64 helpers are imported from the SHIPPED Util/Base64.js — the exact code
+ * PasskeyManagement.js runs — so the tests exercise the real implementation, not a copy.
+ * Full DOM behaviour is covered by the Playwright E2E tests.
  */
 import { describe, it, expect } from 'vitest';
-
-// --- Extracted utility functions (same logic as PasskeyManagement.js) ---
-
-function base64urlToBuffer(base64url) {
-    const base64 = base64url.replace(/-/g, '+').replace(/_/g, '/');
-    const padLen = (4 - (base64.length % 4)) % 4;
-    const padded = base64 + '='.repeat(padLen);
-    const binary = atob(padded);
-    const buffer = new Uint8Array(binary.length);
-    for (let i = 0; i < binary.length; i++) {
-        buffer[i] = binary.charCodeAt(i);
-    }
-    return buffer.buffer;
-}
-
-function bufferToBase64url(buffer) {
-    const bytes = new Uint8Array(buffer);
-    let binary = '';
-    for (let i = 0; i < bytes.length; i++) {
-        binary += String.fromCharCode(bytes[i]);
-    }
-    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
-}
-
-function bufferToBase64(buffer) {
-    const bytes = new Uint8Array(buffer);
-    let binary = '';
-    for (let i = 0; i < bytes.length; i++) {
-        binary += String.fromCharCode(bytes[i]);
-    }
-    return btoa(binary);
-}
+import { base64urlToBuffer, bufferToBase64url, bufferToBase64 } from '../../Resources/Public/JavaScript/Util/Base64.js';
 
 function formatTimestamp(ts) {
     if (!ts) return '-';

--- a/Tests/Unit/EventListener/InjectPasskeyLoginFieldsTest.php
+++ b/Tests/Unit/EventListener/InjectPasskeyLoginFieldsTest.php
@@ -119,21 +119,14 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
     }
 
     #[Test]
-    public function invokeAddsJavaScriptFile(): void
+    public function invokeLoadsJavaScriptModule(): void
     {
         $this->setUpConfigService();
 
         $this->pageRenderer
             ->expects(self::once())
-            ->method('addJsFile')
-            ->with(
-                'EXT:nr_passkeys_be/Resources/Public/JavaScript/PasskeyLogin.js',
-                'text/javascript',
-                false,
-                false,
-                '',
-                true,
-            );
+            ->method('loadJavaScriptModule')
+            ->with('@netresearch/nr-passkeys-be/PasskeyLogin.js');
 
         $this->pageRenderer
             ->method('addJsInlineCode');
@@ -151,7 +144,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
         );
 
         $this->pageRenderer
-            ->method('addJsFile');
+            ->method('loadJavaScriptModule');
 
         $this->pageRenderer
             ->expects(self::once())
@@ -183,7 +176,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
     {
         $this->setUpConfigService();
 
-        $this->pageRenderer->method('addJsFile');
+        $this->pageRenderer->method('loadJavaScriptModule');
 
         $this->pageRenderer
             ->expects(self::once())
@@ -215,7 +208,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
     {
         $this->setUpConfigService(rpId: 'fallback.example.com');
 
-        $this->pageRenderer->method('addJsFile');
+        $this->pageRenderer->method('loadJavaScriptModule');
 
         $this->pageRenderer
             ->expects(self::once())
@@ -239,7 +232,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
     {
         $this->setUpConfigService(origin: 'https://custom-origin.example.com');
 
-        $this->pageRenderer->method('addJsFile');
+        $this->pageRenderer->method('loadJavaScriptModule');
 
         $this->pageRenderer
             ->expects(self::once())
@@ -263,7 +256,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
     {
         $this->setUpConfigService(discoverableEnabled: false);
 
-        $this->pageRenderer->method('addJsFile');
+        $this->pageRenderer->method('loadJavaScriptModule');
 
         $this->pageRenderer
             ->expects(self::once())
@@ -287,7 +280,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
     {
         $this->setUpConfigService();
 
-        $this->pageRenderer->method('addJsFile');
+        $this->pageRenderer->method('loadJavaScriptModule');
 
         $this->pageRenderer
             ->expects(self::once())
@@ -314,7 +307,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
         // The injected PageRenderer should receive the calls
         $this->pageRenderer
             ->expects(self::once())
-            ->method('addJsFile');
+            ->method('loadJavaScriptModule');
 
         $this->pageRenderer
             ->expects(self::once())


### PR DESCRIPTION
TEST-1 from the review (tracked in #73). The JS unit tests exercised re-implemented **copies** of the base64 helpers, not the shipped code.

## Change

- **`Util/Base64.js`** — single shared module with `base64urlToBuffer` / `bufferToBase64url` / `bufferToBase64`, imported by both passkey modules **and** by the unit tests, so the tests now cover the real implementation.
- **`PasskeyManagement.js`** (already an ES module) imports the shared helpers; its inline copies are removed.
- **`PasskeyLogin.js`** is converted from a classic IIFE to an ES module so it can import them, and is now loaded via `loadJavaScriptModule` (the login screen ships the importmap).

### Clearing the SonarCloud gate that blocked the first attempt
The earlier attempt was reverted because the IIFE→module conversion re-attributed the whole login file as "new code" and tripped a 62-smell maintainability gate. This addresses all of it:
- every `var` → `const`
- `handlePasskeyLogin` cognitive complexity reduced by extracting `fetchAssertionOptions` / `buildPublicKeyOptions` / `encodeAssertion` / `submitAssertion` / `handleAuthError`
- the button icon is built via `DOMParser` instead of `innerHTML` (removes the XSS hotspot too)

## Verification

Verified on a live TYPO3 v13.4 backend: the module loads **pre-auth**, renders the button + icon, the shared-util import resolves, the click handler runs (username-required path shown via the aria-live region), zero console errors. Locally: 63 JS tests pass against the real `Util/Base64.js`, PHPStan L10 + CGL clean, `InjectPasskeyLoginFields` unit test green. CI runs e2e (full login ceremony) + SonarCloud (maintainability gate).

Closes TEST-1 in #73.