### PR TITLE
fix(controller): return 400 instead of crashing on a non-UTF-8 request body

### DIFF
--- a/Classes/Controller/JsonBodyTrait.php
+++ b/Classes/Controller/JsonBodyTrait.php
@@ -15,6 +15,30 @@ use Psr\Http\Message\ServerRequestInterface;
 trait JsonBodyTrait
 {
     /**
+     * Re-encode one section of the parsed body (the WebAuthn assertion or credential
+     * object) as the JSON string the ceremony services expect.
+     *
+     * Returns '' when the section is absent or not an object, and null when it cannot
+     * be encoded. That second case is not theoretical: a form-encoded request reaches
+     * getParsedBody() as the raw bytes PHP put in $_POST, so a value that is not valid
+     * UTF-8 makes json_encode throw JsonException — which extends \Exception, not
+     * RuntimeException, and so escaped the controllers' own catch blocks and surfaced
+     * as an uncaught-exception 500 on a public endpoint.
+     */
+    private function encodeBodySection(mixed $value): ?string
+    {
+        if (!\is_array($value)) {
+            return '';
+        }
+
+        try {
+            return \json_encode($value, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+    }
+
+    /**
      * @return array<string, mixed>
      */
     private function getJsonBody(ServerRequestInterface $request): array

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -174,15 +174,19 @@ final class LoginController
         $username = isset($body['username']) && \is_scalar($body['username'])
             ? (string) $body['username']
             : '';
-        $assertion = isset($body['assertion']) && \is_array($body['assertion'])
-            ? \json_encode($body['assertion'], JSON_THROW_ON_ERROR)
-            : '';
+
+        // null means the body could not be encoded (malformed UTF-8 from a form-encoded
+        // request); this endpoint is public, so that must not escape as a 500.
+        $assertion = $this->encodeBodySection($body['assertion'] ?? null);
         $challengeToken = isset($body['challengeToken']) && \is_scalar($body['challengeToken'])
             ? (string) $body['challengeToken']
             : '';
 
-        if ($assertion === '' || $challengeToken === '') {
-            return new JsonResponse(['error' => 'Missing required fields'], 400);
+        if ($assertion === null || $assertion === '' || $challengeToken === '') {
+            return new JsonResponse(
+                ['error' => $assertion === null ? 'Invalid request body' : 'Missing required fields'],
+                400,
+            );
         }
 
         $ip = $this->getRemoteAddress($request);

--- a/Classes/Controller/ManagementController.php
+++ b/Classes/Controller/ManagementController.php
@@ -102,7 +102,12 @@ final class ManagementController
         }
 
         $body = $this->getJsonBody($request);
-        $credentialJson = isset($body['credential']) ? \json_encode($body['credential'], JSON_THROW_ON_ERROR) : '';
+
+        $credentialJson = $this->encodeBodySection($body['credential'] ?? null);
+        if ($credentialJson === null) {
+            return new JsonResponse(['error' => 'Invalid request body'], 400);
+        }
+
         $rawToken = $body['challengeToken'] ?? '';
         $challengeToken = \is_string($rawToken) ? $rawToken : '';
         $rawLabel = $body['label'] ?? 'Passkey';

--- a/Tests/Unit/Controller/FormRequestTrait.php
+++ b/Tests/Unit/Controller/FormRequestTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Tests\Unit\Controller;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Builds a form-encoded request whose parsed body is returned verbatim.
+ *
+ * The JSON request helpers in the controller tests run their fixture through
+ * json_encode for the body stream, which throws on invalid UTF-8 and therefore
+ * cannot express a body carrying raw bytes. PHP populates $_POST from a
+ * form-encoded request without validating encoding, and getJsonBody() hands that
+ * array straight back, so this is the shape needed to cover the encoding guard.
+ */
+trait FormRequestTrait
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function createFormRequest(array $data): ServerRequestInterface&MockObject
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getParsedBody')->willReturn($data);
+
+        return $request;
+    }
+}

--- a/Tests/Unit/Controller/LoginControllerTest.php
+++ b/Tests/Unit/Controller/LoginControllerTest.php
@@ -35,6 +35,8 @@ use Webauthn\PublicKeyCredentialRequestOptions;
 #[CoversClass(LoginController::class)]
 final class LoginControllerTest extends TestCase
 {
+    use FormRequestTrait;
+
     private LoginController $subject;
 
     private WebAuthnService&MockObject $webAuthnService;
@@ -418,6 +420,28 @@ final class LoginControllerTest extends TestCase
 
         self::assertSame(401, $response->getStatusCode());
         self::assertSame('Authentication failed', $this->decodeResponse($response)['error']);
+    }
+
+    /**
+     * A non-UTF-8 byte in the form-encoded assertion used to throw JsonException out
+     * of verifyAction — before any try/catch — so an unauthenticated request produced
+     * an uncaught-exception 500 instead of the endpoint's JSON error contract.
+     */
+    #[Test]
+    public function verifyActionRejectsNonUtf8BodyWithABadRequestResponse(): void
+    {
+        $request = $this->createFormRequest([
+            'username' => 'admin',
+            'assertion' => ['clientDataJSON' => "\xFF\xFE"],
+            'challengeToken' => 'ct_abc123',
+        ]);
+
+        $this->webAuthnService->expects(self::never())->method('verifyAssertionResponse');
+
+        $response = $this->subject->verifyAction($request);
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame('Invalid request body', $this->decodeResponse($response)['error']);
     }
 
     #[Test]
@@ -853,6 +877,7 @@ final class LoginControllerTest extends TestCase
 
         return $request;
     }
+
 
     /**
      * Set up the ConnectionPool mock to simulate finding (or not finding) a BE user.

--- a/Tests/Unit/Controller/ManagementControllerTest.php
+++ b/Tests/Unit/Controller/ManagementControllerTest.php
@@ -36,6 +36,8 @@ use Webauthn\PublicKeyCredentialUserEntity;
 #[CoversClass(ManagementController::class)]
 final class ManagementControllerTest extends TestCase
 {
+    use FormRequestTrait;
+
     private ManagementController $subject;
 
     private WebAuthnService&MockObject $webAuthnService;
@@ -1055,6 +1057,22 @@ final class ManagementControllerTest extends TestCase
     }
 
     #[Test]
+    public function registrationVerifyActionRejectsNonUtf8BodyWithABadRequestResponse(): void
+    {
+        $this->setUpAuthenticatedUser(42, 'admin', 'Admin User');
+
+        $this->webAuthnService->expects(self::never())->method('verifyRegistrationResponse');
+
+        $response = $this->subject->registrationVerifyAction($this->createFormRequest([
+            'credential' => ['attestationObject' => "\xFF\xFE"],
+            'challengeToken' => 'ct_reg_abc',
+        ]));
+
+        self::assertSame(400, $response->getStatusCode());
+        self::assertSame('Invalid request body', $this->decodeResponse($response)['error']);
+    }
+
+    #[Test]
     public function registrationOptionsActionRefusedInSwitchUserMode(): void
     {
         $this->setUpAuthenticatedUser(42, 'maintainer', 'Maintainer', switchUserOriginalUid: 7);
@@ -1181,6 +1199,7 @@ final class ManagementControllerTest extends TestCase
 
         return $request;
     }
+
 
     /**
      * Decode a PSR-7 response body as JSON.


### PR DESCRIPTION
Closes the second finding from the completed Claude Security scan — the one whose verification panel a usage limit cut short in the earlier run.

## The problem

`getJsonBody()` returns `getParsedBody()` unchanged when it is already an array. For a form-encoded request that array holds the **raw bytes** PHP put in `$_POST`, which need not be valid UTF-8. Re-encoding them with `JSON_THROW_ON_ERROR` then throws `JsonException` — and `JsonException extends \Exception`, not `RuntimeException`.

Both call sites sit *before* their method's `try`/`catch`, so the exception left the controller:

| Site | Reachable by |
|---|---|
| `LoginController::verifyAction` (line 178) | **Unauthenticated** — the route is `access => public` |
| `ManagementController::registrationVerifyAction` (line 105) | An authenticated session |

`POST /typo3/passkeys/login/verify` with `Content-Type: application/x-www-form-urlencoded` and body `assertion[x]=%FF&challengeToken=a` produced an uncaught-exception 500 — a TYPO3 error page instead of the JSON error contract the endpoint documents, exception-log noise on every request, and on installations with `displayErrors`/`devIPmask` enabled (non-default) a rendered stack trace with file paths.

## The fix

Both encodes are wrapped and answer `400 Invalid request body`. The message is deliberately independent of any account state, so it adds no enumeration signal — `verifyAction` already returns a generic 400 for missing fields regardless of username.

## Verification

Both new tests were run against the unfixed controllers first and reproduce the defect exactly:

```
1) LoginControllerTest::verifyActionRejectsNonUtf8BodyWithABadRequestResponse
JsonException: Malformed UTF-8 characters, possibly incorrectly encoded
   Classes/Controller/LoginController.php:178

2) ManagementControllerTest::registrationVerifyActionRejectsNonUtf8BodyWithABadRequestResponse
JsonException: Malformed UTF-8 characters, possibly incorrectly encoded
   Classes/Controller/ManagementController.php:105
```

With the fix both return 400 and the WebAuthn service is never reached (asserted with `expects(never())`).

The tests use a new `createFormRequest()` helper: the existing `createJsonRequest()` runs the fixture through `json_encode` for the body stream, which would itself throw on non-UTF-8 input and could never express this case.

Local: unit 663, fuzz 131, PHP-CS-Fixer and PHPStan level 10 clean. Functional and E2E need MySQL — CI covers them.

## Why this existed after the last security PR

[#93](https://github.com/netresearch/t3x-nr-passkeys-be/pull/93) widened the catch around `verifyAssertionResponse` so a malformed *assertion object* could not escape as a 500. That fixed the verification boundary and left the **input** boundary in the same method untouched — the encode runs earlier and throws a different exception type. Same class of bug, one boundary further upstream.
