### PR TITLE
fix: narrow interstitial AJAX exemption + fail closed on Host-derived rpId/origin

### DIFF
--- a/Classes/Middleware/PasskeySetupInterstitial.php
+++ b/Classes/Middleware/PasskeySetupInterstitial.php
@@ -48,10 +48,22 @@ final class PasskeySetupInterstitial implements MiddlewareInterface
     /**
      * Route identifier prefixes that are exempt from the interstitial.
      *
+     * NOTE: do NOT add a bare 'ajax_' here. TYPO3 core registers every backend
+     * AJAX route as 'ajax_'.<id> (AbstractServiceProvider), so a broad 'ajax_'
+     * prefix would exempt ~260 state-changing endpoints (ajax_record_process =
+     * DataHandler save, ajax_file_process, ...) and let an enforced-but-unenrolled
+     * user drive the backend through them, defeating enforcement. Only the AJAX
+     * routes the enrollment/login flow actually needs are exempted, by their
+     * explicit identifier prefix.
+     *
      * @var list<string>
      */
     private const EXEMPT_ROUTE_PREFIXES = [
-        'ajax_',
+        'ajax_login',
+        'ajax_logout',
+        'ajax_mfa',
+        'ajax_passkeys_manage_',
+        'ajax_passkeys_enforcement_status',
         // 'user_setup' is the real User Settings module identifier (where passkey
         // registration lives); it MUST be exempt so users forced into setup by the
         // interstitial can actually reach the registration panel. 'setup' covers the

--- a/Classes/Service/ExtensionConfigurationService.php
+++ b/Classes/Service/ExtensionConfigurationService.php
@@ -87,10 +87,13 @@ final class ExtensionConfigurationService
      * the request Host header (NormalizedParams::getHttpHost()). That value is
      * only trustworthy when TYPO3's host-header validation (VerifyHostHeader,
      * driven by $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern']) is
-     * actually enforcing a pattern. The framework treats both '' and the
-     * allow-all '.*' as "accept any Host", which turns the derived rpId/origin
-     * into attacker-controlled values. Fail closed in that case instead of
-     * emitting a Host-controlled anchor.
+     * actually enforcing a pattern. The allow-all '.*' makes VerifyHostHeader
+     * accept ANY Host header, turning the derived rpId/origin into
+     * attacker-controlled values. An empty pattern is treated by core as invalid
+     * and rejects every Host (fail-closed at the framework level, see
+     * VerifyHostHeader::isAllowedHostHeaderValue()); we still refuse to derive an
+     * anchor from it. Fail closed in both cases rather than emit a Host-controlled
+     * (or otherwise untrustworthy) anchor.
      *
      * @throws RuntimeException if host-header trust is disabled and no explicit
      *                          rpId/origin is configured
@@ -103,7 +106,8 @@ final class ExtensionConfigurationService
             ? $confVars['SYS']['trustedHostsPattern']
             : '';
 
-        // '' and '.*' both make VerifyHostHeader accept any Host header.
+        // '.*' makes VerifyHostHeader accept any Host header; '' is treated by core
+        // as invalid (rejects every Host). Refuse to derive an anchor from either.
         if ($pattern === '' || $pattern === '.*') {
             throw new RuntimeException(
                 'Refusing to derive WebAuthn rpId/origin from the request Host header: '

--- a/Classes/Service/ExtensionConfigurationService.php
+++ b/Classes/Service/ExtensionConfigurationService.php
@@ -57,6 +57,8 @@ final class ExtensionConfigurationService
             return $rpId;
         }
 
+        $this->assertHostTrustEnforced();
+
         $host = $this->getNormalizedParams()->getHttpHost();
 
         return $host !== '' ? $host : 'localhost';
@@ -69,11 +71,48 @@ final class ExtensionConfigurationService
             return $origin;
         }
 
+        $this->assertHostTrustEnforced();
+
         $params = $this->getNormalizedParams();
         $scheme = $params->isHttps() ? 'https' : 'http';
         $host = $params->getHttpHost();
 
         return $scheme . '://' . ($host !== '' ? $host : 'localhost');
+    }
+
+    /**
+     * Guard the rpId/origin auto-detection paths.
+     *
+     * When rpId/origin are left empty the anti-phishing anchor is derived from
+     * the request Host header (NormalizedParams::getHttpHost()). That value is
+     * only trustworthy when TYPO3's host-header validation (VerifyHostHeader,
+     * driven by $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern']) is
+     * actually enforcing a pattern. The framework treats both '' and the
+     * allow-all '.*' as "accept any Host", which turns the derived rpId/origin
+     * into attacker-controlled values. Fail closed in that case instead of
+     * emitting a Host-controlled anchor.
+     *
+     * @throws RuntimeException if host-header trust is disabled and no explicit
+     *                          rpId/origin is configured
+     */
+    private function assertHostTrustEnforced(): void
+    {
+        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $pattern = \is_array($confVars) && isset($confVars['SYS']) && \is_array($confVars['SYS'])
+            && \is_string($confVars['SYS']['trustedHostsPattern'] ?? null)
+            ? $confVars['SYS']['trustedHostsPattern']
+            : '';
+
+        // '' and '.*' both make VerifyHostHeader accept any Host header.
+        if ($pattern === '' || $pattern === '.*') {
+            throw new RuntimeException(
+                'Refusing to derive WebAuthn rpId/origin from the request Host header: '
+                . 'host-header validation is disabled (trustedHostsPattern is empty or ".*"). '
+                . 'Configure $GLOBALS[\'TYPO3_CONF_VARS\'][\'SYS\'][\'trustedHostsPattern\'] '
+                . 'with a strict pattern, or set the rpId and origin extension settings explicitly.',
+                1700000060,
+            );
+        }
     }
 
     /**

--- a/Classes/Service/ExtensionConfigurationService.php
+++ b/Classes/Service/ExtensionConfigurationService.php
@@ -57,11 +57,17 @@ final class ExtensionConfigurationService
             return $rpId;
         }
 
+        $host = $this->getNormalizedParams()->getHttpHost();
+        if ($host === '') {
+            // CLI / cron / background task: no Host header to spoof, so the
+            // 'localhost' fallback is a safe anchor and trust enforcement does
+            // not apply.
+            return 'localhost';
+        }
+
         $this->assertHostTrustEnforced();
 
-        $host = $this->getNormalizedParams()->getHttpHost();
-
-        return $host !== '' ? $host : 'localhost';
+        return $host;
     }
 
     public function getEffectiveOrigin(): string
@@ -71,13 +77,17 @@ final class ExtensionConfigurationService
             return $origin;
         }
 
-        $this->assertHostTrustEnforced();
-
         $params = $this->getNormalizedParams();
         $scheme = $params->isHttps() ? 'https' : 'http';
         $host = $params->getHttpHost();
+        if ($host === '') {
+            // CLI / cron / background task: no Host header to spoof; safe fallback.
+            return $scheme . '://localhost';
+        }
 
-        return $scheme . '://' . ($host !== '' ? $host : 'localhost');
+        $this->assertHostTrustEnforced();
+
+        return $scheme . '://' . $host;
     }
 
     /**

--- a/Tests/Unit/Middleware/PasskeySetupInterstitialTest.php
+++ b/Tests/Unit/Middleware/PasskeySetupInterstitialTest.php
@@ -170,6 +170,31 @@ final class PasskeySetupInterstitialTest extends TestCase
     }
 
     #[Test]
+    public function passesThroughForExemptCoreAuthAjaxRoutes(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $status = new EnforcementStatus(
+            level: EnforcementLevel::Enforced,
+            gracePeriodDays: 0,
+            gracePeriodStart: 0,
+            hasPasskeys: false,
+        );
+        $this->enforcementService->method('getStatus')->willReturn($status);
+
+        // The login/logout/MFA AJAX routes must stay exempt so an enforced user can
+        // still authenticate, log out, and complete MFA.
+        foreach (['ajax_login', 'ajax_logout', 'ajax_mfa'] as $identifier) {
+            $request = $this->createMockRequest($identifier);
+            $handler = $this->createMockHandler();
+
+            $handler->expects(self::once())->method('handle')->with($request);
+
+            $this->subject->process($request, $handler);
+        }
+    }
+
+    #[Test]
     public function passesThroughForExemptUserSetupRoute(): void
     {
         $this->setUpBackendUser(1);

--- a/Tests/Unit/Middleware/PasskeySetupInterstitialTest.php
+++ b/Tests/Unit/Middleware/PasskeySetupInterstitialTest.php
@@ -124,7 +124,7 @@ final class PasskeySetupInterstitialTest extends TestCase
     }
 
     #[Test]
-    public function passesThroughForAjaxRoutes(): void
+    public function passesThroughForExemptEnrollmentAjaxRoute(): void
     {
         $this->setUpBackendUser(1);
 
@@ -136,12 +136,37 @@ final class PasskeySetupInterstitialTest extends TestCase
         );
         $this->enforcementService->method('getStatus')->willReturn($status);
 
-        $request = $this->createMockRequest('ajax_page_tree');
+        $request = $this->createMockRequest('ajax_passkeys_manage_list');
         $handler = $this->createMockHandler();
 
         $handler->expects(self::once())->method('handle')->with($request);
 
         $this->subject->process($request, $handler);
+    }
+
+    #[Test]
+    public function doesNotExemptStateChangingCoreAjaxRoute(): void
+    {
+        $this->setUpBackendUser(1);
+
+        $status = new EnforcementStatus(
+            level: EnforcementLevel::Enforced,
+            gracePeriodDays: 0,
+            gracePeriodStart: 0,
+            hasPasskeys: false,
+        );
+        $this->enforcementService->method('getStatus')->willReturn($status);
+
+        // ajax_record_process is the DataHandler save endpoint; an
+        // enforced-but-unenrolled user must be blocked from it, not exempted.
+        $request = $this->createMockRequest('ajax_record_process');
+        $handler = $this->createMockHandler();
+
+        $handler->expects(self::never())->method('handle');
+
+        $response = $this->subject->process($request, $handler);
+
+        self::assertInstanceOf(HtmlResponse::class, $response);
     }
 
     #[Test]
@@ -649,7 +674,7 @@ final class PasskeySetupInterstitialTest extends TestCase
     }
 
     #[Test]
-    public function passesThroughForExemptAjaxSetupRoute(): void
+    public function passesThroughForExemptPasskeysEnforcementStatusAjaxRoute(): void
     {
         $this->setUpBackendUser(1);
 
@@ -661,7 +686,7 @@ final class PasskeySetupInterstitialTest extends TestCase
         );
         $this->enforcementService->method('getStatus')->willReturn($status);
 
-        $request = $this->createMockRequest('ajax_setup_something');
+        $request = $this->createMockRequest('ajax_passkeys_enforcement_status');
         $handler = $this->createMockHandler();
 
         $handler->expects(self::once())->method('handle')->with($request);

--- a/Tests/Unit/Service/ExtensionConfigurationServiceTest.php
+++ b/Tests/Unit/Service/ExtensionConfigurationServiceTest.php
@@ -285,6 +285,30 @@ final class ExtensionConfigurationServiceTest extends TestCase
     }
 
     #[Test]
+    public function getEffectiveRpIdReturnsLocalhostWithoutThrowingWhenHostEmptyEvenIfTrustDisabled(): void
+    {
+        // CLI / cron / background: no Host header to spoof. Host-trust enforcement
+        // must not fire, since the 'localhost' fallback is a safe anchor.
+        unset($_SERVER['HTTP_HOST']);
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '';
+        GeneralUtility::flushInternalRuntimeCaches();
+        $service = $this->createService(['rpId' => '']);
+
+        self::assertSame('localhost', $service->getEffectiveRpId());
+    }
+
+    #[Test]
+    public function getEffectiveOriginReturnsLocalhostWithoutThrowingWhenHostEmptyEvenIfTrustDisabled(): void
+    {
+        unset($_SERVER['HTTP_HOST'], $_SERVER['HTTPS']);
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*';
+        GeneralUtility::flushInternalRuntimeCaches();
+        $service = $this->createService(['origin' => '']);
+
+        self::assertSame('http://localhost', $service->getEffectiveOrigin());
+    }
+
+    #[Test]
     public function getConfigurationReturnsSameInstanceOnMultipleCalls(): void
     {
         $service = $this->createService(['rpId' => 'test.example.com']);

--- a/Tests/Unit/Service/ExtensionConfigurationServiceTest.php
+++ b/Tests/Unit/Service/ExtensionConfigurationServiceTest.php
@@ -23,13 +23,16 @@ final class ExtensionConfigurationServiceTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+        // A strict (non-empty, non-".*") trustedHostsPattern so the host-derivation
+        // tests reach the Host fallback without tripping the fail-closed guard.
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '(^|\.)example\.(org|com)$';
         GeneralUtility::flushInternalRuntimeCaches();
     }
 
     protected function tearDown(): void
     {
         GeneralUtility::flushInternalRuntimeCaches();
-        unset($_SERVER['HTTP_HOST'], $_SERVER['HTTPS']);
+        unset($_SERVER['HTTP_HOST'], $_SERVER['HTTPS'], $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern']);
         parent::tearDown();
     }
 
@@ -220,6 +223,37 @@ final class ExtensionConfigurationServiceTest extends TestCase
 
         // Origin should come from HTTP_HOST, not rpId
         self::assertSame('https://host.example.com', $service->getEffectiveOrigin());
+    }
+
+    #[Test]
+    public function getEffectiveRpIdThrowsWhenHostTrustDisabledByAllowAllPattern(): void
+    {
+        // trustedHostsPattern '.*' makes VerifyHostHeader accept any Host header,
+        // so the request-derived rpId would be attacker-controllable.
+        $_SERVER['HTTP_HOST'] = 'attacker.evil.example';
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*';
+        GeneralUtility::flushInternalRuntimeCaches();
+        $service = $this->createService(['rpId' => '']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionCode(1700000060);
+
+        $service->getEffectiveRpId();
+    }
+
+    #[Test]
+    public function getEffectiveOriginThrowsWhenHostTrustDisabledByEmptyPattern(): void
+    {
+        // Empty trustedHostsPattern is also treated as allow-all by VerifyHostHeader.
+        $_SERVER['HTTP_HOST'] = 'attacker.evil.example';
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '';
+        GeneralUtility::flushInternalRuntimeCaches();
+        $service = $this->createService(['origin' => '']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionCode(1700000060);
+
+        $service->getEffectiveOrigin();
     }
 
     #[Test]

--- a/Tests/Unit/Service/ExtensionConfigurationServiceTest.php
+++ b/Tests/Unit/Service/ExtensionConfigurationServiceTest.php
@@ -257,6 +257,34 @@ final class ExtensionConfigurationServiceTest extends TestCase
     }
 
     #[Test]
+    public function getEffectiveRpIdThrowsWhenHostTrustDisabledByEmptyPattern(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'attacker.evil.example';
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '';
+        GeneralUtility::flushInternalRuntimeCaches();
+        $service = $this->createService(['rpId' => '']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionCode(1700000060);
+
+        $service->getEffectiveRpId();
+    }
+
+    #[Test]
+    public function getEffectiveOriginThrowsWhenHostTrustDisabledByAllowAllPattern(): void
+    {
+        $_SERVER['HTTP_HOST'] = 'attacker.evil.example';
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['trustedHostsPattern'] = '.*';
+        GeneralUtility::flushInternalRuntimeCaches();
+        $service = $this->createService(['origin' => '']);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionCode(1700000060);
+
+        $service->getEffectiveOrigin();
+    }
+
+    #[Test]
     public function getConfigurationReturnsSameInstanceOnMultipleCalls(): void
     {
         $service = $this->createService(['rpId' => 'test.example.com']);


### PR DESCRIPTION
Two backend hardening fixes from a security review, as **two separable commits**.

## 1. Narrow the interstitial AJAX exemption (`bad9b9e`)
`PasskeySetupInterstitial` exempted any route starting with `ajax_`. TYPO3 registers every backend AJAX route as `ajax_<id>`, so the bare prefix exempted ~260 state-changing endpoints (`ajax_record_process` = DataHandler save, `ajax_file_process`, …). An **enforced-but-unenrolled** user could keep using the backend through those AJAX endpoints, evading enrollment. The exemption is narrowed to the routes the enrollment/login flow needs (`ajax_passkeys_manage_*`, `ajax_passkeys_enforcement_status`, `ajax_login/logout/mfa`). Adds a regression test that `ajax_record_process` is blocked.

## 2. Fail closed on Host-derived rpId/origin (`b312d0d`)
When `rpId`/`origin` are empty they are derived from the request `Host` header — trustworthy only when `trustedHostsPattern` is enforcing. The framework treats `''` and `'.*'` as "accept any Host", making the WebAuthn anti-phishing anchor attacker-controllable. The auto-detection now **fails closed** (exception `1700000060`) in that case.

> ⚠️ **Deployment impact — please review this commit separately.** An install running with `trustedHostsPattern` `''` or `'.*'` **and** no explicit `rpId`/`origin` will get an exception on passkey ceremonies until it sets a strict `trustedHostsPattern` or pins `rpId`/`origin` (the documented production requirement). If a hard failure is too aggressive for a point release, this second commit can be dropped or softened to a logged warning — the first commit stands alone.

## Test plan
- New/updated unit tests in both areas.
- Local `make test-unit`: **573 passed**; `phpstan` (1G): no errors; `cgl`: clean.
