### PR TITLE
fix(admin): enforce system-maintainer boundary on passkey admin API

### DIFF
--- a/Classes/Controller/AdminController.php
+++ b/Classes/Controller/AdminController.php
@@ -303,6 +303,10 @@ final class AdminController
             return new JsonResponse(['error' => 'Missing required fields'], 400);
         }
 
+        if (!$this->isManagementAllowedFor($beUserUid)) {
+            return new JsonResponse(['error' => 'Insufficient privileges to manage this user'], 403);
+        }
+
         // Verify the user exists and is active
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable('be_users');
         $queryBuilder->getRestrictions()->removeAll();
@@ -367,6 +371,10 @@ final class AdminController
 
         if ($beUserUid === 0) {
             return new JsonResponse(['error' => 'Missing required fields'], 400);
+        }
+
+        if (!$this->isManagementAllowedFor($beUserUid)) {
+            return new JsonResponse(['error' => 'Insufficient privileges to manage this user'], 403);
         }
 
         // Verify the user exists and is active

--- a/Classes/Controller/AdminController.php
+++ b/Classes/Controller/AdminController.php
@@ -32,6 +32,8 @@ final class AdminController
 
     private const NUDGE_DURATION_DAYS = 14;
 
+    private const ERROR_INSUFFICIENT_PRIVILEGES = 'Insufficient privileges to manage this user';
+
     public function __construct(
         private readonly CredentialRepository $credentialRepository,
         private readonly RateLimiterService $rateLimiterService,
@@ -60,7 +62,7 @@ final class AdminController
         }
 
         if (!$this->isManagementAllowedFor($beUserUid)) {
-            return new JsonResponse(['error' => 'Insufficient privileges to manage this user'], 403);
+            return new JsonResponse(['error' => self::ERROR_INSUFFICIENT_PRIVILEGES], 403);
         }
 
         $credentials = $this->credentialRepository->findAllByBeUser($beUserUid);
@@ -100,7 +102,7 @@ final class AdminController
         }
 
         if (!$this->isManagementAllowedFor($beUserUid)) {
-            return new JsonResponse(['error' => 'Insufficient privileges to manage this user'], 403);
+            return new JsonResponse(['error' => self::ERROR_INSUFFICIENT_PRIVILEGES], 403);
         }
 
         // Verify the credential belongs to the specified user
@@ -144,7 +146,7 @@ final class AdminController
         }
 
         if (!$this->isManagementAllowedFor($beUserUid)) {
-            return new JsonResponse(['error' => 'Insufficient privileges to manage this user'], 403);
+            return new JsonResponse(['error' => self::ERROR_INSUFFICIENT_PRIVILEGES], 403);
         }
 
         // Validate that beUserUid matches the given username to ensure audit log integrity
@@ -193,7 +195,7 @@ final class AdminController
         }
 
         if (!$this->isManagementAllowedFor($beUserUid)) {
-            return new JsonResponse(['error' => 'Insufficient privileges to manage this user'], 403);
+            return new JsonResponse(['error' => self::ERROR_INSUFFICIENT_PRIVILEGES], 403);
         }
 
         $credentials = $this->credentialRepository->findAllByBeUser($beUserUid);
@@ -304,7 +306,7 @@ final class AdminController
         }
 
         if (!$this->isManagementAllowedFor($beUserUid)) {
-            return new JsonResponse(['error' => 'Insufficient privileges to manage this user'], 403);
+            return new JsonResponse(['error' => self::ERROR_INSUFFICIENT_PRIVILEGES], 403);
         }
 
         // Verify the user exists and is active
@@ -374,7 +376,7 @@ final class AdminController
         }
 
         if (!$this->isManagementAllowedFor($beUserUid)) {
-            return new JsonResponse(['error' => 'Insufficient privileges to manage this user'], 403);
+            return new JsonResponse(['error' => self::ERROR_INSUFFICIENT_PRIVILEGES], 403);
         }
 
         // Verify the user exists and is active

--- a/Classes/Controller/AdminController.php
+++ b/Classes/Controller/AdminController.php
@@ -59,6 +59,10 @@ final class AdminController
             return new JsonResponse(['error' => 'Missing beUserUid parameter'], 400);
         }
 
+        if (!$this->isManagementAllowedFor($beUserUid)) {
+            return new JsonResponse(['error' => 'Insufficient privileges to manage this user'], 403);
+        }
+
         $credentials = $this->credentialRepository->findAllByBeUser($beUserUid);
         $list = \array_map(
             static fn($cred) => $cred->toAdminCredentialInfo(),
@@ -93,6 +97,10 @@ final class AdminController
 
         if ($beUserUid === 0 || $credentialUid === 0) {
             return new JsonResponse(['error' => 'Missing required fields'], 400);
+        }
+
+        if (!$this->isManagementAllowedFor($beUserUid)) {
+            return new JsonResponse(['error' => 'Insufficient privileges to manage this user'], 403);
         }
 
         // Verify the credential belongs to the specified user
@@ -133,6 +141,10 @@ final class AdminController
 
         if ($beUserUid === 0 || $username === '') {
             return new JsonResponse(['error' => 'Missing required fields'], 400);
+        }
+
+        if (!$this->isManagementAllowedFor($beUserUid)) {
+            return new JsonResponse(['error' => 'Insufficient privileges to manage this user'], 403);
         }
 
         // Validate that beUserUid matches the given username to ensure audit log integrity
@@ -178,6 +190,10 @@ final class AdminController
 
         if ($beUserUid === 0) {
             return new JsonResponse(['error' => 'Missing required fields'], 400);
+        }
+
+        if (!$this->isManagementAllowedFor($beUserUid)) {
+            return new JsonResponse(['error' => 'Insufficient privileges to manage this user'], 403);
         }
 
         $credentials = $this->credentialRepository->findAllByBeUser($beUserUid);

--- a/Classes/Controller/BackendUserTrait.php
+++ b/Classes/Controller/BackendUserTrait.php
@@ -89,7 +89,13 @@ trait BackendUserTrait
             return true;
         }
 
-        $systemMaintainerIds = \array_map('\intval', $systemMaintainers);
+        $systemMaintainerIds = [];
+        foreach ($systemMaintainers as $maintainer) {
+            if (\is_numeric($maintainer)) {
+                $systemMaintainerIds[] = (int) $maintainer;
+            }
+        }
+
         if (!\in_array($targetUid, $systemMaintainerIds, true)) {
             return true;
         }

--- a/Classes/Controller/BackendUserTrait.php
+++ b/Classes/Controller/BackendUserTrait.php
@@ -67,4 +67,33 @@ trait BackendUserTrait
 
         return $user;
     }
+
+    /**
+     * Whether the current admin may manage the given target backend user's passkeys.
+     *
+     * Mirrors the system-maintainer boundary enforced in the FormEngine UI
+     * (PasskeyInfoElement): only a system maintainer may manage another system
+     * maintainer's security settings. Any non-maintainer target is allowed.
+     */
+    private function isManagementAllowedFor(int $targetUid): bool
+    {
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+        if (!$backendUser instanceof BackendUserAuthentication) {
+            return false;
+        }
+
+        $typo3Conf = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $sysConf = \is_array($typo3Conf) ? ($typo3Conf['SYS'] ?? null) : null;
+        $systemMaintainers = \is_array($sysConf) ? ($sysConf['systemMaintainers'] ?? []) : [];
+        if (!\is_array($systemMaintainers) || $systemMaintainers === []) {
+            return true;
+        }
+
+        $systemMaintainerIds = \array_map('\intval', $systemMaintainers);
+        if (!\in_array($targetUid, $systemMaintainerIds, true)) {
+            return true;
+        }
+
+        return $backendUser->isSystemMaintainer();
+    }
 }

--- a/Tests/Unit/Controller/AdminControllerTest.php
+++ b/Tests/Unit/Controller/AdminControllerTest.php
@@ -56,7 +56,7 @@ final class AdminControllerTest extends TestCase
 
     protected function tearDown(): void
     {
-        unset($GLOBALS['BE_USER']);
+        unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers']);
         parent::tearDown();
     }
 
@@ -171,6 +171,72 @@ final class AdminControllerTest extends TestCase
     }
 
     #[Test]
+    public function removeActionDeniedWhenNonMaintainerTargetsSystemMaintainer(): void
+    {
+        $this->setUpAdminUser(1, 'admin');
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+
+        $request = $this->createJsonRequest([
+            'beUserUid' => 99,
+            'credentialUid' => 5,
+        ]);
+
+        $this->credentialRepository->expects(self::never())->method('findByUidAndBeUser');
+        $this->credentialRepository->expects(self::never())->method('revoke');
+
+        $response = $this->subject->removeAction($request);
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertSame(
+            'Insufficient privileges to manage this user',
+            $this->decodeResponse($response)['error'],
+        );
+    }
+
+    #[Test]
+    public function listActionDeniedWhenNonMaintainerTargetsSystemMaintainer(): void
+    {
+        $this->setUpAdminUser(1, 'admin');
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn(['beUserUid' => 99]);
+
+        $this->credentialRepository->expects(self::never())->method('findAllByBeUser');
+
+        $response = $this->subject->listAction($request);
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function removeActionAllowedWhenSystemMaintainerTargetsSystemMaintainer(): void
+    {
+        $this->setUpAdminUser(1, 'superadmin', isSystemMaintainer: true);
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+
+        $request = $this->createJsonRequest([
+            'beUserUid' => 99,
+            'credentialUid' => 5,
+        ]);
+
+        $cred = new Credential(uid: 5, beUser: 99, label: 'Key');
+        $this->credentialRepository
+            ->expects(self::once())
+            ->method('findByUidAndBeUser')
+            ->with(5, 99)
+            ->willReturn($cred);
+        $this->credentialRepository
+            ->expects(self::once())
+            ->method('revoke')
+            ->with(5, 1);
+
+        $response = $this->subject->removeAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
     public function removeActionCredentialNotFound(): void
     {
         $this->setUpAdminUser(1, 'superadmin');
@@ -277,7 +343,7 @@ final class AdminControllerTest extends TestCase
     /**
      * Set up GLOBALS['BE_USER'] as an admin user.
      */
-    private function setUpAdminUser(int $uid, string $username): void
+    private function setUpAdminUser(int $uid, string $username, bool $isSystemMaintainer = false): void
     {
         $backendUser = $this->createMock(\TYPO3\CMS\Core\Authentication\BackendUserAuthentication::class);
         $backendUser->user = [
@@ -286,6 +352,7 @@ final class AdminControllerTest extends TestCase
             'admin' => 1,
         ];
         $backendUser->method('isAdmin')->willReturn(true);
+        $backendUser->method('isSystemMaintainer')->willReturn($isSystemMaintainer);
         $GLOBALS['BE_USER'] = $backendUser;
     }
 

--- a/Tests/Unit/Controller/AdminControllerTest.php
+++ b/Tests/Unit/Controller/AdminControllerTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
@@ -173,8 +174,7 @@ final class AdminControllerTest extends TestCase
     #[Test]
     public function removeActionDeniedWhenNonMaintainerTargetsSystemMaintainer(): void
     {
-        $this->setUpAdminUser(1, 'admin');
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+        $this->setUpNonMaintainerAdminTargetingMaintainer();
 
         $request = $this->createJsonRequest([
             'beUserUid' => 99,
@@ -186,18 +186,13 @@ final class AdminControllerTest extends TestCase
 
         $response = $this->subject->removeAction($request);
 
-        self::assertSame(403, $response->getStatusCode());
-        self::assertSame(
-            'Insufficient privileges to manage this user',
-            $this->decodeResponse($response)['error'],
-        );
+        $this->assertManagementDenied($response);
     }
 
     #[Test]
     public function listActionDeniedWhenNonMaintainerTargetsSystemMaintainer(): void
     {
-        $this->setUpAdminUser(1, 'admin');
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+        $this->setUpNonMaintainerAdminTargetingMaintainer();
 
         $request = $this->createMock(ServerRequestInterface::class);
         $request->method('getQueryParams')->willReturn(['beUserUid' => 99]);
@@ -239,8 +234,7 @@ final class AdminControllerTest extends TestCase
     #[Test]
     public function unlockActionDeniedWhenNonMaintainerTargetsSystemMaintainer(): void
     {
-        $this->setUpAdminUser(1, 'admin');
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+        $this->setUpNonMaintainerAdminTargetingMaintainer();
 
         $request = $this->createJsonRequest([
             'beUserUid' => 99,
@@ -251,18 +245,13 @@ final class AdminControllerTest extends TestCase
 
         $response = $this->subject->unlockAction($request);
 
-        self::assertSame(403, $response->getStatusCode());
-        self::assertSame(
-            'Insufficient privileges to manage this user',
-            $this->decodeResponse($response)['error'],
-        );
+        $this->assertManagementDenied($response);
     }
 
     #[Test]
     public function revokeAllActionDeniedWhenNonMaintainerTargetsSystemMaintainer(): void
     {
-        $this->setUpAdminUser(1, 'admin');
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+        $this->setUpNonMaintainerAdminTargetingMaintainer();
 
         $request = $this->createJsonRequest(['beUserUid' => 99]);
 
@@ -277,8 +266,7 @@ final class AdminControllerTest extends TestCase
     #[Test]
     public function sendReminderActionDeniedWhenNonMaintainerTargetsSystemMaintainer(): void
     {
-        $this->setUpAdminUser(1, 'admin');
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+        $this->setUpNonMaintainerAdminTargetingMaintainer();
 
         $request = $this->createJsonRequest(['beUserUid' => 99]);
 
@@ -287,18 +275,13 @@ final class AdminControllerTest extends TestCase
 
         $response = $this->subject->sendReminderAction($request);
 
-        self::assertSame(403, $response->getStatusCode());
-        self::assertSame(
-            'Insufficient privileges to manage this user',
-            $this->decodeResponse($response)['error'],
-        );
+        $this->assertManagementDenied($response);
     }
 
     #[Test]
     public function clearNudgeActionDeniedWhenNonMaintainerTargetsSystemMaintainer(): void
     {
-        $this->setUpAdminUser(1, 'admin');
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+        $this->setUpNonMaintainerAdminTargetingMaintainer();
 
         $request = $this->createJsonRequest(['beUserUid' => 99]);
 
@@ -313,8 +296,7 @@ final class AdminControllerTest extends TestCase
     public function removeActionAllowedForNonMaintainerTargetWhenMaintainerListSet(): void
     {
         // A non-empty systemMaintainers list must not block managing a NON-maintainer.
-        $this->setUpAdminUser(1, 'admin');
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+        $this->setUpNonMaintainerAdminTargetingMaintainer();
 
         $request = $this->createJsonRequest([
             'beUserUid' => 42,
@@ -452,6 +434,27 @@ final class AdminControllerTest extends TestCase
         $backendUser->method('isAdmin')->willReturn(true);
         $backendUser->method('isSystemMaintainer')->willReturn($isSystemMaintainer);
         $GLOBALS['BE_USER'] = $backendUser;
+    }
+
+    /**
+     * Authenticate as a plain (non-maintainer) admin and mark $maintainerUid a system maintainer.
+     */
+    private function setUpNonMaintainerAdminTargetingMaintainer(int $maintainerUid = 99): void
+    {
+        $this->setUpAdminUser(1, 'admin');
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [$maintainerUid];
+    }
+
+    /**
+     * Assert a 403 "insufficient privileges" management-denied response.
+     */
+    private function assertManagementDenied(ResponseInterface $response): void
+    {
+        self::assertSame(403, $response->getStatusCode());
+        self::assertSame(
+            'Insufficient privileges to manage this user',
+            $this->decodeResponse($response)['error'],
+        );
     }
 
     /**

--- a/Tests/Unit/Controller/AdminControllerTest.php
+++ b/Tests/Unit/Controller/AdminControllerTest.php
@@ -237,6 +237,104 @@ final class AdminControllerTest extends TestCase
     }
 
     #[Test]
+    public function unlockActionDeniedWhenNonMaintainerTargetsSystemMaintainer(): void
+    {
+        $this->setUpAdminUser(1, 'admin');
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+
+        $request = $this->createJsonRequest([
+            'beUserUid' => 99,
+            'username' => 'maintainer',
+        ]);
+
+        $this->rateLimiterService->expects(self::never())->method('resetLockout');
+
+        $response = $this->subject->unlockAction($request);
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertSame(
+            'Insufficient privileges to manage this user',
+            $this->decodeResponse($response)['error'],
+        );
+    }
+
+    #[Test]
+    public function revokeAllActionDeniedWhenNonMaintainerTargetsSystemMaintainer(): void
+    {
+        $this->setUpAdminUser(1, 'admin');
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+
+        $request = $this->createJsonRequest(['beUserUid' => 99]);
+
+        $this->credentialRepository->expects(self::never())->method('findAllByBeUser');
+        $this->credentialRepository->expects(self::never())->method('revoke');
+
+        $response = $this->subject->revokeAllAction($request);
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function sendReminderActionDeniedWhenNonMaintainerTargetsSystemMaintainer(): void
+    {
+        $this->setUpAdminUser(1, 'admin');
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+
+        $request = $this->createJsonRequest(['beUserUid' => 99]);
+
+        // The guard returns before any DB access.
+        $this->connectionPool->expects(self::never())->method('getConnectionForTable');
+
+        $response = $this->subject->sendReminderAction($request);
+
+        self::assertSame(403, $response->getStatusCode());
+        self::assertSame(
+            'Insufficient privileges to manage this user',
+            $this->decodeResponse($response)['error'],
+        );
+    }
+
+    #[Test]
+    public function clearNudgeActionDeniedWhenNonMaintainerTargetsSystemMaintainer(): void
+    {
+        $this->setUpAdminUser(1, 'admin');
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+
+        $request = $this->createJsonRequest(['beUserUid' => 99]);
+
+        $this->connectionPool->expects(self::never())->method('getConnectionForTable');
+
+        $response = $this->subject->clearNudgeAction($request);
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function removeActionAllowedForNonMaintainerTargetWhenMaintainerListSet(): void
+    {
+        // A non-empty systemMaintainers list must not block managing a NON-maintainer.
+        $this->setUpAdminUser(1, 'admin');
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemMaintainers'] = [99];
+
+        $request = $this->createJsonRequest([
+            'beUserUid' => 42,
+            'credentialUid' => 5,
+        ]);
+
+        $cred = new Credential(uid: 5, beUser: 42, label: 'Key');
+        $this->credentialRepository
+            ->expects(self::once())
+            ->method('findByUidAndBeUser')
+            ->with(5, 42)
+            ->willReturn($cred);
+        $this->credentialRepository->expects(self::once())->method('revoke')->with(5, 1);
+
+        $response = $this->subject->removeAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
     public function removeActionCredentialNotFound(): void
     {
         $this->setUpAdminUser(1, 'superadmin');


### PR DESCRIPTION
## Summary

The system-maintainer privilege boundary — in TYPO3 only system maintainers may manage other admins/maintainers — was enforced **only in the FormEngine UI element** (`PasskeyInfoElement`), which hides the revoke/unlock buttons. The admin AJAX endpoints enforced just `isAdmin()`:

- `listAction`, `removeAction`, `unlockAction`, `revokeAllAction`

so any backend admin could call them directly against a system maintainer's UID and read, revoke, or reset that maintainer's passkeys / lockout — a missing server-side authorization gate behind a UI-only control.

## Change

- Adds `isManagementAllowedFor(int $targetUid)` to `BackendUserTrait`, mirroring the `systemMaintainers` check already used in the UI element.
- Applies it server-side in all four user-targeted admin actions: a non-maintainer admin targeting a system maintainer now gets `403`. Non-maintainer targets and system-maintainer callers are unaffected.

## Test plan
- New unit tests: denied (non-maintainer → maintainer) on `removeAction` and `listAction`, and allowed (maintainer → maintainer) on `removeAction`.
- Local `make test-unit`: **573 passed**; `phpstan` (1G): no errors; `cgl`: clean.
