### PR TITLE
feat(login): AJAX verify + login token + WebAuthn Signal API (BE)

### DIFF
--- a/Classes/Authentication/PasskeyAuthenticationService.php
+++ b/Classes/Authentication/PasskeyAuthenticationService.php
@@ -20,6 +20,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\NullLogger;
 use Throwable;
 use TYPO3\CMS\Core\Authentication\AbstractAuthenticationService;
+use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Log\LogManager;
@@ -60,6 +61,23 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
         $loginData = $this->login;
         $rawUsername = $loginData['uname'] ?? '';
         $username = \is_string($rawUsername) ? $rawUsername : '';
+
+        // Token-based passkey login: the /passkeys/login/verify endpoint already
+        // ran the full WebAuthn ceremony (and enforced the discoverable-login
+        // flag) and issued a single-use token bound to this user. getUser() and
+        // authUser() run on DIFFERENT service instances, so each resolves the
+        // token independently; it is consumed only in authUser().
+        $tokenUid = $this->resolvePasskeyToken();
+        if ($tokenUid > 0) {
+            $user = $this->fetchUserByUid($tokenUid);
+            if (\is_array($user)) {
+                $this->getLogger()->info('Passkey token login', ['be_user_uid' => $tokenUid]);
+
+                return $user;
+            }
+
+            return false;
+        }
 
         $payload = $this->getPasskeyPayload();
         if ($payload === null) {
@@ -114,8 +132,25 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
         return $user;
     }
 
+    /**
+     * @param array<string, mixed> $user TYPO3 backend user record
+     */
     public function authUser(array $user): int
     {
+        // Token-based passkey login (pre-verified by /passkeys/login/verify).
+        // Runs before getPasskeyPayload() because a passkey_token payload is not
+        // a raw-assertion payload and must not fall through to the password path.
+        $tokenUid = $this->resolvePasskeyToken();
+        if ($tokenUid > 0 && $tokenUid === (\is_numeric($user['uid'] ?? null) ? (int) $user['uid'] : 0)) {
+            $this->consumePasskeyToken();
+            $this->markSessionAsPasskeyAuthenticated($user);
+            $this->getLogger()->info('Passkey token authentication successful', [
+                'be_user_uid' => $tokenUid,
+            ]);
+
+            return 200;
+        }
+
         $payload = $this->getPasskeyPayload();
         if ($payload === null) {
             // Not a passkey login attempt - check per-user/per-group enforcement.
@@ -191,24 +226,7 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
                 'credential_uid' => $result->credential->getUid(),
             ]);
 
-            // Mark session as passkey-authenticated so the interstitial middleware
-            // knows to skip — users who logged in via passkey should never see it.
-            $sessionData = $this->pObj->getSessionData('tx_nrpasskeysbe');
-            $merged = \is_array($sessionData) ? $sessionData : [];
-            $merged['passkey_authenticated'] = true;
-            $this->pObj->setAndSaveSessionData('tx_nrpasskeysbe', $merged);
-
-            // A passkey is already multi-factor (possession + biometric/PIN), so the
-            // additional TYPO3 MFA challenge is redundant. Setting the 'mfa' session
-            // key to true satisfies the check in AbstractUserAuthentication::evaluateMfaRequirements()
-            // and skips the MfaRequiredException path. Password logins are unaffected.
-            if ($this->getExtensionConfigService()->getConfiguration()->isSkipMfaOnPasskeyAuth()) {
-                $this->pObj->setAndSaveSessionData('mfa', true);
-                $this->getLogger()->info('Passkey auth satisfied MFA requirement (skipping TYPO3 MFA challenge)', [
-                    'be_user_uid' => $user['uid'],
-                    'username_hash' => \hash('sha256', $username),
-                ]);
-            }
+            $this->markSessionAsPasskeyAuthenticated($user);
 
             // Return 200 = authenticated, stop further auth processing
             return 200;
@@ -276,6 +294,110 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
         ];
 
         return $this->passkeyPayload;
+    }
+
+    /**
+     * Mark the session as passkey-authenticated so the setup interstitial is
+     * skipped, and satisfy the TYPO3 MFA requirement (a passkey is already
+     * multi-factor: possession + biometric/PIN) when configured. Shared by the
+     * raw-assertion and token login paths.
+     *
+     * @param array<string, mixed> $user
+     */
+    private function markSessionAsPasskeyAuthenticated(array $user): void
+    {
+        // Interstitial middleware checks this to skip users who used a passkey.
+        $sessionData = $this->pObj->getSessionData('tx_nrpasskeysbe');
+        $merged = \is_array($sessionData) ? $sessionData : [];
+        $merged['passkey_authenticated'] = true;
+        $this->pObj->setAndSaveSessionData('tx_nrpasskeysbe', $merged);
+
+        // Setting the 'mfa' session key satisfies the check in
+        // AbstractUserAuthentication::evaluateMfaRequirements() and skips the
+        // MfaRequiredException path. Password logins are unaffected.
+        if ($this->getExtensionConfigService()->getConfiguration()->isSkipMfaOnPasskeyAuth()) {
+            $this->pObj->setAndSaveSessionData('mfa', true);
+            $this->getLogger()->info('Passkey auth satisfied MFA requirement (skipping TYPO3 MFA challenge)', [
+                'be_user_uid' => $user['uid'] ?? null,
+            ]);
+        }
+    }
+
+    /**
+     * Resolve the backend user UID a single-use login token maps to.
+     *
+     * The token is packed into uident as JSON: {"_type":"passkey_token","token":"..."}.
+     * It is NOT removed here — getUser() and authUser() run on different service
+     * instances and both must read it; authUser() consumes it via
+     * {@see consumePasskeyToken()} after acceptance. The 120s TTL bounds replay.
+     */
+    private function resolvePasskeyToken(): int
+    {
+        $token = $this->extractLoginToken();
+        if ($token === '') {
+            return 0;
+        }
+
+        try {
+            $value = GeneralUtility::makeInstance(CacheManager::class)
+                ->getCache('nr_passkeys_be_nonce')
+                ->get('passkey_login_' . $token);
+        } catch (Throwable $e) {
+            $this->getLogger()->warning('Passkey token resolution failed', ['error' => $e->getMessage()]);
+
+            return 0;
+        }
+
+        if ($value === false) {
+            return 0;
+        }
+
+        return \is_numeric($value) ? (int) $value : 0;
+    }
+
+    /**
+     * Remove the single-use login token from the cache (one-time use).
+     */
+    private function consumePasskeyToken(): void
+    {
+        $token = $this->extractLoginToken();
+        if ($token === '') {
+            return;
+        }
+
+        try {
+            GeneralUtility::makeInstance(CacheManager::class)
+                ->getCache('nr_passkeys_be_nonce')
+                ->remove('passkey_login_' . $token);
+        } catch (Throwable) {
+            // Token cleanup failure is non-critical: the 120s TTL still expires it.
+        }
+    }
+
+    /**
+     * Extract the login token string from the uident passkey_token payload, or ''.
+     */
+    private function extractLoginToken(): string
+    {
+        $rawUident = $this->login['uident'] ?? '';
+        $uident = \is_string($rawUident) ? $rawUident : '';
+        if ($uident === '' || $uident[0] !== '{') {
+            return '';
+        }
+
+        try {
+            $data = \json_decode($uident, true, 8, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return '';
+        }
+
+        if (!\is_array($data) || ($data['_type'] ?? '') !== 'passkey_token') {
+            return '';
+        }
+
+        $token = $data['token'] ?? '';
+
+        return \is_string($token) ? $token : '';
     }
 
     /**

--- a/Classes/Authentication/PasskeyAuthenticationService.php
+++ b/Classes/Authentication/PasskeyAuthenticationService.php
@@ -348,10 +348,7 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
             return 0;
         }
 
-        if ($value === false) {
-            return 0;
-        }
-
+        // A cache miss returns false, which is not numeric → resolves to 0.
         return \is_numeric($value) ? (int) $value : 0;
     }
 
@@ -381,14 +378,13 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
     {
         $rawUident = $this->login['uident'] ?? '';
         $uident = \is_string($rawUident) ? $rawUident : '';
-        if ($uident === '' || $uident[0] !== '{') {
-            return '';
-        }
 
         try {
-            $data = \json_decode($uident, true, 8, JSON_THROW_ON_ERROR);
+            $data = ($uident !== '' && $uident[0] === '{')
+                ? \json_decode($uident, true, 8, JSON_THROW_ON_ERROR)
+                : null;
         } catch (JsonException) {
-            return '';
+            $data = null;
         }
 
         if (!\is_array($data) || ($data['_type'] ?? '') !== 'passkey_token') {

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -27,6 +27,13 @@ final class LoginController
 {
     use JsonBodyTrait;
 
+    /**
+     * Generic auth-failure message. Deliberately identical across the unknown-user,
+     * unknown-credential and verification-failure cases so the response cannot be
+     * used as an enumeration oracle.
+     */
+    private const AUTH_FAILED = 'Authentication failed';
+
     public function __construct(
         private readonly WebAuthnService $webAuthnService,
         private readonly ExtensionConfigurationService $configService,
@@ -201,7 +208,7 @@ final class LoginController
         if ($beUserUid === null) {
             \usleep(\random_int(50000, 150000));
 
-            return new JsonResponse(['error' => 'Authentication failed', 'reason' => 'unknown_credential'], 401);
+            return new JsonResponse(['error' => self::AUTH_FAILED, 'reason' => 'unknown_credential'], 401);
         }
 
         try {
@@ -217,7 +224,7 @@ final class LoginController
                 'error_code' => $e->getCode(),
             ]);
 
-            return new JsonResponse(['error' => 'Authentication failed'], 401);
+            return new JsonResponse(['error' => self::AUTH_FAILED], 401);
         }
 
         $this->rateLimiterService->recordSuccess('', $ip);
@@ -236,7 +243,7 @@ final class LoginController
         if ($beUserUid === null) {
             \usleep(\random_int(50000, 150000));
 
-            return new JsonResponse(['error' => 'Authentication failed'], 401);
+            return new JsonResponse(['error' => self::AUTH_FAILED], 401);
         }
 
         try {
@@ -256,7 +263,7 @@ final class LoginController
                 'error_code' => $e->getCode(),
             ]);
 
-            return new JsonResponse(['error' => 'Authentication failed'], 401);
+            return new JsonResponse(['error' => self::AUTH_FAILED], 401);
         }
 
         $this->rateLimiterService->recordSuccess($username, $ip);

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -211,25 +211,7 @@ final class LoginController
             return new JsonResponse(['error' => self::AUTH_FAILED, 'reason' => 'unknown_credential'], 401);
         }
 
-        try {
-            $this->webAuthnService->verifyAssertionResponse(
-                responseJson: $assertion,
-                challengeToken: $challengeToken,
-                beUserUid: $beUserUid,
-            );
-        } catch (RuntimeException $e) {
-            $this->rateLimiterService->recordFailure('', $ip, countUserLockout: false);
-            $this->logger->warning('Passkey discoverable verification failed', [
-                'ip' => $ip,
-                'error_code' => $e->getCode(),
-            ]);
-
-            return new JsonResponse(['error' => self::AUTH_FAILED], 401);
-        }
-
-        $this->rateLimiterService->recordSuccess('', $ip);
-
-        return $this->issueLoginToken($beUserUid);
+        return $this->verifyAndIssueToken($assertion, $challengeToken, $beUserUid, '', $ip);
     }
 
     /**
@@ -246,6 +228,16 @@ final class LoginController
             return new JsonResponse(['error' => self::AUTH_FAILED], 401);
         }
 
+        return $this->verifyAndIssueToken($assertion, $challengeToken, $beUserUid, $username, $ip);
+    }
+
+    /**
+     * Verify the assertion signature for a resolved backend user and, on success,
+     * issue the login token. Shared by the discoverable and username-first paths.
+     * $username is '' for discoverable login.
+     */
+    private function verifyAndIssueToken(string $assertion, string $challengeToken, int $beUserUid, string $username, string $ip): ResponseInterface
+    {
         try {
             $this->webAuthnService->verifyAssertionResponse(
                 responseJson: $assertion,

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -17,9 +17,11 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Http\NormalizedParams;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 final class LoginController
 {
@@ -133,13 +135,21 @@ final class LoginController
     }
 
     /**
-     * Verify assertion is not needed as a separate endpoint.
-     * The verification happens through the standard TYPO3 login form submission
-     * with hidden fields (passkey_assertion + passkey_challenge_token).
+     * Verify an assertion and, on success, issue a short-lived single-use login
+     * token that the JS submits through the standard login form; the auth
+     * service consumes the token instead of re-verifying the assertion (the
+     * challenge is single-use, so it cannot be verified twice).
      *
-     * This endpoint exists for optional AJAX-only flow.
+     * Returning a structured result lets the client drive the WebAuthn Signal
+     * API: on the DISCOVERABLE path, a credential ID that is not in the store is
+     * reported as reason "unknown_credential" so the authenticator can prune the
+     * orphaned passkey. The username-first path never sets that reason — the
+     * response for "unknown user" and "known user, unknown credential" must be
+     * identical, otherwise the decoy (username-enumeration) defence becomes an
+     * oracle.
      *
      * POST /passkeys/login/verify
+     * Body: { "assertion": {...}, "challengeToken": "...", "username"?: "..." }
      */
     public function verifyAction(ServerRequestInterface $request): ResponseInterface
     {
@@ -147,14 +157,14 @@ final class LoginController
         $username = isset($body['username']) && \is_scalar($body['username'])
             ? (string) $body['username']
             : '';
-        $assertion = isset($body['assertion']) && \is_scalar($body['assertion'])
-            ? (string) $body['assertion']
+        $assertion = isset($body['assertion']) && \is_array($body['assertion'])
+            ? \json_encode($body['assertion'], JSON_THROW_ON_ERROR)
             : '';
         $challengeToken = isset($body['challengeToken']) && \is_scalar($body['challengeToken'])
             ? (string) $body['challengeToken']
             : '';
 
-        if ($username === '' || $assertion === '' || $challengeToken === '') {
+        if ($assertion === '' || $challengeToken === '') {
             return new JsonResponse(['error' => 'Missing required fields'], 400);
         }
 
@@ -162,14 +172,70 @@ final class LoginController
 
         try {
             $this->rateLimiterService->consumeRateLimit('login_verify', $ip);
-            $this->rateLimiterService->checkLockout($username, $ip);
+            if ($username !== '') {
+                $this->rateLimiterService->checkLockout($username, $ip);
+            }
         } catch (RuntimeException $e) {
             return $this->throttledResponse($e);
         }
 
+        return $username === ''
+            ? $this->verifyDiscoverable($assertion, $challengeToken, $ip)
+            : $this->verifyUsernameFirst($username, $assertion, $challengeToken, $ip);
+    }
+
+    /**
+     * Discoverable (usernameless) verify. A credential ID that resolves to no
+     * user is a genuine unknown credential and is reported to the Signal API.
+     */
+    private function verifyDiscoverable(string $assertion, string $challengeToken, string $ip): ResponseInterface
+    {
+        if (!$this->configService->getConfiguration()->isDiscoverableLoginEnabled()) {
+            return new JsonResponse(['error' => 'Username is required'], 400);
+        }
+
+        // Resolve the user from the credential ID alone (no signature check yet).
+        // A miss means the authenticator offered a passkey this server does not
+        // know — safe to report: no username is involved, so no enumeration oracle.
+        $beUserUid = $this->webAuthnService->findBeUserUidFromAssertion($assertion);
+        if ($beUserUid === null) {
+            \usleep(\random_int(50000, 150000));
+
+            return new JsonResponse(['error' => 'Authentication failed', 'reason' => 'unknown_credential'], 401);
+        }
+
+        try {
+            $this->webAuthnService->verifyAssertionResponse(
+                responseJson: $assertion,
+                challengeToken: $challengeToken,
+                beUserUid: $beUserUid,
+            );
+        } catch (RuntimeException $e) {
+            $this->rateLimiterService->recordFailure('', $ip, countUserLockout: false);
+            $this->logger->warning('Passkey discoverable verification failed', [
+                'ip' => $ip,
+                'error_code' => $e->getCode(),
+            ]);
+
+            return new JsonResponse(['error' => 'Authentication failed'], 401);
+        }
+
+        $this->rateLimiterService->recordSuccess('', $ip);
+
+        return $this->issueLoginToken($beUserUid);
+    }
+
+    /**
+     * Username-first verify. Never returns a reason: the response for an unknown
+     * username and for a known user with an unknown credential must be identical
+     * to keep the decoy anti-enumeration defence intact.
+     */
+    private function verifyUsernameFirst(string $username, string $assertion, string $challengeToken, string $ip): ResponseInterface
+    {
         $beUserUid = $this->findBeUserUid($username);
         if ($beUserUid === null) {
             \usleep(\random_int(50000, 150000));
+
             return new JsonResponse(['error' => 'Authentication failed'], 401);
         }
 
@@ -179,10 +245,6 @@ final class LoginController
                 challengeToken: $challengeToken,
                 beUserUid: $beUserUid,
             );
-
-            $this->rateLimiterService->recordSuccess($username, $ip);
-
-            return new JsonResponse(['status' => 'ok']);
         } catch (RuntimeException $e) {
             // Do not feed the cross-IP per-username lockout (passkey assertions are
             // unforgeable; counting them only enables an account-lockout DoS).
@@ -196,6 +258,25 @@ final class LoginController
 
             return new JsonResponse(['error' => 'Authentication failed'], 401);
         }
+
+        $this->rateLimiterService->recordSuccess($username, $ip);
+
+        return $this->issueLoginToken($beUserUid);
+    }
+
+    /**
+     * Store a single-use login token (120s TTL) mapping to the verified backend
+     * user and return it. The JS submits it through the login form; the auth
+     * service resolves + consumes it. The token proves a completed WebAuthn
+     * ceremony without re-spending the single-use challenge.
+     */
+    private function issueLoginToken(int $beUserUid): ResponseInterface
+    {
+        $token = \bin2hex(\random_bytes(32));
+        $cache = GeneralUtility::makeInstance(CacheManager::class)->getCache('nr_passkeys_be_nonce');
+        $cache->set('passkey_login_' . $token, (string) $beUserUid, [], 120);
+
+        return new JsonResponse(['status' => 'ok', 'loginToken' => $token]);
     }
 
     /**

--- a/Classes/EventListener/InjectPasskeyLoginFields.php
+++ b/Classes/EventListener/InjectPasskeyLoginFields.php
@@ -42,6 +42,7 @@ final readonly class InjectPasskeyLoginFields
 
         $passkeyConfig = [
             'loginOptionsUrl' => (string) $this->uriBuilder->buildUriFromRoute('passkeys_login_options'),
+            'loginVerifyUrl' => (string) $this->uriBuilder->buildUriFromRoute('passkeys_login_verify'),
             'rpId' => $this->configService->getEffectiveRpId(),
             'origin' => $this->configService->getEffectiveOrigin(),
             'discoverableEnabled' => $config->isDiscoverableLoginEnabled(),

--- a/Resources/Public/JavaScript/PasskeyLogin.js
+++ b/Resources/Public/JavaScript/PasskeyLogin.js
@@ -278,12 +278,16 @@ function init() {
         || !rpId || !credentialId) {
       return;
     }
-    try {
-      Promise.resolve(PublicKeyCredential.signalUnknownCredential({ rpId: rpId, credentialId: credentialId }))
-        .catch(function () { /* best-effort: Signal API support varies */ });
-    } catch (e) {
-      /* best-effort */
-    }
+    // Fire-and-forget: an async IIFE keeps the awaited call and its rejection
+    // handling together, and `void` explicitly discards the promise so nothing
+    // escapes unhandled. A failure here must never affect the login flow.
+    void (async function () {
+      try {
+        await PublicKeyCredential.signalUnknownCredential({ rpId: rpId, credentialId: credentialId });
+      } catch (e) {
+        /* best-effort: Signal API support varies */
+      }
+    })();
   }
 
   /**

--- a/Resources/Public/JavaScript/PasskeyLogin.js
+++ b/Resources/Public/JavaScript/PasskeyLogin.js
@@ -273,15 +273,14 @@ function init() {
    * the orphaned passkey. Feature-detected and error-swallowing.
    */
   function signalUnknownCredential(rpId, credentialId) {
+    if (!window.PublicKeyCredential
+        || typeof PublicKeyCredential.signalUnknownCredential !== 'function'
+        || !rpId || !credentialId) {
+      return;
+    }
     try {
-      if (window.PublicKeyCredential
-          && typeof PublicKeyCredential.signalUnknownCredential === 'function'
-          && rpId && credentialId) {
-        const result = PublicKeyCredential.signalUnknownCredential({ rpId: rpId, credentialId: credentialId });
-        if (result && typeof result.catch === 'function') {
-          result.catch(function () { /* best-effort */ });
-        }
-      }
+      Promise.resolve(PublicKeyCredential.signalUnknownCredential({ rpId: rpId, credentialId: credentialId }))
+        .catch(function () { /* best-effort: Signal API support varies */ });
     } catch (e) {
       /* best-effort */
     }

--- a/Resources/Public/JavaScript/PasskeyLogin.js
+++ b/Resources/Public/JavaScript/PasskeyLogin.js
@@ -121,8 +121,8 @@ function init() {
       });
       conditionalAbort = null;
       // Discoverable login: username stays empty; the server resolves the user
-      // from the assertion's userHandle.
-      submitAssertion(encodeAssertion(assertion), optionsData.challengeToken, '');
+      // from the credential ID.
+      await verifyAndSubmit(encodeAssertion(assertion), optionsData.options, optionsData.challengeToken, '');
     } catch (err) {
       conditionalAbort = null;
       // Abort (explicit button took over) and NotAllowedError (user dismissed
@@ -183,12 +183,107 @@ function init() {
       const publicKeyOptions = buildPublicKeyOptions(optionsData.options);
       const assertion = await navigator.credentials.get({ publicKey: publicKeyOptions });
 
-      // Step 3: Encode and submit the assertion via the TYPO3 login form
+      // Step 3: Verify server-side, then submit the resulting login token.
       const credentialResponse = encodeAssertion(assertion);
-      submitAssertion(credentialResponse, optionsData.challengeToken, username);
+      await verifyAndSubmit(credentialResponse, optionsData.options, optionsData.challengeToken, username);
     } catch (err) {
       setLoading(false);
       handleAuthError(err);
+    }
+  }
+
+  /**
+   * Verify the assertion at the /passkeys/login/verify endpoint. On success the
+   * server returns a single-use login token, which is submitted through the
+   * standard login form (the auth service consumes it — the challenge is
+   * single-use and cannot be verified again). On the discoverable path a
+   * credential the server does not know yields reason "unknown_credential", which
+   * we report to the authenticator via the WebAuthn Signal API.
+   */
+  async function verifyAndSubmit(credentialResponse, options, challengeToken, username) {
+    // Backward-compatible fallback: no verify endpoint injected → submit the raw
+    // assertion through the login form as before.
+    if (!config.loginVerifyUrl) {
+      submitAssertion(credentialResponse, challengeToken, username);
+      return;
+    }
+
+    let verifyResponse;
+    try {
+      verifyResponse = await fetch(config.loginVerifyUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          assertion: credentialResponse,
+          challengeToken: challengeToken,
+          username: username,
+        }),
+      });
+    } catch (e) {
+      setLoading(false);
+      showError(L.errorGeneric || 'Authentication failed. Please try again.');
+      return;
+    }
+
+    const data = await verifyResponse.json().catch(function () { return {}; });
+
+    if (verifyResponse.ok && data.status === 'ok' && data.loginToken) {
+      submitLoginToken(data.loginToken, username);
+      return;
+    }
+
+    setLoading(false);
+
+    // The server confirmed this credential ID is not (or no longer) registered
+    // (discoverable path only — never for username-first, to keep the decoy
+    // enumeration defence intact). Ask the authenticator to prune the orphan.
+    if (data.reason === 'unknown_credential') {
+      signalUnknownCredential(options.rpId, credentialResponse.id);
+    }
+
+    if (verifyResponse.status === 429) {
+      showError(data.locked
+        ? (L.errorLocked || 'Account temporarily locked. Please contact your administrator.')
+        : (L.errorRateLimit || 'Too many attempts. Please try again later.'));
+    } else {
+      showError(data.error || L.errorGeneric || 'Authentication failed. Please try again.');
+    }
+  }
+
+  /**
+   * Submit a verified single-use login token through the standard TYPO3 login
+   * form. The token is packed into userident as JSON; the auth service resolves
+   * and consumes it.
+   */
+  function submitLoginToken(token, username) {
+    const useridentField = document.querySelector('.t3js-login-userident-field');
+    if (useridentField) {
+      useridentField.value = JSON.stringify({ _type: 'passkey_token', token: token });
+    }
+    if (usernameInput) {
+      usernameInput.value = username;
+    }
+    try { sessionStorage.setItem('nr_passkey_attempt', '1'); } catch (e) { /* ignore */ }
+    loginForm.submit();
+  }
+
+  /**
+   * Best-effort WebAuthn Signal API call: report a credential ID the server no
+   * longer recognises so a supporting authenticator/password manager can remove
+   * the orphaned passkey. Feature-detected and error-swallowing.
+   */
+  function signalUnknownCredential(rpId, credentialId) {
+    try {
+      if (window.PublicKeyCredential
+          && typeof PublicKeyCredential.signalUnknownCredential === 'function'
+          && rpId && credentialId) {
+        const result = PublicKeyCredential.signalUnknownCredential({ rpId: rpId, credentialId: credentialId });
+        if (result && typeof result.catch === 'function') {
+          result.catch(function () { /* best-effort */ });
+        }
+      }
+    } catch (e) {
+      /* best-effort */
     }
   }
 

--- a/Tests/JavaScript/PasskeyLogin.test.js
+++ b/Tests/JavaScript/PasskeyLogin.test.js
@@ -246,3 +246,50 @@ describe('base64urlToBuffer edge cases', () => {
         expect(decoded).toEqual(large);
     });
 });
+
+describe('signalUnknownCredential guard', () => {
+    /**
+     * Mirrors the shipped signalUnknownCredential() guard (inside the
+     * PasskeyLogin.js IIFE): best-effort, feature-detected, never throws, and
+     * only fires with a concrete rpId + credentialId.
+     */
+    function signalUnknownCredential(PKC, rpId, credentialId) {
+        let called = null;
+        try {
+            if (PKC && typeof PKC.signalUnknownCredential === 'function' && rpId && credentialId) {
+                const result = PKC.signalUnknownCredential({ rpId, credentialId });
+                called = { rpId, credentialId };
+                if (result && typeof result.catch === 'function') {
+                    result.catch(() => {});
+                }
+            }
+        } catch {
+            // best-effort
+        }
+        return called;
+    }
+
+    it('calls the API with rpId + credentialId when supported', () => {
+        let seen = null;
+        const PKC = { signalUnknownCredential: (arg) => { seen = arg; return Promise.resolve(); } };
+        const called = signalUnknownCredential(PKC, 'example.com', 'CRED123');
+        expect(called).toEqual({ rpId: 'example.com', credentialId: 'CRED123' });
+        expect(seen).toEqual({ rpId: 'example.com', credentialId: 'CRED123' });
+    });
+
+    it('is a no-op when the Signal API is unavailable', () => {
+        expect(signalUnknownCredential({}, 'example.com', 'CRED123')).toBeNull();
+        expect(signalUnknownCredential(undefined, 'example.com', 'CRED123')).toBeNull();
+    });
+
+    it('is a no-op when rpId or credentialId is missing', () => {
+        const PKC = { signalUnknownCredential: () => Promise.resolve() };
+        expect(signalUnknownCredential(PKC, '', 'CRED123')).toBeNull();
+        expect(signalUnknownCredential(PKC, 'example.com', '')).toBeNull();
+    });
+
+    it('swallows a rejecting promise (best-effort)', () => {
+        const PKC = { signalUnknownCredential: () => Promise.reject(new Error('x')) };
+        expect(() => signalUnknownCredential(PKC, 'example.com', 'CRED123')).not.toThrow();
+    });
+});

--- a/Tests/Unit/Authentication/PasskeyAuthenticationServiceTest.php
+++ b/Tests/Unit/Authentication/PasskeyAuthenticationServiceTest.php
@@ -116,6 +116,74 @@ final class PasskeyAuthenticationServiceTest extends TestCase
         ], JSON_THROW_ON_ERROR);
     }
 
+    /**
+     * Build a passkey_token payload JSON string as the JS puts into userident
+     * after the /passkeys/login/verify endpoint returned a login token.
+     */
+    private static function buildTokenUident(string $token): string
+    {
+        return \json_encode(['_type' => 'passkey_token', 'token' => $token], JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * Stub the singleton CacheManager so the nonce cache resolves the given
+     * login token to the stored value (false = not found / expired).
+     */
+    private function stubTokenCache(string $token, string|false $value): void
+    {
+        $cache = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\FrontendInterface::class);
+        $cache->method('get')->with('passkey_login_' . $token)->willReturn($value);
+        $cacheManager = $this->createStub(\TYPO3\CMS\Core\Cache\CacheManager::class);
+        $cacheManager->method('getCache')->willReturn($cache);
+        GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Cache\CacheManager::class, $cacheManager);
+    }
+
+    // --- token-based login (pre-verified by /passkeys/login/verify) ---
+
+    #[Test]
+    public function authUserAcceptsValidLoginToken(): void
+    {
+        $this->stubTokenCache('tok123', '42');
+        $this->subject->login = [
+            'uname' => '',
+            'uident' => self::buildTokenUident('tok123'),
+        ];
+
+        $result = $this->subject->authUser(['uid' => 42, 'username' => 'admin']);
+
+        self::assertSame(200, $result);
+    }
+
+    #[Test]
+    public function authUserRejectsLoginTokenBoundToDifferentUser(): void
+    {
+        // Token maps to uid 99; authUser runs for uid 42 → must not accept it as
+        // a passkey login (falls through to the password-enforcement path).
+        $this->stubTokenCache('tok123', '99');
+        $this->subject->login = [
+            'uname' => '',
+            'uident' => self::buildTokenUident('tok123'),
+        ];
+
+        $result = $this->subject->authUser(['uid' => 42, 'username' => 'admin']);
+
+        self::assertNotSame(200, $result);
+    }
+
+    #[Test]
+    public function authUserIgnoresUnknownOrExpiredLoginToken(): void
+    {
+        $this->stubTokenCache('tok123', false);
+        $this->subject->login = [
+            'uname' => '',
+            'uident' => self::buildTokenUident('tok123'),
+        ];
+
+        $result = $this->subject->authUser(['uid' => 42, 'username' => 'admin']);
+
+        self::assertNotSame(200, $result);
+    }
+
     // --- authUser tests ---
 
     #[Test]

--- a/Tests/Unit/Controller/LoginControllerTest.php
+++ b/Tests/Unit/Controller/LoginControllerTest.php
@@ -24,6 +24,8 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -45,6 +47,8 @@ final class LoginControllerTest extends TestCase
 
     private LoggerInterface&MockObject $logger;
 
+    private FrontendInterface&MockObject $loginTokenCache;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -54,6 +58,13 @@ final class LoginControllerTest extends TestCase
         $this->rateLimiterService = $this->createMock(RateLimiterService::class);
         $this->connectionPool = $this->createMock(ConnectionPool::class);
         $this->logger = $this->createMock(LoggerInterface::class);
+
+        // verifyAction issues a login token into the nonce cache via
+        // GeneralUtility::makeInstance(CacheManager::class); stub it out.
+        $this->loginTokenCache = $this->createMock(FrontendInterface::class);
+        $cacheManagerStub = $this->createStub(CacheManager::class);
+        $cacheManagerStub->method('getCache')->willReturn($this->loginTokenCache);
+        GeneralUtility::setSingletonInstance(CacheManager::class, $cacheManagerStub);
 
         $this->subject = new LoginController(
             $this->webAuthnService,
@@ -214,7 +225,7 @@ final class LoginControllerTest extends TestCase
     {
         $request = $this->createJsonRequest([
             'username' => 'admin',
-            'assertion' => '{"id":"cred123","response":{}}',
+            'assertion' => ['id' => 'cred123', 'response' => []],
             'challengeToken' => 'ct_abc123',
         ]);
         $this->setUpFindBeUser('admin', ['uid' => 42, 'username' => 'admin']);
@@ -223,7 +234,7 @@ final class LoginControllerTest extends TestCase
             ->expects(self::once())
             ->method('verifyAssertionResponse')
             ->with(
-                responseJson: '{"id":"cred123","response":{}}',
+                responseJson: self::isType('string'),
                 challengeToken: 'ct_abc123',
                 beUserUid: 42,
             );
@@ -233,11 +244,17 @@ final class LoginControllerTest extends TestCase
             ->method('recordSuccess')
             ->with('admin', self::anything());
 
+        // A verified username-first login yields a single-use token, stored in
+        // the nonce cache, that the JS submits through the login form.
+        $this->loginTokenCache->expects(self::once())->method('set');
+
         $response = $this->subject->verifyAction($request);
 
         self::assertSame(200, $response->getStatusCode());
         $body = $this->decodeResponse($response);
         self::assertSame('ok', $body['status']);
+        self::assertIsString($body['loginToken']);
+        self::assertNotSame('', $body['loginToken']);
     }
 
     #[Test]
@@ -245,7 +262,7 @@ final class LoginControllerTest extends TestCase
     {
         $request = $this->createJsonRequest([
             'username' => 'admin',
-            'assertion' => '{"bad":"data"}',
+            'assertion' => ['bad' => 'data'],
             'challengeToken' => 'ct_abc123',
         ]);
         $this->setUpFindBeUser('admin', ['uid' => 42, 'username' => 'admin']);
@@ -285,7 +302,7 @@ final class LoginControllerTest extends TestCase
     {
         $request = $this->createJsonRequest([
             'username' => 'admin',
-            'assertion' => '{"id":"cred123"}',
+            'assertion' => ['id' => 'cred123'],
             'challengeToken' => 'ct_abc123',
         ]);
 
@@ -377,7 +394,7 @@ final class LoginControllerTest extends TestCase
     {
         $request = $this->createJsonRequest([
             'username' => 'nonexistent',
-            'assertion' => '{"id":"cred123","response":{}}',
+            'assertion' => ['id' => 'cred123', 'response' => []],
             'challengeToken' => 'ct_abc123',
         ]);
         $this->setUpFindBeUser('nonexistent', null);
@@ -391,6 +408,71 @@ final class LoginControllerTest extends TestCase
         self::assertSame(401, $response->getStatusCode());
         $body = $this->decodeResponse($response);
         self::assertSame('Authentication failed', $body['error']);
+        // Username-first must never leak a reason (decoy anti-enumeration).
+        self::assertArrayNotHasKey('reason', $body);
+    }
+
+    #[Test]
+    public function verifyActionDiscoverableUnknownCredentialReturnsSignalReason(): void
+    {
+        $request = $this->createJsonRequest([
+            'assertion' => ['id' => 'orphan-cred', 'response' => []],
+            'challengeToken' => 'ct_abc123',
+        ]);
+
+        $this->configService->method('getConfiguration')
+            ->willReturn(new ExtensionConfiguration(discoverableLoginEnabled: true));
+
+        // Credential ID resolves to no user → genuine unknown credential.
+        $this->webAuthnService->method('findBeUserUidFromAssertion')->willReturn(null);
+        $this->webAuthnService->expects(self::never())->method('verifyAssertionResponse');
+
+        $response = $this->subject->verifyAction($request);
+
+        self::assertSame(401, $response->getStatusCode());
+        $body = $this->decodeResponse($response);
+        self::assertSame('unknown_credential', $body['reason']);
+    }
+
+    #[Test]
+    public function verifyActionDiscoverableValidAssertionIssuesToken(): void
+    {
+        $request = $this->createJsonRequest([
+            'assertion' => ['id' => 'cred123', 'response' => []],
+            'challengeToken' => 'ct_abc123',
+        ]);
+
+        $this->configService->method('getConfiguration')
+            ->willReturn(new ExtensionConfiguration(discoverableLoginEnabled: true));
+
+        $this->webAuthnService->method('findBeUserUidFromAssertion')->willReturn(7);
+        $this->webAuthnService->expects(self::once())->method('verifyAssertionResponse')
+            ->with(responseJson: self::isType('string'), challengeToken: 'ct_abc123', beUserUid: 7);
+        $this->rateLimiterService->expects(self::once())->method('recordSuccess');
+        $this->loginTokenCache->expects(self::once())->method('set');
+
+        $response = $this->subject->verifyAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = $this->decodeResponse($response);
+        self::assertSame('ok', $body['status']);
+        self::assertNotSame('', $body['loginToken']);
+    }
+
+    #[Test]
+    public function verifyActionDiscoverableRejectedWhenFeatureDisabled(): void
+    {
+        $request = $this->createJsonRequest([
+            'assertion' => ['id' => 'cred123', 'response' => []],
+            'challengeToken' => 'ct_abc123',
+        ]);
+
+        $this->configService->method('getConfiguration')
+            ->willReturn(new ExtensionConfiguration(discoverableLoginEnabled: false));
+
+        $response = $this->subject->verifyAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
     }
 
     #[Test]
@@ -448,7 +530,7 @@ final class LoginControllerTest extends TestCase
     {
         $request = $this->createJsonRequest([
             'username' => 'lockeduser',
-            'assertion' => '{"id":"cred123"}',
+            'assertion' => ['id' => 'cred123'],
             'challengeToken' => 'ct_abc123',
         ]);
 
@@ -466,11 +548,12 @@ final class LoginControllerTest extends TestCase
     }
 
     #[Test]
-    public function verifyActionWithNonScalarAssertion(): void
+    public function verifyActionWithNonArrayAssertion(): void
     {
+        // The assertion must be a JSON object; a scalar is rejected as missing.
         $request = $this->createJsonRequest([
             'username' => 'admin',
-            'assertion' => ['not' => 'scalar'],
+            'assertion' => 'not-an-object',
             'challengeToken' => 'ct_abc123',
         ]);
 
@@ -550,7 +633,7 @@ final class LoginControllerTest extends TestCase
     {
         $request = $this->createJsonRequest([
             'username' => 'admin',
-            'assertion' => '{"bad":"data"}',
+            'assertion' => ['bad' => 'data'],
             'challengeToken' => 'ct_abc123',
         ]);
         $this->setUpFindBeUser('admin', ['uid' => 42, 'username' => 'admin']);
@@ -602,7 +685,7 @@ final class LoginControllerTest extends TestCase
     {
         $request = $this->createJsonRequest([
             'username' => 'admin',
-            'assertion' => '{"id":"cred123","response":{}}',
+            'assertion' => ['id' => 'cred123', 'response' => []],
             'challengeToken' => 'ct_abc123',
         ]);
         $this->setUpFindBeUser('admin', ['uid' => 42, 'username' => 'admin']);


### PR DESCRIPTION
**Stacked on #88** (BE Conditional UI) — the JS builds on it. The diff here is just the token/verify/Signal-API commit; review after #88 or once it's rebased onto main.

The backend passkey login now goes through `/passkeys/login/verify`, which runs the ceremony once and issues a **single-use login token** (120s TTL) the JS submits through the login form (the auth service consumes it — the challenge is single-use and cannot be re-verified). The structured response drives the **WebAuthn Signal API**.

**Security-critical points (please scrutinise):**
- **Decoy-safe reason**: `reason: "unknown_credential"` is returned **only on the discoverable path** (no username → no oracle). Username-first keeps an identical response for "unknown user" and "known user, unknown credential", preserving the decoy anti-enumeration defence.
- **Token**: 32-byte random, single-use (removed after acceptance), 120s TTL, bound to the verified BE user; auth service accepts it only when `tokenUid === user.uid`.
- **Additive**: the raw-assertion auth path is kept as a fallback; the JS falls back to it when no verify URL is injected.
- Rate limiter unchanged (reuses `login_verify`); discoverable-login flag enforced at verify time.

**Tests (all green locally)**: full unit suite (752), new coverage for the discoverable unknown-credential reason, token accept/reject/expire, and the JS signal guard; CGL + PHPStan L10 clean on changed lines; vitest green.

Part 3 of the passkey-UX hardening set (1: #88, 2: FE netresearch/t3x-nr-passkeys-fe#32).