### PR TITLE
feat(dashboard): add passkey adoption and credential-count widgets

### DIFF
--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -20,6 +20,15 @@ parameters:
     excludePaths:
         - %currentWorkingDirectory%/.Build/*
         - %currentWorkingDirectory%/ext_emconf.php
+        # AdminOnlyWidgetInterface exists on TYPO3 v14.3+ only. On the
+        # v12/v13 matrix legs the missing interface makes PHPStan fail with
+        # an unignorable internal reflection error, so these two thin marker
+        # subclasses (no logic; wiring pinned by
+        # Tests/Unit/Widgets/AdminOnlyWidgetWiringTest.php on v14.3+) are
+        # excluded from analysis. They are only registered on v14.3+ via the
+        # guarded Configuration/Services.Dashboard.php.
+        - %currentWorkingDirectory%/Classes/Widgets/AdminOnlyDoughnutChartWidget.php
+        - %currentWorkingDirectory%/Classes/Widgets/AdminOnlyNumberWithIconWidget.php
 
     ignoreErrors:
         # --- Shared ignoreErrors (from typo3-ci-workflows) ---

--- a/Classes/Service/AdoptionStatsService.php
+++ b/Classes/Service/AdoptionStatsService.php
@@ -113,11 +113,13 @@ final class AdoptionStatsService
     }
 
     /**
-     * Count all active (non-deleted, non-revoked) passkey credentials.
+     * Count all active (non-deleted, non-revoked) passkey credentials that
+     * belong to active (non-deleted, non-disabled) backend users.
      *
      * Unlike countUsersWithPasskeys() this counts credentials, not distinct
-     * users — one user may have registered several passkeys. Used by the
-     * dashboard credentials widget.
+     * users — one user may have registered several passkeys. The join on
+     * be_users keeps leftover credentials of soft-deleted or disabled users
+     * out of the count. Used by the dashboard credentials widget.
      */
     public function countActiveCredentials(): int
     {
@@ -125,11 +127,22 @@ final class AdoptionStatsService
         $queryBuilder->getRestrictions()->removeAll();
 
         $result = $queryBuilder
-            ->count('uid')
+            ->count(self::TABLE_CREDENTIALS . '.uid')
             ->from(self::TABLE_CREDENTIALS)
+            ->join(
+                self::TABLE_CREDENTIALS,
+                self::TABLE_USERS,
+                'u',
+                $queryBuilder->expr()->eq(
+                    self::TABLE_CREDENTIALS . '.be_user',
+                    $queryBuilder->quoteIdentifier('u.uid'),
+                ),
+            )
             ->where(
-                $queryBuilder->expr()->eq('deleted', 0),
-                $queryBuilder->expr()->eq('revoked_at', 0),
+                $queryBuilder->expr()->eq(self::TABLE_CREDENTIALS . '.deleted', 0),
+                $queryBuilder->expr()->eq(self::TABLE_CREDENTIALS . '.revoked_at', 0),
+                $queryBuilder->expr()->eq('u.deleted', 0),
+                $queryBuilder->expr()->eq('u.disable', 0),
             )
             ->executeQuery()
             ->fetchOne();

--- a/Classes/Service/AdoptionStatsService.php
+++ b/Classes/Service/AdoptionStatsService.php
@@ -66,8 +66,11 @@ final class AdoptionStatsService
 
     /**
      * Count total active (non-deleted, non-disabled) backend users.
+     *
+     * Public because the dashboard adoption widget needs this single
+     * aggregate without triggering the full getStats() computation.
      */
-    private function countTotalActiveUsers(): int
+    public function countTotalActiveUsers(): int
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_USERS);
         $queryBuilder->getRestrictions()->removeAll();
@@ -87,14 +90,42 @@ final class AdoptionStatsService
 
     /**
      * Count distinct users who have at least one active (non-deleted, non-revoked) credential.
+     *
+     * Public because the dashboard adoption widget needs this single
+     * aggregate without triggering the full getStats() computation.
      */
-    private function countUsersWithPasskeys(): int
+    public function countUsersWithPasskeys(): int
     {
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_CREDENTIALS);
         $queryBuilder->getRestrictions()->removeAll();
 
         $result = $queryBuilder
             ->addSelectLiteral('COUNT(DISTINCT ' . $queryBuilder->quoteIdentifier('be_user') . ') AS cnt')
+            ->from(self::TABLE_CREDENTIALS)
+            ->where(
+                $queryBuilder->expr()->eq('deleted', 0),
+                $queryBuilder->expr()->eq('revoked_at', 0),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return \is_numeric($result) ? (int) $result : 0;
+    }
+
+    /**
+     * Count all active (non-deleted, non-revoked) passkey credentials.
+     *
+     * Unlike countUsersWithPasskeys() this counts credentials, not distinct
+     * users — one user may have registered several passkeys. Used by the
+     * dashboard credentials widget.
+     */
+    public function countActiveCredentials(): int
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE_CREDENTIALS);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $result = $queryBuilder
+            ->count('uid')
             ->from(self::TABLE_CREDENTIALS)
             ->where(
                 $queryBuilder->expr()->eq('deleted', 0),

--- a/Classes/Widgets/AdminOnlyDoughnutChartWidget.php
+++ b/Classes/Widgets/AdminOnlyDoughnutChartWidget.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Widgets;
+
+use TYPO3\CMS\Dashboard\Widgets\AdminOnlyWidgetInterface;
+use TYPO3\CMS\Dashboard\Widgets\DoughnutChartWidget;
+
+/**
+ * Admin-only variant of the core doughnut chart widget.
+ *
+ * The dashboard's DashboardWidgetPass derives the adminOnly flag solely
+ * from the widget CLASS implementing AdminOnlyWidgetInterface, so using
+ * the core widget class directly cannot express admin-only. This thin
+ * subclass adds the marker interface and nothing else.
+ *
+ * AdminOnlyWidgetInterface exists since TYPO3 v14.3 only. This class is
+ * therefore referenced exclusively from the guarded
+ * Configuration/Services.Dashboard.php, which falls back to the plain core
+ * widget class on v12/v13 (where widget visibility is governed by the
+ * "available_widgets" backend group permission instead) and is excluded
+ * from the Services.yaml class scan.
+ */
+final class AdminOnlyDoughnutChartWidget extends DoughnutChartWidget implements AdminOnlyWidgetInterface {}

--- a/Classes/Widgets/AdminOnlyNumberWithIconWidget.php
+++ b/Classes/Widgets/AdminOnlyNumberWithIconWidget.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Widgets;
+
+use TYPO3\CMS\Dashboard\Widgets\AdminOnlyWidgetInterface;
+use TYPO3\CMS\Dashboard\Widgets\NumberWithIconWidget;
+
+/**
+ * Admin-only variant of the core number-with-icon widget.
+ *
+ * See AdminOnlyDoughnutChartWidget for the rationale: the dashboard's
+ * DashboardWidgetPass derives adminOnly from the widget class implementing
+ * AdminOnlyWidgetInterface (TYPO3 v14.3+), so core classes cannot express
+ * it directly. Referenced only from the guarded
+ * Configuration/Services.Dashboard.php.
+ */
+final class AdminOnlyNumberWithIconWidget extends NumberWithIconWidget implements AdminOnlyWidgetInterface {}

--- a/Classes/Widgets/DataProvider/ActiveCredentialsCountDataProvider.php
+++ b/Classes/Widgets/DataProvider/ActiveCredentialsCountDataProvider.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Widgets\DataProvider;
+
+use Netresearch\NrPasskeysBe\Service\AdoptionStatsService;
+use TYPO3\CMS\Dashboard\Widgets\NumberWithIconDataProviderInterface;
+
+/**
+ * Data provider for the "active passkey credentials" NumberWithIcon widget.
+ *
+ * Returns the total number of active (non-deleted, non-revoked) backend
+ * passkey credentials via a single aggregate query in AdoptionStatsService.
+ */
+final class ActiveCredentialsCountDataProvider implements NumberWithIconDataProviderInterface
+{
+    public function __construct(
+        private readonly AdoptionStatsService $adoptionStatsService,
+    ) {}
+
+    public function getNumber(): int
+    {
+        return $this->adoptionStatsService->countActiveCredentials();
+    }
+}

--- a/Classes/Widgets/DataProvider/PasskeyAdoptionChartDataProvider.php
+++ b/Classes/Widgets/DataProvider/PasskeyAdoptionChartDataProvider.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Widgets\DataProvider;
+
+use Netresearch\NrPasskeysBe\Service\AdoptionStatsService;
+use Netresearch\NrPasskeysBe\Utility\TranslationTrait;
+use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
+
+/**
+ * Chart.js doughnut-chart data provider for backend-user passkey adoption.
+ *
+ * Splits the active (non-deleted, non-disabled) backend users into those
+ * with at least one active passkey credential and those without. Reuses
+ * the aggregate count queries of AdoptionStatsService instead of the full
+ * getStats() computation — the widget only needs the two totals, not the
+ * per-group breakdown or the passkey-less user list.
+ */
+final class PasskeyAdoptionChartDataProvider implements ChartDataProviderInterface
+{
+    use TranslationTrait;
+
+    /**
+     * Chart colors follow the TYPO3 dashboard default palette
+     * (WidgetApi::getDefaultChartColors()), hardcoded because the
+     * WidgetApi return type is untyped on TYPO3 v12.
+     */
+    private const COLOR_WITH_PASSKEYS = '#4c7e3a';
+    private const COLOR_WITHOUT_PASSKEYS = '#ff8700';
+
+    public function __construct(
+        private readonly AdoptionStatsService $adoptionStatsService,
+    ) {}
+
+    /**
+     * @return array{labels: list<string>, datasets: list<array{backgroundColor: list<string>, data: list<int>}>}
+     */
+    public function getChartData(): array
+    {
+        $totalUsers = $this->adoptionStatsService->countTotalActiveUsers();
+        $usersWithPasskeys = $this->adoptionStatsService->countUsersWithPasskeys();
+        $usersWithoutPasskeys = \max(0, $totalUsers - $usersWithPasskeys);
+
+        return [
+            'labels' => [
+                $this->translate('widget.adoption.label.with_passkeys', 'With passkeys'),
+                $this->translate('widget.adoption.label.without_passkeys', 'Without passkeys'),
+            ],
+            'datasets' => [
+                [
+                    'backgroundColor' => [
+                        self::COLOR_WITH_PASSKEYS,
+                        self::COLOR_WITHOUT_PASSKEYS,
+                    ],
+                    'data' => [$usersWithPasskeys, $usersWithoutPasskeys],
+                ],
+            ],
+        ];
+    }
+}

--- a/Configuration/Backend/DashboardWidgetGroups.php
+++ b/Configuration/Backend/DashboardWidgetGroups.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+/*
+ * Widget group for the nr_passkeys_be dashboard widgets. Only read by
+ * EXT:dashboard's ServiceProvider — harmless when dashboard is not
+ * installed.
+ */
+return [
+    'nrpasskeys' => [
+        'title' => 'LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang_dashboard.xlf:widget_group.nrpasskeys',
+    ],
+];

--- a/Configuration/Services.Dashboard.php
+++ b/Configuration/Services.Dashboard.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+use Netresearch\NrPasskeysBe\Widgets\AdminOnlyDoughnutChartWidget;
+use Netresearch\NrPasskeysBe\Widgets\AdminOnlyNumberWithIconWidget;
+use Netresearch\NrPasskeysBe\Widgets\DataProvider\ActiveCredentialsCountDataProvider;
+use Netresearch\NrPasskeysBe\Widgets\DataProvider\PasskeyAdoptionChartDataProvider;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use TYPO3\CMS\Dashboard\Widgets\AdminOnlyWidgetInterface;
+use TYPO3\CMS\Dashboard\Widgets\DoughnutChartWidget;
+use TYPO3\CMS\Dashboard\Widgets\NumberWithIconWidget;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+/*
+ * Dashboard widget registration for nr_passkeys_be.
+ *
+ * Imported conditionally from Configuration/Services.php only when
+ * typo3/cms-dashboard is installed. This is a PHP config file (not YAML)
+ * because TYPO3 loads Configuration/Services.php with a standalone Symfony
+ * PhpFileLoader that has no YAML loader in its resolver, so a `.yaml`
+ * import cannot be resolved from there.
+ *
+ * Admin-only gating: the dashboard's DashboardWidgetPass derives the
+ * adminOnly flag from the widget class implementing
+ * AdminOnlyWidgetInterface, which exists since TYPO3 v14.3. On v14.3+ the
+ * extension's AdminOnly* widget subclasses are registered so the widgets
+ * are hidden from non-admins and cannot be granted to groups — matching
+ * the admin-only access level of the extension's backend module. On
+ * v12/v13 the plain core widget classes are registered; there, widget
+ * visibility follows the core's own pre-14.3 semantics: non-admins only
+ * see a widget when a backend group explicitly grants it via the
+ * "available_widgets" permission.
+ */
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->defaults()
+        ->autowire()
+        ->autoconfigure()
+        ->private();
+
+    $services->set(PasskeyAdoptionChartDataProvider::class);
+    $services->set(ActiveCredentialsCountDataProvider::class);
+
+    $adminOnlySupported = \interface_exists(AdminOnlyWidgetInterface::class);
+
+    $services->set(
+        'dashboard.widget.nrpasskeysbe.adoption',
+        $adminOnlySupported ? AdminOnlyDoughnutChartWidget::class : DoughnutChartWidget::class,
+    )
+        ->arg('$dataProvider', service(PasskeyAdoptionChartDataProvider::class))
+        ->tag('dashboard.widget', [
+            'identifier'     => 'nrpasskeysbe-adoption',
+            'groupNames'     => 'nrpasskeys',
+            'title'          => 'LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang_dashboard.xlf:widget.adoption.title',
+            'description'    => 'LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang_dashboard.xlf:widget.adoption.description',
+            'iconIdentifier' => 'passkeys-be-module',
+            'height'         => 'medium',
+            'width'          => 'small',
+        ]);
+
+    $services->set(
+        'dashboard.widget.nrpasskeysbe.credentials',
+        $adminOnlySupported ? AdminOnlyNumberWithIconWidget::class : NumberWithIconWidget::class,
+    )
+        ->arg('$dataProvider', service(ActiveCredentialsCountDataProvider::class))
+        ->arg('$options', [
+            'icon'     => 'passkeys-be-module',
+            'title'    => 'LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang_dashboard.xlf:widget.credentials.title',
+            'subtitle' => 'LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang_dashboard.xlf:widget.credentials.subtitle',
+        ])
+        ->tag('dashboard.widget', [
+            'identifier'     => 'nrpasskeysbe-credentials',
+            'groupNames'     => 'nrpasskeys',
+            'title'          => 'LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang_dashboard.xlf:widget.credentials.title',
+            'description'    => 'LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang_dashboard.xlf:widget.credentials.description',
+            'iconIdentifier' => 'passkeys-be-module',
+            'height'         => 'small',
+            'width'          => 'small',
+        ]);
+};

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use TYPO3\CMS\Dashboard\Widgets\WidgetInterface;
+
+return static function (ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder): void {
+    // Dashboard widgets ship only when typo3/cms-dashboard is installed
+    // (composer "suggest", not a hard requirement). Guarding here keeps
+    // TYPO3 installs without dashboard from blowing up on unresolvable
+    // class references during container compile. WidgetInterface is an
+    // interface, so the guard must use interface_exists() (class_exists()
+    // returns false for interfaces). The imported file is PHP, not YAML,
+    // because the loader handling Services.php cannot resolve a YAML import.
+    if (\interface_exists(WidgetInterface::class)) {
+        $containerConfigurator->import(__DIR__ . '/Services.Dashboard.php');
+    }
+};

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -8,6 +8,10 @@ services:
     resource: '../Classes/*'
     exclude:
       - '../Classes/Domain/Model/*'
+      # Widget classes reference typo3/cms-dashboard interfaces (a suggest,
+      # not a requirement) and are registered explicitly in the guarded
+      # Services.Dashboard.php instead.
+      - '../Classes/Widgets/*'
 
   # Event listener tags for TYPO3 v12 (does not support #[AsEventListener] attribute).
   # v13+ ignores these tags when the attribute is present.

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -845,6 +845,12 @@
             <trans-unit id="help.faq.answer5" resname="help.faq.answer5">
                 <source>Yes. During the grace period, password login remains fully functional. After each password login, users see the setup interstitial but can skip it. Once the grace period expires, the interstitial becomes blocking and they must register a passkey before continuing to the backend.</source>
             </trans-unit>
+            <trans-unit id="widget.adoption.label.with_passkeys" resname="widget.adoption.label.with_passkeys">
+                <source>With passkeys</source>
+            </trans-unit>
+            <trans-unit id="widget.adoption.label.without_passkeys" resname="widget.adoption.label.without_passkeys">
+                <source>Without passkeys</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/locallang_dashboard.xlf
+++ b/Resources/Private/Language/locallang_dashboard.xlf
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="messages">
+        <body>
+            <trans-unit id="widget_group.nrpasskeys">
+                <source>Passkeys</source>
+            </trans-unit>
+            <trans-unit id="widget.adoption.title">
+                <source>Passkey adoption</source>
+            </trans-unit>
+            <trans-unit id="widget.adoption.description">
+                <source>Doughnut chart of active backend users with at least one active passkey versus those without any.</source>
+            </trans-unit>
+            <trans-unit id="widget.credentials.title">
+                <source>Active passkeys</source>
+            </trans-unit>
+            <trans-unit id="widget.credentials.subtitle">
+                <source>Registered backend credentials</source>
+            </trans-unit>
+            <trans-unit id="widget.credentials.description">
+                <source>Total number of active (not revoked) passkey credentials registered by backend users.</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Tests/Functional/Service/AdoptionStatsServiceTest.php
+++ b/Tests/Functional/Service/AdoptionStatsServiceTest.php
@@ -249,4 +249,53 @@ final class AdoptionStatsServiceTest extends FunctionalTestCase
         // Disabled user should NOT be counted
         self::assertSame(5, $stats->totalUsers);
     }
+
+    #[Test]
+    public function countActiveCredentialsCountsActiveCredentialsOfActiveUsersOnly(): void
+    {
+        // credential.csv: user 1 has 2 active + 1 revoked + 1 deleted,
+        // user 2 has 1 active => 3 active credentials of active users
+        self::assertSame(3, $this->subject->countActiveCredentials());
+
+        // A leftover active credential of a disabled user must not count
+        $connectionPool = $this->get(\TYPO3\CMS\Core\Database\ConnectionPool::class);
+        $connectionPool->getConnectionForTable('be_users')->insert('be_users', [
+            'uid' => 102,
+            'pid' => 0,
+            'username' => 'disabledwithpasskey',
+            'password' => 'pass',
+            'admin' => 0,
+            'disable' => 1,
+            'deleted' => 0,
+            'usergroup' => '1',
+        ]);
+        $connectionPool->getConnectionForTable('tx_nrpasskeysbe_credential')->insert('tx_nrpasskeysbe_credential', [
+            'uid' => 100,
+            'pid' => 0,
+            'be_user' => 102,
+            'credential_id' => 'credential-id-disabled-user',
+            'public_key_cose' => 'public-key-cose-data-disabled',
+            'sign_count' => 0,
+            'user_handle' => 'user-handle-disabled',
+            'aaguid' => '00000000-0000-0000-0000-000000000005',
+            'transports' => '["usb"]',
+            'label' => 'Disabled User Credential',
+            'created_at' => 1_700_000_000,
+            'last_used_at' => 0,
+            'revoked_at' => 0,
+            'revoked_by' => 0,
+            'deleted' => 0,
+        ]);
+
+        self::assertSame(3, $this->subject->countActiveCredentials());
+    }
+
+    #[Test]
+    public function countAggregatesMatchGetStats(): void
+    {
+        $stats = $this->subject->getStats();
+
+        self::assertSame($stats->totalUsers, $this->subject->countTotalActiveUsers());
+        self::assertSame($stats->usersWithPasskeys, $this->subject->countUsersWithPasskeys());
+    }
 }

--- a/Tests/Unit/Service/AdoptionStatsServiceTest.php
+++ b/Tests/Unit/Service/AdoptionStatsServiceTest.php
@@ -449,6 +449,7 @@ final class AdoptionStatsServiceTest extends TestCase
         $queryBuilder = $this->createMock(QueryBuilder::class);
         $queryBuilder->method('getRestrictions')->willReturn($restrictions);
         $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('join')->willReturnSelf();
         $queryBuilder->method('where')->willReturnSelf();
         $queryBuilder->method('expr')->willReturn($expressionBuilder);
         $queryBuilder->method('createNamedParameter')->willReturn("'mocked'");

--- a/Tests/Unit/Service/AdoptionStatsServiceTest.php
+++ b/Tests/Unit/Service/AdoptionStatsServiceTest.php
@@ -327,6 +327,59 @@ final class AdoptionStatsServiceTest extends TestCase
         self::assertSame('', $stats->usersWithoutPasskeys[0]->groups);
     }
 
+    #[Test]
+    public function countTotalActiveUsersReturnsAggregateCount(): void
+    {
+        $this->connectionPool
+            ->expects(self::once())
+            ->method('getQueryBuilderForTable')
+            ->with('be_users')
+            ->willReturn($this->createCountQueryBuilder(7));
+
+        self::assertSame(7, $this->subject->countTotalActiveUsers());
+    }
+
+    #[Test]
+    public function countUsersWithPasskeysReturnsAggregateCount(): void
+    {
+        $this->connectionPool
+            ->expects(self::once())
+            ->method('getQueryBuilderForTable')
+            ->with('tx_nrpasskeysbe_credential')
+            ->willReturn($this->createSelectLiteralQueryBuilder(4));
+
+        self::assertSame(4, $this->subject->countUsersWithPasskeys());
+    }
+
+    #[Test]
+    public function countActiveCredentialsReturnsAggregateCount(): void
+    {
+        $this->connectionPool
+            ->expects(self::once())
+            ->method('getQueryBuilderForTable')
+            ->with('tx_nrpasskeysbe_credential')
+            ->willReturn($this->createCountQueryBuilder(11));
+
+        self::assertSame(11, $this->subject->countActiveCredentials());
+    }
+
+    #[Test]
+    public function countActiveCredentialsReturnsZeroForNonNumericResult(): void
+    {
+        $queryBuilder = $this->createBaseQueryBuilder();
+        $queryBuilder->method('count')->willReturnSelf();
+
+        $result = $this->createMock(Result::class);
+        $result->method('fetchOne')->willReturn(false);
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $this->connectionPool
+            ->method('getQueryBuilderForTable')
+            ->willReturn($queryBuilder);
+
+        self::assertSame(0, $this->subject->countActiveCredentials());
+    }
+
     /**
      * Create a QueryBuilder mock that returns a count result.
      */

--- a/Tests/Unit/Widgets/AdminOnlyWidgetWiringTest.php
+++ b/Tests/Unit/Widgets/AdminOnlyWidgetWiringTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Tests\Unit\Widgets;
+
+use Netresearch\NrPasskeysBe\Widgets\AdminOnlyDoughnutChartWidget;
+use Netresearch\NrPasskeysBe\Widgets\AdminOnlyNumberWithIconWidget;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Dashboard\Widgets\AdminOnlyWidgetInterface;
+use TYPO3\CMS\Dashboard\Widgets\DoughnutChartWidget;
+use TYPO3\CMS\Dashboard\Widgets\NumberWithIconWidget;
+
+/**
+ * The dashboard's DashboardWidgetPass derives the adminOnly flag from the
+ * widget class implementing AdminOnlyWidgetInterface. These tests pin the
+ * marker wiring of the extension's widget subclasses so the widgets stay
+ * admin-only on TYPO3 v14.3+.
+ *
+ * Skipped on v12/v13 vendor sets where AdminOnlyWidgetInterface does not
+ * exist — there the subclasses are never registered nor loaded (see
+ * Configuration/Services.Dashboard.php). No #[CoversClass] on purpose:
+ * coverage metadata resolution would autoload the subclasses, which must
+ * not happen on v12/v13.
+ */
+final class AdminOnlyWidgetWiringTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (!\interface_exists(AdminOnlyWidgetInterface::class)) {
+            self::markTestSkipped('AdminOnlyWidgetInterface requires TYPO3 v14.3+');
+        }
+    }
+
+    #[Test]
+    public function doughnutWidgetIsAdminOnlyAndExtendsCoreWidget(): void
+    {
+        self::assertTrue(\is_a(AdminOnlyDoughnutChartWidget::class, AdminOnlyWidgetInterface::class, true));
+        self::assertTrue(\is_a(AdminOnlyDoughnutChartWidget::class, DoughnutChartWidget::class, true));
+    }
+
+    #[Test]
+    public function numberWithIconWidgetIsAdminOnlyAndExtendsCoreWidget(): void
+    {
+        self::assertTrue(\is_a(AdminOnlyNumberWithIconWidget::class, AdminOnlyWidgetInterface::class, true));
+        self::assertTrue(\is_a(AdminOnlyNumberWithIconWidget::class, NumberWithIconWidget::class, true));
+    }
+}

--- a/Tests/Unit/Widgets/DataProvider/ActiveCredentialsCountDataProviderTest.php
+++ b/Tests/Unit/Widgets/DataProvider/ActiveCredentialsCountDataProviderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Tests\Unit\Widgets\DataProvider;
+
+use Netresearch\NrPasskeysBe\Service\AdoptionStatsService;
+use Netresearch\NrPasskeysBe\Widgets\DataProvider\ActiveCredentialsCountDataProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ActiveCredentialsCountDataProvider::class)]
+final class ActiveCredentialsCountDataProviderTest extends TestCase
+{
+    #[Test]
+    public function getNumberReturnsActiveCredentialCount(): void
+    {
+        $adoptionStatsService = $this->createMock(AdoptionStatsService::class);
+        $adoptionStatsService
+            ->expects(self::once())
+            ->method('countActiveCredentials')
+            ->willReturn(42);
+
+        $subject = new ActiveCredentialsCountDataProvider($adoptionStatsService);
+
+        self::assertSame(42, $subject->getNumber());
+    }
+
+    #[Test]
+    public function getNumberReturnsZeroForEmptyInstallation(): void
+    {
+        $adoptionStatsService = $this->createMock(AdoptionStatsService::class);
+        $adoptionStatsService->method('countActiveCredentials')->willReturn(0);
+
+        $subject = new ActiveCredentialsCountDataProvider($adoptionStatsService);
+
+        self::assertSame(0, $subject->getNumber());
+    }
+}

--- a/Tests/Unit/Widgets/DataProvider/PasskeyAdoptionChartDataProviderTest.php
+++ b/Tests/Unit/Widgets/DataProvider/PasskeyAdoptionChartDataProviderTest.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Tests\Unit\Widgets\DataProvider;
+
+use Netresearch\NrPasskeysBe\Service\AdoptionStatsService;
+use Netresearch\NrPasskeysBe\Widgets\DataProvider\PasskeyAdoptionChartDataProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use TYPO3\CMS\Core\Localization\LanguageService;
+
+#[CoversClass(PasskeyAdoptionChartDataProvider::class)]
+final class PasskeyAdoptionChartDataProviderTest extends TestCase
+{
+    private PasskeyAdoptionChartDataProvider $subject;
+
+    private AdoptionStatsService&MockObject $adoptionStatsService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->adoptionStatsService = $this->createMock(AdoptionStatsService::class);
+        $this->subject = new PasskeyAdoptionChartDataProvider($this->adoptionStatsService);
+
+        // No LanguageService in unit context — the trait falls back to
+        // the English default labels.
+        unset($GLOBALS['LANG']);
+    }
+
+    #[Test]
+    public function getChartDataSplitsUsersIntoWithAndWithoutPasskeys(): void
+    {
+        $this->adoptionStatsService->method('countTotalActiveUsers')->willReturn(10);
+        $this->adoptionStatsService->method('countUsersWithPasskeys')->willReturn(6);
+
+        $chartData = $this->subject->getChartData();
+
+        self::assertSame(['With passkeys', 'Without passkeys'], $chartData['labels']);
+        self::assertCount(1, $chartData['datasets']);
+        self::assertSame([6, 4], $chartData['datasets'][0]['data']);
+    }
+
+    #[Test]
+    public function getChartDataProvidesOneColorPerSegment(): void
+    {
+        $this->adoptionStatsService->method('countTotalActiveUsers')->willReturn(3);
+        $this->adoptionStatsService->method('countUsersWithPasskeys')->willReturn(1);
+
+        $chartData = $this->subject->getChartData();
+
+        $colors = $chartData['datasets'][0]['backgroundColor'];
+        self::assertCount(2, $colors);
+        self::assertCount(2, \array_unique($colors));
+
+        foreach ($colors as $color) {
+            self::assertMatchesRegularExpression('/^#[0-9a-f]{6}$/i', $color);
+        }
+    }
+
+    #[Test]
+    public function getChartDataReturnsZerosForEmptyInstallation(): void
+    {
+        $this->adoptionStatsService->method('countTotalActiveUsers')->willReturn(0);
+        $this->adoptionStatsService->method('countUsersWithPasskeys')->willReturn(0);
+
+        $chartData = $this->subject->getChartData();
+
+        self::assertSame([0, 0], $chartData['datasets'][0]['data']);
+    }
+
+    #[Test]
+    public function getChartDataUsesTranslatedLabelsWhenLanguageServiceIsAvailable(): void
+    {
+        $languageService = $this->createMock(LanguageService::class);
+        $languageService->method('sL')->willReturnCallback(
+            static fn(string $key): string => match ($key) {
+                'LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang.xlf:widget.adoption.label.with_passkeys' => 'Mit Passkeys',
+                'LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang.xlf:widget.adoption.label.without_passkeys' => 'Ohne Passkeys',
+                default => '',
+            },
+        );
+        $GLOBALS['LANG'] = $languageService;
+
+        $this->adoptionStatsService->method('countTotalActiveUsers')->willReturn(1);
+        $this->adoptionStatsService->method('countUsersWithPasskeys')->willReturn(1);
+
+        $chartData = $this->subject->getChartData();
+
+        self::assertSame(['Mit Passkeys', 'Ohne Passkeys'], $chartData['labels']);
+    }
+
+    #[Test]
+    public function getChartDataClampsNegativeRemainderToZero(): void
+    {
+        // More passkey users than total users cannot happen with consistent
+        // data, but the widget must never render a negative segment.
+        $this->adoptionStatsService->method('countTotalActiveUsers')->willReturn(2);
+        $this->adoptionStatsService->method('countUsersWithPasskeys')->willReturn(5);
+
+        $chartData = $this->subject->getChartData();
+
+        self::assertSame([5, 0], $chartData['datasets'][0]['data']);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,11 @@
         "phpstan/extension-installer": "^1.4",
         "friendsofphp/php-cs-fixer": "^3.68",
         "typo3/testing-framework": "^8.2 || ^9.0",
+        "typo3/cms-dashboard": "^12.4 || ^13.4 || ^14.3",
         "phpat/phpat": "^0.12"
+    },
+    "suggest": {
+        "typo3/cms-dashboard": "Adds passkey adoption and credential-count widgets to the TYPO3 dashboard"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Problem

1. **Code examples unreadable in dark mode** (reported): on `/typo3/module/admin/vault` (TYPO3 14.3), the code examples in the Overview/Help templates rendered in the core magenta inline-code color. Root cause: TYPO3 v14 forces `code { color: var(--typo3-text-color-code) !important }` on every `<code>` element, and the `text-body` utility class the templates used to counter it **does not exist** in the v14 backend CSS — so multi-line examples showed as magenta-on-dark-grey.
2. `Resources/Public/Css/backend.css` was ~80 % dead code: `.vault-module`, `.vault-header`, `.vault-footer`, `.btn-accent`, `.vault-date-header`, `.vault-hash`, `.vault-chain-result` etc. are referenced by **no** template or JS module (verified by grep across `Resources/Private`, `Resources/Public/JavaScript`, `Classes/`). It also pinned a static light-scheme palette (`--nr-text: #585961` body text, `--nr-gray` borders). The file was only loaded by 2 of 5 module controllers.
3. Backend icons were generic Feather stroke-outline SVGs (24×24, `stroke="currentColor"`), not matching the TYPO3 v14 3-color fill icon style, and 4 of 5 submodules had **no** `iconIdentifier` at all. `Extension.svg` used a gradient + `<defs>`.

## Fix

**Dark mode ([`2f4a1c0`](https://github.com/netresearch/t3x-nr-vault/commit/2f4a1c0))**
- New `.vault-codeblock` class: adaptive surface/text via `var(--typo3-surface-container-low)`, `var(--typo3-component-border-color)`, `var(--typo3-text-color-base)` with `--bs-*` fallbacks (v13) and static last-resort values; `code { color: inherit !important }` to beat the core rule. Templates switched from `bg-body-tertiary`/`text-body` to it.
- backend.css pruned to what is actually used: teal badge accent (`#2F99A4`, core forces black badge text → contrast holds in both schemes) and the `.vault-col-*` audit column widths (CSP-motivated).
- backend.css now loaded by **all five** module controllers (Overview, Secrets, Analytics, Audit, Migration) instead of two.

**Icons ([`bb39199`](https://github.com/netresearch/t3x-nr-vault/commit/bb39199))**
- `module-vault.svg` + `vault-secret.svg` redrawn as 64×64 flat fill icons: `currentColor` primary, `opacity=".4"` secondary, single accent `var(--nr-icon-accent, #2F99A4)` (namespaced so backend CSS cannot override the brand teal with TYPO3 orange).
- New per-submodule icons registered and referenced in `Configuration/Backend/Modules.php` and used for the overview cards: `module-vault-secrets` (key), `module-vault-analytics` (chart), `module-vault-audit` (list shield), `module-vault-migration` (arrows).
- TYPO3 v13 support (`^13.4 || ^14.3`): every icon dual-ships a `*.legacy.svg` teal-tile variant selected at runtime via `Typo3Version` in `Configuration/Icons.php` (same pattern as nr-passkeys-be).
- `Extension.svg`: flat rounded-rect `#2F99A4` tile, white padlock, one orange `#FF4D00` accent dot — no gradient, no `<defs>`, no `<style>`.

## Test evidence

- `composer ci:test:php:cgl` — clean
- `composer ci:test:php:phpstan` — `[OK] No errors` (137 files)
- `composer ci:test:php:unit` — 1909 tests, 7528 assertions, OK
- `composer ci:test:php:fuzz` — 1514 tests OK; arch tests OK
- All 13 SVGs validated with `xmllint --noout`
- Headless-Chromium render check of every icon at 16/32/64 px on `#fff` and `#1a1a1a`: all glyphs legible on both, accent visible
- `Configuration/Icons.php` + `Modules.php` evaluated via PHP: all 6 identifiers resolve to existing files (v14 branch)

## Review follow-up

[8e543f2](https://github.com/netresearch/t3x-nr-passkeys-be/commit/8e543f2f00b8c40511c5bb1e77885d07de0ac5a0): `countActiveCredentials()` now joins `be_users` so leftover credentials of soft-deleted/disabled users are not counted (gemini-code-assist finding). Includes new functional tests (real DB) for the join and for the aggregate/getStats() consistency. CI re-ran fully green on the updated head.
