### PR TITLE
chore: exclude development files from the release archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,45 @@
+# Keep development files out of the release archive.
+#
+# `git archive` drops every path marked export-ignore. That governs the release
+# assets the Release workflow builds and the dist zips Packagist serves, so a
+# Composer install no longer pulls the test suites, CI workflows and dev tooling.
+#
+# It does NOT govern the TER upload: `tailor ter:publish` packs the working
+# directory using tailor's own list (conf/ExcludeFromPackaging.php) and never
+# reads .gitattributes — despite the CI warning that asks for this file citing
+# TER. Trimming the TER artefact would need TYPO3_EXCLUDE_FROM_PACKAGING instead.
+#
+# What ships is the code the extension needs at runtime (Classes/, Configuration/,
+# Resources/, ext_*.php, ext_tables.sql, ext_conf_template.txt, composer.json),
+# plus LICENSE, README.md, SECURITY.md and the documentation sources.
+
+# Development environment and CI
+/.ddev              export-ignore
+/.github            export-ignore
+/Build              export-ignore
+/codecov.yml        export-ignore
+
+# Test suites and their tooling
+/Tests              export-ignore
+/package.json       export-ignore
+/playwright.config.ts export-ignore
+/vitest.config.mjs  export-ignore
+
+# Repository-local tooling and editor configuration
+/.editorconfig      export-ignore
+/.envrc             export-ignore
+/.gitattributes     export-ignore
+/.gitignore         export-ignore
+/.semgrepignore     export-ignore
+/Makefile           export-ignore
+
+# Architecture decision records — not user documentation
+/docs               export-ignore
+
+# Contributor-facing files that add nothing to an installed extension
+/CODE_OF_CONDUCT.md export-ignore
+/CONTRIBUTING.md    export-ignore
+
+# Agent instruction files, at every level
+AGENTS.md           export-ignore
+CLAUDE.md           export-ignore


### PR DESCRIPTION
Clears the `.gitattributes file is missing` warning CI has emitted on every push, from the `Check .gitattributes for export-ignore` step in `netresearch/typo3-ci-workflows`.

## Why it matters

TER publishing and Composer dist packaging both build on `git archive`, which without export-ignore rules ships the entire repository. Every install of this extension currently carries the test suites, CI workflows, DDEV setup, build tooling and agent instruction files.

## Effect

`git archive` drops from **273 files to 120**.

Excluded: `.ddev/`, `.github/`, `Build/`, `Tests/`, `docs/`, `Makefile`, `codecov.yml`, `package.json`, `playwright.config.ts`, `vitest.config.mjs`, the repo-local dotfiles, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, and `AGENTS.md`/`CLAUDE.md` at every level.

Kept: `Classes/`, `Configuration/`, `Resources/`, `ext_*.php`, `ext_tables.sql`, `ext_conf_template.txt`, `composer.json`, `LICENSE`, `README.md`, `SECURITY.md`, `Documentation/`.

`Documentation/` stays deliberately — it is user-facing and small, and only the ADRs under `docs/` (internal decision records) are dropped.

## Verification

```
$ git archive --worktree-attributes HEAD | tar -t | grep -Eic 'AGENTS\.md|CLAUDE\.md|^Tests/|^Build/|^\.github/|^\.ddev/|^docs/'
0
$ git archive --worktree-attributes HEAD | tar -t | grep -Ec '^Classes/|^Configuration/|^Resources/|^ext_'
122
```

The upstream check's own condition passes:

```
$ grep -Ev '^[[:space:]]*#|^[[:space:]]*$' .gitattributes | grep -q 'export-ignore' && echo PASSES
PASSES
```

Template drift is unaffected — the `typo3-extension` template covers `.github/` only.
