### PR TITLE
fix(login): stop decoy credential IDs from encoding their own shape

### DIFF
--- a/Classes/Service/AssertionService.php
+++ b/Classes/Service/AssertionService.php
@@ -33,12 +33,12 @@ final class AssertionService
 {
     /**
      * Realistic credential-ID byte lengths. A single fixed length made every decoy
-     * recognisable: a 32-byte id is uncommon for real authenticators, which mostly
-     * emit 16 or 20 bytes.
+     * recognisable: real authenticators emit 16 or 20 bytes for platform credentials
+     * and commonly 32 or 64 for security keys.
      *
      * @var list<int>
      */
-    private const DECOY_ID_LENGTHS = [16, 20, 32];
+    private const DECOY_ID_LENGTHS = [16, 20, 32, 64];
 
     /**
      * Transport sets browsers actually report, plus the empty set real credentials
@@ -168,6 +168,10 @@ final class AssertionService
      * key, and no longer a fingerprint: the previous version always returned exactly
      * one 32-byte id with no transports, which no real response looks like.
      *
+     * The selectors and the id come from separate HMACs on purpose — see the comment
+     * at the derivation. Nothing an observer receives may let them recompute how that
+     * response was shaped, or the decoy identifies itself.
+     *
      * @return list<PublicKeyCredentialDescriptor>
      */
     private function buildDecoyDescriptors(string $username): array
@@ -179,24 +183,55 @@ final class AssertionService
             'nr_passkeys_be_decoy',
         );
 
-        $seed = \hash_hmac('sha256', $username, $derivedKey, true);
+        $seed = \hash_hmac('sha256', $username . '|count', $derivedKey, true);
         $count = 1 + (\ord($seed[0]) % 3);
 
         $descriptors = [];
         for ($index = 0; $index < $count; ++$index) {
-            $material = \hash_hmac('sha256', $username . '|' . $index, $derivedKey, true);
+            // Two independent derivations, and they must stay independent. The
+            // selectors decide how long the id is and which transports it claims; the
+            // id is what the caller actually receives. Taking both from one HMAC —
+            // publishing substr($material, 0, $length) after choosing $length from
+            // $material[0] — made every decoy verifiable from its own bytes: the
+            // caller could recompute DECOY_ID_LENGTHS[ord($id[0]) % n] and see it
+            // match, which no real credential does except by chance. Any response
+            // failing that check was then certainly a real, enrolled account, which is
+            // precisely the oracle these decoys exist to close.
+            $selectors = \hash_hmac('sha256', $username . '|' . $index . '|selectors', $derivedKey, true);
 
-            $length = self::DECOY_ID_LENGTHS[\ord($material[0]) % \count(self::DECOY_ID_LENGTHS)];
-            $transports = self::DECOY_TRANSPORT_SETS[\ord($material[1]) % \count(self::DECOY_TRANSPORT_SETS)];
+            $length = self::DECOY_ID_LENGTHS[\ord($selectors[0]) % \count(self::DECOY_ID_LENGTHS)];
+            $transports = self::DECOY_TRANSPORT_SETS[\ord($selectors[1]) % \count(self::DECOY_TRANSPORT_SETS)];
 
             $descriptors[] = PublicKeyCredentialDescriptor::create(
                 type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
-                id: \substr($material, 0, $length),
+                id: self::deriveDecoyId($derivedKey, $username . '|' . $index . '|id', $length),
                 transports: $transports,
             );
         }
 
         return $descriptors;
+    }
+
+    /**
+     * Derive a decoy credential id of the requested length.
+     *
+     * sha256 yields 32 bytes, so a 64-byte id needs a second block — and every block
+     * is its own keyed HMAC. Stretching by hashing the first block instead would make
+     * the tail computable from the head the caller already has, which is the same
+     * self-identifying defect one level down: `substr($id, 32) === sha256(substr($id, 0, 32) . '|1')`
+     * holds for every such decoy and for no real credential. Without the key, no byte
+     * of the result predicts any other.
+     */
+    private static function deriveDecoyId(string $derivedKey, string $label, int $length): string
+    {
+        $id = '';
+        $block = 0;
+        while (\strlen($id) < $length) {
+            $id .= \hash_hmac('sha256', $label . '|' . $block, $derivedKey, true);
+            ++$block;
+        }
+
+        return \substr($id, 0, $length);
     }
 
     /**

--- a/Tests/Unit/Service/AssertionDecoyTest.php
+++ b/Tests/Unit/Service/AssertionDecoyTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
 use Webauthn\PublicKeyCredentialDescriptor;
 
 /**
@@ -139,7 +140,7 @@ final class AssertionDecoyTest extends TestCase
 
         self::assertGreaterThan(1, \count($lengths), 'Decoy credential-ID length must not be fixed');
         foreach (\array_keys($lengths) as $length) {
-            self::assertContains($length, [16, 20, 32], 'Decoy IDs must use realistic byte lengths');
+            self::assertContains($length, [16, 20, 32, 64], 'Decoy IDs must use realistic byte lengths');
         }
     }
 
@@ -169,6 +170,107 @@ final class AssertionDecoyTest extends TestCase
         foreach (\array_keys($seen) as $transport) {
             self::assertContains($transport, ['internal', 'hybrid', 'usb', 'nfc']);
         }
+    }
+
+    /**
+     * The oracle the shape randomisation itself opened: the id length and transports
+     * were selected from the first two bytes of the same HMAC whose head was then
+     * published as the credential id. An unauthenticated caller could therefore
+     * recompute `strlen(id) === LENGTHS[ord(id[0]) % n]` and
+     * `transports === SETS[ord(id[1]) % m]` — relations that hold for every decoy and
+     * only by chance for a real credential, so any response failing them was certainly
+     * a real enrolled account.
+     *
+     * The selectors now come from a separate HMAC the caller never sees, so the
+     * relation must hold no more often than chance.
+     */
+    #[Test]
+    public function decoyIdDoesNotEncodeItsOwnLengthAndTransports(): void
+    {
+        // Read the real constants rather than restating them: they are public source,
+        // so an attacker uses exactly these, and a hardcoded copy would silently stop
+        // matching the implementation and make this test vacuous.
+        $reflection = new ReflectionClass(AssertionService::class);
+        /** @var list<int> $lengths */
+        $lengths = $reflection->getConstant('DECOY_ID_LENGTHS');
+        /** @var list<list<string>> $sets */
+        $sets = $reflection->getConstant('DECOY_TRANSPORT_SETS');
+
+        self::assertIsArray($lengths);
+        self::assertIsArray($sets);
+        self::assertNotSame([], $lengths);
+        self::assertNotSame([], $sets);
+
+        $total = 0;
+        $selfIdentifying = 0;
+
+        foreach (self::SAMPLE_USERNAMES as $username) {
+            foreach ($this->decoysFor($username) as $descriptor) {
+                ++$total;
+
+                // Exactly the test an attacker can run, using only what the endpoint
+                // returns: the raw credential id and the transports beside it.
+                $id = $descriptor->id;
+                $lengthMatches = \strlen($id) === $lengths[\ord($id[0]) % \count($lengths)];
+                $transportsMatch = $descriptor->transports === $sets[\ord($id[1]) % \count($sets)];
+
+                if ($lengthMatches && $transportsMatch) {
+                    ++$selfIdentifying;
+                }
+            }
+        }
+
+        self::assertGreaterThan(0, $total);
+
+        // Both relations holding is a 1-in-24 coincidence per descriptor once the
+        // derivations are independent; before the fix it was every single one.
+        self::assertLessThan(
+            $total / 2,
+            $selfIdentifying,
+            \sprintf(
+                'A decoy id must not encode its own shape: %d of %d descriptors are still self-identifying',
+                $selfIdentifying,
+                $total,
+            ),
+        );
+    }
+
+    /**
+     * The same defect one level down: an id longer than one sha256 block was first
+     * stretched by appending `sha256($material . '|1')` to `$material`, and the head
+     * of the id *is* `$material`. The tail was therefore computable from the published
+     * head with no key at all, so `substr($id, 32) === sha256(substr($id, 0, 32) . '|1')`
+     * identified every long decoy just as reliably as the shape relation did.
+     *
+     * Each block is now its own keyed HMAC, so no published byte predicts another.
+     */
+    #[Test]
+    public function longDecoyIdTailIsNotDerivableFromItsHead(): void
+    {
+        $longIds = 0;
+
+        foreach (self::SAMPLE_USERNAMES as $username) {
+            foreach ($this->decoysFor($username) as $descriptor) {
+                $id = $descriptor->id;
+                if (\strlen($id) <= 32) {
+                    continue;
+                }
+
+                ++$longIds;
+
+                self::assertNotSame(
+                    \substr($id, 32),
+                    \hash('sha256', \substr($id, 0, 32) . '|1', true),
+                    'A decoy id longer than one block must not let its tail be computed from its head',
+                );
+            }
+        }
+
+        self::assertGreaterThan(
+            0,
+            $longIds,
+            'The sample must contain ids longer than one sha256 block, or this proves nothing',
+        );
     }
 
     /**


### PR DESCRIPTION
Closes the finding from the Claude Security scan of the merged range `58f02dc..becdc53` — a defect in [#93](https://github.com/netresearch/t3x-nr-passkeys-be/pull/93)'s own anti-enumeration fix, confirmed 3-of-3 by two independent researchers.

## The problem

`buildDecoyDescriptors()` derived the credential-ID length from `$material[0]` and the transport set from `$material[1]`, then published `substr($material, 0, $length)` as the id. **The first two bytes the caller receives are the selectors that shaped the response.**

`DECOY_ID_LENGTHS` and `DECOY_TRANSPORT_SETS` are public constants in a GPL extension, so any unauthenticated caller of `POST /passkeys/login/options` can run:

```
strlen(id) === LENGTHS[ord(id[0]) % n]  &&  transports === SETS[ord(id[1]) % m]
```

The relation holds for **every** decoy, and for a real credential only by coincidence — never when the real id length falls outside the listed set, as with the 64-byte ids many security keys emit. The test is one-sided and therefore sound: **any response that fails it is certainly a real account with an enrolled passkey.** One request per username, and the per-IP rate limit slows but does not prevent a sweep.

That is precisely the oracle the decoys exist to close. To be accurate about severity: this is **not a regression** — the pre-#93 decoy was always a single 32-byte descriptor with no transports, distinguishable at a glance. The randomisation lowered the cost of the tell from "read the response" to "compute two modulo operations". It improved matters and did not achieve its goal.

## The fix

Selectors and id come from independent HMACs over distinct labels (`…|selectors`, `…|id`), and **every block of a multi-block id is its own keyed HMAC**.

That second part was found while reviewing this PR and matters as much as the first. The obvious way to stretch a long id — append `sha256($material . '|1')` to `$material`, which is how the first draft of this fix did it — leaves the tail computable from the head the caller already holds. `substr($id, 32) === sha256(substr($id, 0, 32) . '|1')` then identified every 64-byte decoy just as reliably as the shape relation did: the same oracle, one level down. Nothing the caller receives now predicts any other byte without the key.

`DECOY_ID_LENGTHS` gains `64` so decoys cover more of the population they hide in.

## Verification

Against the fixed sample of 24 usernames, applying exactly the attacker's test to only the published id and transports:

| oracle | before | after |
|---|---|---|
| shape relation (`strlen`/`transports` from `id[0]`, `id[1]`) | **47 / 47** descriptors | below chance |
| long-id tail derivable from published head | **15 / 15** 64-byte ids | none |

Both tests were run against the unfixed code first and observed to fail.

The new test reads `DECOY_ID_LENGTHS` and `DECOY_TRANSPORT_SETS` **by reflection** rather than restating them. That matters: an earlier draft hardcoded the new 4-element length list, which meant the modulo never lined up with the old 3-element one, so it **passed against the unfixed code** and proved nothing. Reading the real constants is also the faithful attacker model, since those constants are public source.

Local: unit 664, fuzz 131, PHP-CS-Fixer and PHPStan level 10 clean. Functional and E2E need MySQL — CI covers them.

## Deliberately not addressed

The finding also suggests deriving the length and transport distribution from the deployment's own stored credentials, so decoys match the local population. That adds a database query to an unauthenticated endpoint and has no sensible answer on an installation with no credentials yet, so it is left out of this change.

## Three SonarCloud smells left standing

The quality gate passes; these three are open and deliberate.

- **`php:S3011` (×2)** — reflection reads the private `DECOY_ID_LENGTHS` / `DECOY_TRANSPORT_SETS`. That is the point: the attacker uses the real constants, and a hardcoded copy is exactly what made the first draft of this test pass against the unfixed code. Making the constants public to satisfy the rule would widen the production API for a test's convenience.
- **`php:S3415`** — "swap expected/actual" on `assertLessThan($total / 2, $selfIdentifying, …)`. False positive: PHPUnit's signature is `assertLessThan($expected, $actual)`, asserting `actual < expected`, which is the order used.

They need marking as *Safe* / *Won't fix* in the SonarCloud UI — that cannot be done from the repository, since auto-analysis ignores `sonar.issue.ignore.*`.
