### PR TITLE
fix(auth): enforce discoverableLoginEnabled on the auth-service login path

### DIFF
--- a/Classes/Authentication/PasskeyAuthenticationService.php
+++ b/Classes/Authentication/PasskeyAuthenticationService.php
@@ -73,6 +73,16 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
         ]);
 
         if ($username === '') {
+            // Discoverable login is an operator-gated feature. Enforce the flag on the
+            // path that establishes a session, not only on challenge issuance
+            // (LoginController::optionsAction). A challenge token carries no mode binding,
+            // so a token from the username-first flow must not be replayable through the
+            // discoverable code path when the operator disabled it.
+            if (!$this->getExtensionConfigService()->getConfiguration()->isDiscoverableLoginEnabled()) {
+                $this->getLogger()->info('Discoverable login attempted while disabled');
+                return false;
+            }
+
             // Discoverable login: resolve user from credential ID in the assertion
             $beUserUid = $this->getWebAuthnService()->findBeUserUidFromAssertion($payload['assertion']);
             if ($beUserUid === null) {

--- a/Tests/Unit/Authentication/PasskeyAuthenticationServiceTest.php
+++ b/Tests/Unit/Authentication/PasskeyAuthenticationServiceTest.php
@@ -918,6 +918,30 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     }
 
     #[Test]
+    public function getUserWithEmptyUsernameReturnsFalseWhenDiscoverableLoginDisabled(): void
+    {
+        GeneralUtility::purgeInstances();
+
+        $configServiceDisabled = $this->createMock(ExtensionConfigurationService::class);
+        $configServiceDisabled
+            ->method('getConfiguration')
+            ->willReturn(new ExtensionConfiguration(discoverableLoginEnabled: false));
+        GeneralUtility::addInstance(ExtensionConfigurationService::class, $configServiceDisabled);
+
+        $this->subject->login = [
+            'uname' => '',
+            'uident' => self::buildPasskeyUident(['assertion' => 'data'], 'token-123'),
+        ];
+
+        // Policy gate must short-circuit before any credential resolution.
+        $this->webAuthnService
+            ->expects(self::never())
+            ->method('findBeUserUidFromAssertion');
+
+        self::assertFalse($this->subject->getUser());
+    }
+
+    #[Test]
     public function getUserWithEmptyUsernameResolvesUserFromCredential(): void
     {
         $this->subject->login = [


### PR DESCRIPTION
## Summary

`discoverableLoginEnabled` was enforced only at challenge issuance (`LoginController::optionsAction`), not on the auth-service path that establishes the session. Because a challenge token carries no mode binding, a username-first token could otherwise drive the discoverable code path even when an operator disabled the feature. `getUser()` now refuses the discoverable branch when the flag is off.

A valid signature was always still required, so this is policy enforcement, not an auth bypass.

## Reconcile note

Rebased onto current `main`. The lockout-keying change originally bundled in this PR was **dropped**: main's `ca2180a` already addresses the lockout DoS via `recordFailure(countUserLockout: false)`. This PR is now scoped to the discoverable-flag enforcement only.

## Validation
PHPStan level 10, full unit suite, and CGL all green locally.