### PR TITLE
fix(log): write passkey audit log to the project var path

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -34,9 +34,14 @@ ExtensionManagementUtility::addService(
 // WARNING and above: failed logins, lockouts, rate limiting, password-disable blocks.
 // INFO: successful logins, discoverable flow resolutions.
 // Uses ??= so site configuration can override.
+// The log must live in the project var path: a relative path resolves below
+// the public web root (typo3temp/), where the file may be world-readable and,
+// in containerized setups, the directory is often not writable by the PHP
+// user — an unwritable FileWriter throws and takes down every request that
+// logs a warning.
 $GLOBALS['TYPO3_CONF_VARS']['LOG']['Netresearch']['NrPasskeysBe']['writerConfiguration'][\TYPO3\CMS\Core\Log\LogLevel::WARNING] ??= [
     \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
-        'logFile' => 'typo3temp/var/log/passkey_auth.log',
+        'logFile' => \TYPO3\CMS\Core\Core\Environment::getVarPath() . '/log/passkey_auth.log',
     ],
 ];
 


### PR DESCRIPTION
## Summary

The audit-log FileWriter used the relative path `typo3temp/var/log/passkey_auth.log`, which resolves **below the public web root**. Two problems:

1. **Availability**: in containerized deployments the directory is often not writable by the PHP user, or the file gets created root-owned by CLI runs (`cache:warmup` via `docker compose exec`). An unwritable FileWriter throws `#1321804422` on every request that logs a warning — this took the entire typo3-demo backend down today after the 0.10.0 deploy (500 on `/typo3/`).
2. **Security**: a security audit log below the docroot is a web-reachable artifact.

Fix: `Environment::getVarPath() . '/log/passkey_auth.log'` — the canonical writable location in composer mode.

## Test plan

- `composer ci:test:php:cgl` ✔, `ci:test:php:phpstan` ✔ (level 10), `ci:test:php:unit` ✔ (598 tests).
- After release + demo redeploy: `/typo3/` serves 200 again and warnings land in `var/log/passkey_auth.log`.
