### PR TITLE
style(test): name the positional parameters in the ddev hook test

### DIFF
--- a/Build/Scripts/test-ddev-git-info.sh
+++ b/Build/Scripts/test-ddev-git-info.sh
@@ -33,17 +33,20 @@ SANITIZER="tr -cd 'A-Za-z0-9._/-'"
 failures=0
 
 fail() {
-    printf 'FAIL: %s\n' "$1" >&2
+    reason="$1"
+    printf 'FAIL: %s\n' "$reason" >&2
     failures=$((failures + 1))
 }
 
 pass() {
-    printf 'ok: %s\n' "$1"
+    reason="$1"
+    printf 'ok: %s\n' "$reason"
 }
 
 # Apply exactly the sanitization the sources apply.
 sanitize() {
-    printf '%s' "$1" | tr -cd 'A-Za-z0-9._/-' | cut -c1-100
+    raw_value="$1"
+    printf '%s' "$raw_value" | tr -cd 'A-Za-z0-9._/-' | cut -c1-100
 }
 
 # --- 1. The sources still sanitize -------------------------------------------


### PR DESCRIPTION
Clears three `shelldre:S7679` findings in `Build/Scripts/test-ddev-git-info.sh` — leftover from last week's security work.

## Why this surfaces only now

The shell analyzer arrived in `checks.yml` with [#99](https://github.com/netresearch/t3x-nr-passkeys-be/pull/99), after [#97](https://github.com/netresearch/t3x-nr-passkeys-be/pull/97) had merged. The rule did not exist in the repo at review time, so the finding was invisible then — not an overlooked comment.

## Change

`fail()`, `pass()` and `sanitize()` no longer read `$1` directly; each binds its argument to a named variable (`reason`, `raw_value`) first. Six lines, no behaviour change. `run_hook_shape()` already did this.

Deliberately without `local`: the script runs under `#!/bin/sh` and `local` is not POSIX, so shellcheck would raise SC3043. A plain assignment is enough here — the functions are short and never recurse.

## Verification

- Test green, 21 checks.
- Negative control: removing the sanitizer from `.ddev/config.yaml` produces `FAIL: config.yaml no longer applies tr -cd …`, exit 1. The test still carries its weight; the refactor did not blunt it.
- `shellcheck -S warning` clean, and it still runs under `dash` as well as `sh`.

Whether the three findings actually clear is for the Sonar re-analysis on this PR to say, not this description.
