### PR TITLE
fix(ratelimit): close rate-limit check/record TOCTOU with atomic consume

### DIFF
--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -79,6 +79,9 @@ final class LoginController
         }
 
         try {
+            // consumeRateLimit counts this attempt up front (atomic check+increment),
+            // so an attempt that is subsequently lockout-rejected still consumes
+            // per-IP rate-limit budget. This is intentional: it is still an attempt.
             $this->rateLimiterService->consumeRateLimit('login_options', $ip);
             $this->rateLimiterService->checkLockout($username, $ip);
         } catch (RuntimeException $e) {

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -55,12 +55,10 @@ final class LoginController
             }
 
             try {
-                $this->rateLimiterService->checkRateLimit('login_options', $ip);
+                $this->rateLimiterService->consumeRateLimit('login_options', $ip);
             } catch (RuntimeException) {
                 return new JsonResponse(['error' => 'Too many requests'], 429, ['Retry-After' => '60']);
             }
-
-            $this->rateLimiterService->recordAttempt('login_options', $ip);
 
             try {
                 $result = $this->webAuthnService->createDiscoverableAssertionOptions();
@@ -81,13 +79,11 @@ final class LoginController
         }
 
         try {
-            $this->rateLimiterService->checkRateLimit('login_options', $ip);
+            $this->rateLimiterService->consumeRateLimit('login_options', $ip);
             $this->rateLimiterService->checkLockout($username, $ip);
         } catch (RuntimeException $e) {
             return $this->throttledResponse($e);
         }
-
-        $this->rateLimiterService->recordAttempt('login_options', $ip);
 
         // Look up user. To prevent username enumeration, an unknown user receives a
         // DECOY options response with the SAME shape and HTTP 200 status as a real
@@ -162,13 +158,11 @@ final class LoginController
         $ip = $this->getRemoteAddress($request);
 
         try {
-            $this->rateLimiterService->checkRateLimit('login_verify', $ip);
+            $this->rateLimiterService->consumeRateLimit('login_verify', $ip);
             $this->rateLimiterService->checkLockout($username, $ip);
         } catch (RuntimeException $e) {
             return $this->throttledResponse($e);
         }
-
-        $this->rateLimiterService->recordAttempt('login_verify', $ip);
 
         $beUserUid = $this->findBeUserUid($username);
         if ($beUserUid === null) {

--- a/Classes/Service/RateLimiterService.php
+++ b/Classes/Service/RateLimiterService.php
@@ -30,8 +30,11 @@ final class RateLimiterService
     /**
      * Check if the rate limit for the given endpoint and identifier has been exceeded.
      *
-     * Uses a lock to prevent TOCTOU race conditions between checking the
-     * current count and incrementing it.
+     * @deprecated Use {@see consumeRateLimit()}, which checks and increments under a
+     *             single lock. This method only checks; pairing it with a separate
+     *             {@see recordAttempt()} leaves a check-then-record window where
+     *             concurrent requests can all pass the check before any increments,
+     *             overshooting the limit by the number of in-flight requests.
      *
      * @throws RuntimeException if rate limit exceeded or lock cannot be acquired
      */
@@ -57,6 +60,9 @@ final class RateLimiterService
 
     /**
      * Record a request attempt.
+     *
+     * @deprecated Use {@see consumeRateLimit()}, which records the attempt atomically
+     *             with the limit check.
      */
     public function recordAttempt(string $endpoint, string $identifier): void
     {
@@ -65,6 +71,54 @@ final class RateLimiterService
         $windowSeconds = $config->getRateLimitWindowSeconds();
 
         $this->atomicIncrement($key, [], $windowSeconds);
+    }
+
+    /**
+     * Atomically check the rate limit AND record the attempt under a single lock.
+     *
+     * The read, threshold comparison and increment all happen inside one critical
+     * section, so concurrent requests cannot all pass the check before any of them
+     * increments — the overshoot a separate check/record pair allows. This is the
+     * rate-limit gate the request path should call.
+     *
+     * @throws RuntimeException if the rate limit is exceeded or the lock cannot be acquired
+     */
+    public function consumeRateLimit(string $endpoint, string $identifier): void
+    {
+        $config = $this->configService->getConfiguration();
+        $key = $this->buildKey($endpoint, $identifier);
+        $maxAttempts = $config->getRateLimitMaxAttempts();
+        $windowSeconds = $config->getRateLimitWindowSeconds();
+
+        $locker = $this->lockFactory->createLocker(
+            'ratelimit_' . $key,
+            LockingStrategyInterface::LOCK_CAPABILITY_EXCLUSIVE,
+        );
+
+        if (!$locker->acquire(LockingStrategyInterface::LOCK_CAPABILITY_EXCLUSIVE)) {
+            $this->logger->error('Failed to acquire rate limit lock', [
+                'operation' => 'consumeRateLimit',
+                'key' => $key,
+            ]);
+
+            throw new RuntimeException('Failed to acquire rate limit lock', 1700000012);
+        }
+
+        try {
+            $current = $this->getAttemptCount($key);
+            if ($current >= $maxAttempts) {
+                $this->logger->warning('Rate limit exceeded', [
+                    'endpoint' => $endpoint,
+                    'identifier' => \hash('sha256', $identifier),
+                ]);
+
+                throw new RuntimeException('Rate limit exceeded', 1700000010);
+            }
+
+            $this->rateLimitCache->set($key, (string) ($current + 1), [], $windowSeconds);
+        } finally {
+            $locker->release();
+        }
     }
 
     /**

--- a/Tests/Unit/Controller/LoginControllerTest.php
+++ b/Tests/Unit/Controller/LoginControllerTest.php
@@ -198,7 +198,7 @@ final class LoginControllerTest extends TestCase
         $request = $this->createJsonRequest(['username' => 'admin']);
 
         $this->rateLimiterService
-            ->method('checkRateLimit')
+            ->method('consumeRateLimit')
             ->willThrowException(new RuntimeException('Rate limit exceeded', 1700000010));
 
         $response = $this->subject->optionsAction($request);
@@ -290,7 +290,7 @@ final class LoginControllerTest extends TestCase
         ]);
 
         $this->rateLimiterService
-            ->method('checkRateLimit')
+            ->method('consumeRateLimit')
             ->willThrowException(new RuntimeException('Rate limit exceeded', 1700000010));
 
         $response = $this->subject->verifyAction($request);
@@ -311,7 +311,7 @@ final class LoginControllerTest extends TestCase
             ->willReturn(new ExtensionConfiguration(discoverableLoginEnabled: true));
 
         $this->rateLimiterService
-            ->method('checkRateLimit')
+            ->method('consumeRateLimit')
             ->willThrowException(new RuntimeException('Rate limit exceeded', 1700000010));
 
         $response = $this->subject->optionsAction($request);
@@ -591,7 +591,7 @@ final class LoginControllerTest extends TestCase
 
         $this->rateLimiterService
             ->expects(self::once())
-            ->method('recordAttempt')
+            ->method('consumeRateLimit')
             ->with('login_options', self::anything());
 
         $this->subject->optionsAction($request);
@@ -612,7 +612,7 @@ final class LoginControllerTest extends TestCase
 
         $this->rateLimiterService
             ->expects(self::once())
-            ->method('recordAttempt')
+            ->method('consumeRateLimit')
             ->with('login_verify', self::anything());
 
         $this->subject->verifyAction($request);

--- a/Tests/Unit/Controller/LoginControllerTest.php
+++ b/Tests/Unit/Controller/LoginControllerTest.php
@@ -570,7 +570,7 @@ final class LoginControllerTest extends TestCase
     }
 
     #[Test]
-    public function optionsActionRecordsAttempt(): void
+    public function optionsActionConsumesRateLimit(): void
     {
         $request = $this->createJsonRequest(['username' => 'admin']);
         $this->setUpFindBeUser('admin', ['uid' => 42, 'username' => 'admin']);
@@ -598,7 +598,7 @@ final class LoginControllerTest extends TestCase
     }
 
     #[Test]
-    public function verifyActionRecordsAttempt(): void
+    public function verifyActionConsumesRateLimit(): void
     {
         $request = $this->createJsonRequest([
             'username' => 'admin',

--- a/Tests/Unit/Service/RateLimiterServiceTest.php
+++ b/Tests/Unit/Service/RateLimiterServiceTest.php
@@ -594,6 +594,54 @@ final class RateLimiterServiceTest extends TestCase
     }
 
     #[Test]
+    public function consumeRateLimitIncrementsUnderLimitInOneCriticalSection(): void
+    {
+        $this->rateLimitCacheMock->method('get')->willReturn('2');
+        $this->rateLimitCacheMock
+            ->expects(self::once())
+            ->method('set')
+            ->with(self::anything(), '3', [], 300);
+
+        $this->subject->consumeRateLimit('login_options', '10.0.0.1');
+    }
+
+    #[Test]
+    public function consumeRateLimitThrowsAtLimitWithoutIncrementing(): void
+    {
+        // At the limit (5/5): the single critical section must reject and must NOT
+        // increment, so a rejected attempt cannot push the counter further.
+        $this->rateLimitCacheMock->method('get')->willReturn('5');
+        $this->rateLimitCacheMock->expects(self::never())->method('set');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionCode(1700000010);
+
+        $this->subject->consumeRateLimit('login_options', '10.0.0.1');
+    }
+
+    #[Test]
+    public function consumeRateLimitThrowsWhenLockCannotBeAcquired(): void
+    {
+        $failingLocker = $this->createMock(LockingStrategyInterface::class);
+        $failingLocker->method('acquire')->willReturn(false);
+
+        $failingLockFactory = $this->createMock(LockFactory::class);
+        $failingLockFactory->method('createLocker')->willReturn($failingLocker);
+
+        $subject = new RateLimiterService(
+            $this->rateLimitCacheMock,
+            $this->configService,
+            $failingLockFactory,
+            $this->loggerMock,
+        );
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionCode(1700000012);
+
+        $subject->consumeRateLimit('login_options', '10.0.0.1');
+    }
+
+    #[Test]
     public function recordAttemptAcquiresAndReleasesLock(): void
     {
         $this->rateLimitCacheMock

--- a/Tests/Unit/Service/RateLimiterServiceTest.php
+++ b/Tests/Unit/Service/RateLimiterServiceTest.php
@@ -606,6 +606,20 @@ final class RateLimiterServiceTest extends TestCase
     }
 
     #[Test]
+    public function consumeRateLimitAllowsAndIncrementsAtLastAllowedAttempt(): void
+    {
+        // Count is 4, limit is 5: the last allowed attempt (>= comparison) must pass
+        // and increment to 5. Guards the >= vs > boundary the at-limit test cannot.
+        $this->rateLimitCacheMock->method('get')->willReturn('4');
+        $this->rateLimitCacheMock
+            ->expects(self::once())
+            ->method('set')
+            ->with(self::anything(), '5', [], 300);
+
+        $this->subject->consumeRateLimit('login_options', '10.0.0.1');
+    }
+
+    #[Test]
     public function consumeRateLimitThrowsAtLimitWithoutIncrementing(): void
     {
         // At the limit (5/5): the single critical section must reject and must NOT


### PR DESCRIPTION
## Summary

The rate-limit gate split the check and the record across two separate lock acquisitions: `checkRateLimit()` (read + compare, release) then later `recordAttempt()` (increment, release). On the live login path that leaves a **check-then-record window** — N concurrent requests can all pass the check before any of them increments, so the configured limit is overshot by the number of in-flight requests. The method's docblock claimed the pair was TOCTOU-safe, which it was not (this is the honest fix for that claim; a docblock-only change was rejected in review).

## Change

- Adds `consumeRateLimit()`, which performs the read, threshold comparison and increment **inside a single critical section** — concurrent requests can no longer slip past the check before incrementing.
- Migrates `LoginController`'s three rate-limit gates (discoverable + username-first `login_options`, and `login_verify`) to it.
- `checkRateLimit()` / `recordAttempt()` are kept but `@deprecated` with an honest docblock; they are no longer used on the request path.

The per-account **lockout** (`checkLockout`/`recordFailure`) is deliberately left as check-then-record: a failure can only be known *after* verification, so the failure counter is updated post-verify by design (its bounded overshoot is inherent, not a fixable TOCTOU).

## Test plan
- New unit tests for `consumeRateLimit`: atomic increment under the limit, reject at the limit without incrementing, fail-closed when the lock can't be acquired.
- Local `make test-unit`: **573 passed**; `phpstan` (1G): no errors; `cgl`: clean.
