### PR TITLE
feat(rector): enable rector with the shared org config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       typo3-versions: '["^12.4", "^13.4", "^14.3"]'
       typo3-packages: '["typo3/cms-core", "typo3/cms-backend", "typo3/cms-setup"]'
       php-extensions: 'intl, mbstring, xml, openssl, pdo_mysql'
-      run-rector: false
+      run-rector: true
       run-functional-tests: true
       functional-test-db: 'mysql'
       upload-coverage: false

--- a/Build/phpstan.neon
+++ b/Build/phpstan.neon
@@ -117,6 +117,18 @@ parameters:
         -
             message: '#should be contravariant with parameter#'
             reportUnmatched: false
+        # The system-maintainer list is coerced with the same expression TYPO3
+        # core uses in BackendUserAuthentication::isSystemMaintainer() and
+        # SystemMaintainerAllowanceCheck, so both lists resolve identically —
+        # any narrowing here (is_numeric/is_scalar) would make this check
+        # disagree with core's. PHPStan rejects it only because its intval()
+        # stub narrows the parameter that PHP itself declares as mixed, so
+        # intval(...) does not satisfy array_map's callable(mixed): mixed.
+        -
+            identifier: argument.type
+            message: '#\$callback of function array_map#'
+            path: %currentWorkingDirectory%/Classes/Form/Element/PasskeyInfoElement.php
+            reportUnmatched: false
         # IconSize enum does not exist in TYPO3 v12 (introduced in v13).
         # v12: getIcon() expects string; v13+: expects IconSize enum.
         # The enum_exists() runtime branch resolves correctly per-version,

--- a/Build/rector.php
+++ b/Build/rector.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
+
+$configure = require_once __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
+
+return static function (RectorConfig $rectorConfig) use ($configure): void {
+    // Shared org base config: code-quality sets, rule skips, importNames,
+    // phpVersion, and the package's ergebnis-free phpstan-rector.neon.
+    $configure($rectorConfig, __DIR__ . '/..');
+
+    // paths() REPLACES the shared list, so repeat it and add Tests/.
+    $rectorConfig->paths([
+        __DIR__ . '/../Classes',
+        __DIR__ . '/../Configuration',
+        __DIR__ . '/../Tests',
+        __DIR__ . '/../ext_localconf.php',
+        __DIR__ . '/../ext_tables.php',
+    ]);
+
+    $rectorConfig->skip([
+        // Every public method here is a framework entry point whose signature IS
+        // the contract, so an unused parameter is not dead code. The decisive
+        // case: both #[AsEventListener] listeners omit the `event:` argument, so
+        // TYPO3 v13/v14 resolves the event from the __invoke() parameter type —
+        // dropping it deregisters the listener. The AJAX route actions
+        // (Configuration/Backend/AjaxRoutes.php) and the Setup-module
+        // callUserFunction() panel are invoked with a request/params argument
+        // they must keep declaring.
+        RemoveUnusedPublicMethodParameterRector::class,
+    ]);
+};

--- a/Classes/Authentication/PasskeyAuthenticationService.php
+++ b/Classes/Authentication/PasskeyAuthenticationService.php
@@ -17,6 +17,7 @@ use Netresearch\NrPasskeysBe\Service\ExtensionConfigurationService;
 use Netresearch\NrPasskeysBe\Service\RateLimiterService;
 use Netresearch\NrPasskeysBe\Service\WebAuthnService;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Throwable;
 use TYPO3\CMS\Core\Authentication\AbstractAuthenticationService;
@@ -344,7 +345,7 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
             return 0;
         }
 
-        $payload = self::decodeLoginTokenPayload($value);
+        $payload = $this->decodeLoginTokenPayload($value);
         if ($payload === null || \time() > $payload['expiresAt']) {
             $this->getLogger()->warning('Passkey login token rejected', [
                 'reason' => $payload === null ? 'unusable_payload' : 'expired',
@@ -389,7 +390,7 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
      *
      * @return array{uid: int, expiresAt: int}|null
      */
-    private static function decodeLoginTokenPayload(string $value): ?array
+    private function decodeLoginTokenPayload(string $value): ?array
     {
         try {
             $payload = \json_decode($value, true, 8, JSON_THROW_ON_ERROR);
@@ -464,7 +465,7 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
         $queryBuilder = GeneralUtility::makeInstance(ConnectionPool::class)
             ->getQueryBuilderForTable('be_users');
 
-        $row = $queryBuilder
+        return $queryBuilder
             ->select('*')
             ->from('be_users')
             ->where(
@@ -477,8 +478,6 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
             )
             ->executeQuery()
             ->fetchAssociative();
-
-        return $row !== false ? $row : false;
     }
 
     /**
@@ -518,7 +517,7 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
 
     private function getWebAuthnService(): WebAuthnService
     {
-        if ($this->webAuthnService === null) {
+        if (!$this->webAuthnService instanceof WebAuthnService) {
             $this->webAuthnService = GeneralUtility::makeInstance(WebAuthnService::class);
         }
 
@@ -527,7 +526,7 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
 
     private function getExtensionConfigService(): ExtensionConfigurationService
     {
-        if ($this->configService === null) {
+        if (!$this->configService instanceof ExtensionConfigurationService) {
             $this->configService = GeneralUtility::makeInstance(ExtensionConfigurationService::class);
         }
 
@@ -536,16 +535,16 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
 
     private function getRateLimiterService(): RateLimiterService
     {
-        if ($this->rateLimiterService === null) {
+        if (!$this->rateLimiterService instanceof RateLimiterService) {
             $this->rateLimiterService = GeneralUtility::makeInstance(RateLimiterService::class);
         }
 
         return $this->rateLimiterService;
     }
 
-    private function getLogger(): \Psr\Log\LoggerInterface
+    private function getLogger(): LoggerInterface
     {
-        if ($this->logger === null) {
+        if (!$this->logger instanceof LoggerInterface) {
             try {
                 $this->setLogger(GeneralUtility::makeInstance(LogManager::class)->getLogger(static::class));
             } catch (Throwable) {
@@ -553,7 +552,7 @@ class PasskeyAuthenticationService extends AbstractAuthenticationService
             }
         }
 
-        \assert($this->logger instanceof \Psr\Log\LoggerInterface);
+        \assert($this->logger instanceof LoggerInterface);
 
         return $this->logger;
     }

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -12,27 +12,27 @@ namespace Netresearch\NrPasskeysBe\Configuration;
 /**
  * Typed, immutable value object for the extension's configuration settings.
  */
-final class ExtensionConfiguration
+final readonly class ExtensionConfiguration
 {
     private const VALID_USER_VERIFICATION = ['required', 'preferred', 'discouraged'];
 
-    private readonly string $userVerification;
+    private string $userVerification;
 
     public function __construct(
-        private readonly string $rpId = '',
-        private readonly string $rpName = 'TYPO3 Backend',
-        private readonly string $origin = '',
-        private readonly int $challengeTtlSeconds = 120,
+        private string $rpId = '',
+        private string $rpName = 'TYPO3 Backend',
+        private string $origin = '',
+        private int $challengeTtlSeconds = 120,
         string $userVerification = 'required',
-        private readonly bool $discoverableLoginEnabled = true,
-        private readonly bool $disablePasswordLogin = false,
-        private readonly bool $skipMfaOnPasskeyAuth = true,
-        private readonly int $rateLimitMaxAttempts = 10,
-        private readonly int $rateLimitWindowSeconds = 300,
-        private readonly int $lockoutThreshold = 5,
-        private readonly int $lockoutUserThreshold = 15,
-        private readonly int $lockoutDurationSeconds = 900,
-        private readonly string $allowedAlgorithms = 'ES256',
+        private bool $discoverableLoginEnabled = true,
+        private bool $disablePasswordLogin = false,
+        private bool $skipMfaOnPasskeyAuth = true,
+        private int $rateLimitMaxAttempts = 10,
+        private int $rateLimitWindowSeconds = 300,
+        private int $lockoutThreshold = 5,
+        private int $lockoutUserThreshold = 15,
+        private int $lockoutDurationSeconds = 900,
+        private string $allowedAlgorithms = 'ES256',
     ) {
         $this->userVerification = \in_array($userVerification, self::VALID_USER_VERIFICATION, true)
             ? $userVerification
@@ -124,6 +124,6 @@ final class ExtensionConfiguration
      */
     public function getAllowedAlgorithmsList(): array
     {
-        return \array_map('trim', \explode(',', $this->allowedAlgorithms));
+        return \array_map(trim(...), \explode(',', $this->allowedAlgorithms));
     }
 }

--- a/Classes/Controller/AdminController.php
+++ b/Classes/Controller/AdminController.php
@@ -189,16 +189,9 @@ final readonly class AdminController
             return new JsonResponse(['error' => 'Unauthorized'], 403);
         }
 
-        $body = $this->getJsonBody($request);
-        $rawUid = $body['beUserUid'] ?? null;
-        $beUserUid = \is_numeric($rawUid) ? (int) $rawUid : 0;
-
-        if ($beUserUid === 0) {
-            return new JsonResponse(['error' => 'Missing required fields'], 400);
-        }
-
-        if (!$this->isManagementAllowedFor($beUserUid)) {
-            return new JsonResponse(['error' => self::ERROR_INSUFFICIENT_PRIVILEGES], 403);
+        $beUserUid = $this->resolveManagedBeUserUid($this->getJsonBody($request));
+        if ($beUserUid instanceof ResponseInterface) {
+            return $beUserUid;
         }
 
         $credentials = $this->credentialRepository->findAllByBeUser($beUserUid);
@@ -299,34 +292,13 @@ final readonly class AdminController
             return new JsonResponse(['error' => 'Unauthorized'], 403);
         }
 
-        $body = $this->getJsonBody($request);
-
-        $rawUid = $body['beUserUid'] ?? null;
-        $beUserUid = \is_numeric($rawUid) ? (int) $rawUid : 0;
-
-        if ($beUserUid === 0) {
-            return new JsonResponse(['error' => 'Missing required fields'], 400);
+        $beUserUid = $this->resolveManagedBeUserUid($this->getJsonBody($request));
+        if ($beUserUid instanceof ResponseInterface) {
+            return $beUserUid;
         }
 
-        if (!$this->isManagementAllowedFor($beUserUid)) {
-            return new JsonResponse(['error' => self::ERROR_INSUFFICIENT_PRIVILEGES], 403);
-        }
-
-        // Verify the user exists and is active
-        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('be_users');
-        $queryBuilder->getRestrictions()->removeAll();
-        $row = $queryBuilder
-            ->select('uid', 'username')
-            ->from('be_users')
-            ->where(
-                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($beUserUid, Connection::PARAM_INT)),
-                $queryBuilder->expr()->eq('deleted', 0),
-                $queryBuilder->expr()->eq('disable', 0),
-            )
-            ->executeQuery()
-            ->fetchAssociative();
-
-        if ($row === false) {
+        $row = $this->findActiveBackendUser($beUserUid);
+        if ($row === null) {
             return new JsonResponse(['error' => 'User not found'], 404);
         }
 
@@ -369,34 +341,13 @@ final readonly class AdminController
             return new JsonResponse(['error' => 'Unauthorized'], 403);
         }
 
-        $body = $this->getJsonBody($request);
-
-        $rawUid = $body['beUserUid'] ?? null;
-        $beUserUid = \is_numeric($rawUid) ? (int) $rawUid : 0;
-
-        if ($beUserUid === 0) {
-            return new JsonResponse(['error' => 'Missing required fields'], 400);
+        $beUserUid = $this->resolveManagedBeUserUid($this->getJsonBody($request));
+        if ($beUserUid instanceof ResponseInterface) {
+            return $beUserUid;
         }
 
-        if (!$this->isManagementAllowedFor($beUserUid)) {
-            return new JsonResponse(['error' => self::ERROR_INSUFFICIENT_PRIVILEGES], 403);
-        }
-
-        // Verify the user exists and is active
-        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('be_users');
-        $queryBuilder->getRestrictions()->removeAll();
-        $row = $queryBuilder
-            ->select('uid', 'username')
-            ->from('be_users')
-            ->where(
-                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($beUserUid, Connection::PARAM_INT)),
-                $queryBuilder->expr()->eq('deleted', 0),
-                $queryBuilder->expr()->eq('disable', 0),
-            )
-            ->executeQuery()
-            ->fetchAssociative();
-
-        if ($row === false) {
+        $row = $this->findActiveBackendUser($beUserUid);
+        if ($row === null) {
             return new JsonResponse(['error' => 'User not found'], 404);
         }
 
@@ -419,4 +370,56 @@ final readonly class AdminController
         return new JsonResponse(['status' => 'ok']);
     }
 
+    /**
+     * Resolve the backend user an admin action targets, from the request body.
+     *
+     * Returns the uid, or the response to send when `beUserUid` is missing or
+     * when the acting admin may not manage that user. Only for the actions whose
+     * sole required field is `beUserUid`: where a second field is required too,
+     * its absence must still answer 400 before the privilege check answers 403.
+     *
+     * @param array<string, mixed> $body
+     */
+    private function resolveManagedBeUserUid(array $body): int|ResponseInterface
+    {
+        $rawUid = $body['beUserUid'] ?? null;
+        $beUserUid = \is_numeric($rawUid) ? (int) $rawUid : 0;
+
+        if ($beUserUid === 0) {
+            return new JsonResponse(['error' => 'Missing required fields'], 400);
+        }
+
+        if (!$this->isManagementAllowedFor($beUserUid)) {
+            return new JsonResponse(['error' => self::ERROR_INSUFFICIENT_PRIVILEGES], 403);
+        }
+
+        return $beUserUid;
+    }
+
+    /**
+     * Look up a backend user that exists and is neither deleted nor disabled.
+     *
+     * Restrictions are removed so those two conditions are stated in the query
+     * rather than left to the default restriction set. Returns null when no such
+     * row exists.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function findActiveBackendUser(int $beUserUid): ?array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('be_users');
+        $queryBuilder->getRestrictions()->removeAll();
+        $row = $queryBuilder
+            ->select('uid', 'username')
+            ->from('be_users')
+            ->where(
+                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($beUserUid, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('deleted', 0),
+                $queryBuilder->expr()->eq('disable', 0),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        return $row === false ? null : $row;
+    }
 }

--- a/Classes/Controller/AdminController.php
+++ b/Classes/Controller/AdminController.php
@@ -9,7 +9,10 @@ declare(strict_types=1);
 
 namespace Netresearch\NrPasskeysBe\Controller;
 
+use Netresearch\NrPasskeysBe\Domain\Dto\AdminCredentialInfo;
+use Netresearch\NrPasskeysBe\Domain\Dto\AuthenticatedUser;
 use Netresearch\NrPasskeysBe\Domain\Enum\EnforcementLevel;
+use Netresearch\NrPasskeysBe\Domain\Model\Credential;
 use Netresearch\NrPasskeysBe\Service\CredentialRepository;
 use Netresearch\NrPasskeysBe\Service\RateLimiterService;
 use Psr\Http\Message\ResponseInterface;
@@ -25,7 +28,7 @@ use TYPO3\CMS\Core\Http\JsonResponse;
  * Provides AJAX endpoints for listing, revoking, and unlocking passkeys,
  * updating group enforcement levels, and sending setup reminders.
  */
-final class AdminController
+final readonly class AdminController
 {
     use BackendUserTrait;
     use JsonBodyTrait;
@@ -35,10 +38,10 @@ final class AdminController
     private const ERROR_INSUFFICIENT_PRIVILEGES = 'Insufficient privileges to manage this user';
 
     public function __construct(
-        private readonly CredentialRepository $credentialRepository,
-        private readonly RateLimiterService $rateLimiterService,
-        private readonly ConnectionPool $connectionPool,
-        private readonly LoggerInterface $logger,
+        private CredentialRepository $credentialRepository,
+        private RateLimiterService $rateLimiterService,
+        private ConnectionPool $connectionPool,
+        private LoggerInterface $logger,
     ) {}
 
     /**
@@ -49,7 +52,7 @@ final class AdminController
     public function listAction(ServerRequestInterface $request): ResponseInterface
     {
         $admin = $this->requireAdmin();
-        if ($admin === null) {
+        if (!$admin instanceof AuthenticatedUser) {
             return new JsonResponse(['error' => 'Unauthorized'], 403);
         }
 
@@ -67,7 +70,7 @@ final class AdminController
 
         $credentials = $this->credentialRepository->findAllByBeUser($beUserUid);
         $list = \array_map(
-            static fn($cred) => $cred->toAdminCredentialInfo(),
+            static fn(Credential $cred): AdminCredentialInfo => $cred->toAdminCredentialInfo(),
             $credentials,
         );
 
@@ -87,7 +90,7 @@ final class AdminController
     public function removeAction(ServerRequestInterface $request): ResponseInterface
     {
         $admin = $this->requireAdmin();
-        if ($admin === null) {
+        if (!$admin instanceof AuthenticatedUser) {
             return new JsonResponse(['error' => 'Unauthorized'], 403);
         }
 
@@ -107,7 +110,7 @@ final class AdminController
 
         // Verify the credential belongs to the specified user
         $credential = $this->credentialRepository->findByUidAndBeUser($credentialUid, $beUserUid);
-        if ($credential === null) {
+        if (!$credential instanceof Credential) {
             return new JsonResponse(['error' => 'Credential not found for this user'], 404);
         }
 
@@ -131,7 +134,7 @@ final class AdminController
     public function unlockAction(ServerRequestInterface $request): ResponseInterface
     {
         $admin = $this->requireAdmin();
-        if ($admin === null) {
+        if (!$admin instanceof AuthenticatedUser) {
             return new JsonResponse(['error' => 'Unauthorized'], 403);
         }
 
@@ -154,7 +157,7 @@ final class AdminController
         $row = $queryBuilder
             ->select('uid', 'username')
             ->from('be_users')
-            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($beUserUid, \TYPO3\CMS\Core\Database\Connection::PARAM_INT)))
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($beUserUid, Connection::PARAM_INT)))
             ->executeQuery()
             ->fetchAssociative();
 
@@ -182,7 +185,7 @@ final class AdminController
     public function revokeAllAction(ServerRequestInterface $request): ResponseInterface
     {
         $admin = $this->requireAdmin();
-        if ($admin === null) {
+        if (!$admin instanceof AuthenticatedUser) {
             return new JsonResponse(['error' => 'Unauthorized'], 403);
         }
 
@@ -226,7 +229,7 @@ final class AdminController
     public function updateEnforcementAction(ServerRequestInterface $request): ResponseInterface
     {
         $admin = $this->requireAdmin();
-        if ($admin === null) {
+        if (!$admin instanceof AuthenticatedUser) {
             return new JsonResponse(['error' => 'Unauthorized'], 403);
         }
 
@@ -292,7 +295,7 @@ final class AdminController
     public function sendReminderAction(ServerRequestInterface $request): ResponseInterface
     {
         $admin = $this->requireAdmin();
-        if ($admin === null) {
+        if (!$admin instanceof AuthenticatedUser) {
             return new JsonResponse(['error' => 'Unauthorized'], 403);
         }
 
@@ -362,7 +365,7 @@ final class AdminController
     public function clearNudgeAction(ServerRequestInterface $request): ResponseInterface
     {
         $admin = $this->requireAdmin();
-        if ($admin === null) {
+        if (!$admin instanceof AuthenticatedUser) {
             return new JsonResponse(['error' => 'Unauthorized'], 403);
         }
 

--- a/Classes/Controller/AdminModuleController.php
+++ b/Classes/Controller/AdminModuleController.php
@@ -160,6 +160,7 @@ final class AdminModuleController
         if ($activeTab === 'dashboard') {
             $dashboardItem->setActive(true);
         }
+
         $menu->addMenuItem($dashboardItem);
 
         $helpItem = $this->createMenuItem($menu)
@@ -168,6 +169,7 @@ final class AdminModuleController
         if ($activeTab === 'help') {
             $helpItem->setActive(true);
         }
+
         $menu->addMenuItem($helpItem);
 
         $menuRegistry->addMenu($menu);
@@ -180,7 +182,7 @@ final class AdminModuleController
     private function createMenu(MenuRegistry $menuRegistry): Menu
     {
         $factory = $this->componentFactory();
-        if ($factory !== null) {
+        if ($factory instanceof ComponentFactory) {
             return $factory->createMenu();
         }
 
@@ -194,7 +196,7 @@ final class AdminModuleController
     private function createMenuItem(Menu $menu): MenuItem
     {
         $factory = $this->componentFactory();
-        if ($factory !== null) {
+        if ($factory instanceof ComponentFactory) {
             return $factory->createMenuItem();
         }
 
@@ -263,7 +265,7 @@ final class AdminModuleController
     private function createLinkButton(ButtonBar $buttonBar): LinkButton
     {
         $factory = $this->componentFactory();
-        if ($factory !== null) {
+        if ($factory instanceof ComponentFactory) {
             return $factory->createLinkButton();
         }
 

--- a/Classes/Controller/LoginController.php
+++ b/Classes/Controller/LoginController.php
@@ -23,7 +23,7 @@ use TYPO3\CMS\Core\Http\JsonResponse;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-final class LoginController
+final readonly class LoginController
 {
     use JsonBodyTrait;
 
@@ -55,11 +55,11 @@ final class LoginController
     private const TIMING_BUDGET_NS = 150_000_000;
 
     public function __construct(
-        private readonly WebAuthnService $webAuthnService,
-        private readonly ExtensionConfigurationService $configService,
-        private readonly RateLimiterService $rateLimiterService,
-        private readonly ConnectionPool $connectionPool,
-        private readonly LoggerInterface $logger,
+        private WebAuthnService $webAuthnService,
+        private ExtensionConfigurationService $configService,
+        private RateLimiterService $rateLimiterService,
+        private ConnectionPool $connectionPool,
+        private LoggerInterface $logger,
     ) {}
 
     /**
@@ -296,7 +296,7 @@ final class LoginController
                 'username_hash' => \hash('sha256', $username),
                 'ip' => $ip,
                 'error_code' => $e->getCode(),
-                'error_class' => \get_class($e),
+                'error_class' => $e::class,
             ]);
 
             return new JsonResponse(['error' => self::AUTH_FAILED], 401);

--- a/Classes/Controller/ManagementController.php
+++ b/Classes/Controller/ManagementController.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Netresearch\NrPasskeysBe\Controller;
 
 use Netresearch\NrPasskeysBe\Domain\Dto\AuthenticatedUser;
+use Netresearch\NrPasskeysBe\Domain\Dto\CredentialInfo;
+use Netresearch\NrPasskeysBe\Domain\Model\Credential;
 use Netresearch\NrPasskeysBe\Service\CredentialRepository;
 use Netresearch\NrPasskeysBe\Service\EnforcementService;
 use Netresearch\NrPasskeysBe\Service\ExtensionConfigurationService;
@@ -23,18 +25,18 @@ use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\JsonResponse;
 
-final class ManagementController
+final readonly class ManagementController
 {
     use BackendUserTrait;
     use JsonBodyTrait;
     use TypeCastTrait;
 
     public function __construct(
-        private readonly WebAuthnService $webAuthnService,
-        private readonly CredentialRepository $credentialRepository,
-        private readonly ExtensionConfigurationService $configService,
-        private readonly EnforcementService $enforcementService,
-        private readonly LoggerInterface $logger,
+        private WebAuthnService $webAuthnService,
+        private CredentialRepository $credentialRepository,
+        private ExtensionConfigurationService $configService,
+        private EnforcementService $enforcementService,
+        private LoggerInterface $logger,
     ) {}
 
     /**
@@ -45,7 +47,7 @@ final class ManagementController
     public function registrationOptionsAction(ServerRequestInterface $request): ResponseInterface
     {
         $user = $this->getAuthenticatedUser();
-        if ($user === null) {
+        if (!$user instanceof AuthenticatedUser) {
             return new JsonResponse(['error' => 'Not authenticated'], 401);
         }
 
@@ -93,7 +95,7 @@ final class ManagementController
     public function registrationVerifyAction(ServerRequestInterface $request): ResponseInterface
     {
         $user = $this->getAuthenticatedUser();
-        if ($user === null) {
+        if (!$user instanceof AuthenticatedUser) {
             return new JsonResponse(['error' => 'Not authenticated'], 401);
         }
 
@@ -166,13 +168,13 @@ final class ManagementController
     public function listAction(ServerRequestInterface $request): ResponseInterface
     {
         $user = $this->getAuthenticatedUser();
-        if ($user === null) {
+        if (!$user instanceof AuthenticatedUser) {
             return new JsonResponse(['error' => 'Not authenticated'], 401);
         }
 
         $credentials = $this->credentialRepository->findByBeUser($user->uid);
         $list = \array_map(
-            static fn($cred) => $cred->toCredentialInfo(),
+            static fn(Credential $cred): CredentialInfo => $cred->toCredentialInfo(),
             $credentials,
         );
 
@@ -231,7 +233,7 @@ final class ManagementController
     public function renameAction(ServerRequestInterface $request): ResponseInterface
     {
         $user = $this->getAuthenticatedUser();
-        if ($user === null) {
+        if (!$user instanceof AuthenticatedUser) {
             return new JsonResponse(['error' => 'Not authenticated'], 401);
         }
 
@@ -255,7 +257,7 @@ final class ManagementController
 
         // Verify ownership
         $credential = $this->credentialRepository->findByUidAndBeUser($credentialUid, $user->uid);
-        if ($credential === null) {
+        if (!$credential instanceof Credential) {
             return new JsonResponse(['error' => 'Credential not found'], 404);
         }
 
@@ -279,7 +281,7 @@ final class ManagementController
     public function removeAction(ServerRequestInterface $request): ResponseInterface
     {
         $user = $this->getAuthenticatedUser();
-        if ($user === null) {
+        if (!$user instanceof AuthenticatedUser) {
             return new JsonResponse(['error' => 'Not authenticated'], 401);
         }
 
@@ -296,7 +298,7 @@ final class ManagementController
 
         // Verify ownership
         $credential = $this->credentialRepository->findByUidAndBeUser($credentialUid, $user->uid);
-        if ($credential === null) {
+        if (!$credential instanceof Credential) {
             return new JsonResponse(['error' => 'Credential not found'], 404);
         }
 

--- a/Classes/Domain/Dto/EnforcementStatus.php
+++ b/Classes/Domain/Dto/EnforcementStatus.php
@@ -93,10 +93,6 @@ final readonly class EnforcementStatus
             return false;
         }
 
-        if ($this->level === EnforcementLevel::Required && $this->isGracePeriodExpired($currentTime)) {
-            return false;
-        }
-
-        return true;
+        return $this->level !== EnforcementLevel::Required || !$this->isGracePeriodExpired($currentTime);
     }
 }

--- a/Classes/Domain/Model/Credential.php
+++ b/Classes/Domain/Model/Credential.php
@@ -19,6 +19,7 @@ use Netresearch\NrPasskeysBe\Utility\TypeCastTrait;
 final class Credential
 {
     use TypeCastTrait;
+
     public function __construct(
         private int $uid = 0,
         private int $pid = 0,
@@ -136,7 +137,7 @@ final class Credential
             return [];
         }
 
-        return \array_values(\array_filter($decoded, '\is_string'));
+        return \array_values(\array_filter($decoded, \is_string(...)));
     }
 
     /**

--- a/Classes/Form/Element/PasskeyInfoElement.php
+++ b/Classes/Form/Element/PasskeyInfoElement.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrPasskeysBe\Form\Element;
 
+use Netresearch\NrPasskeysBe\Domain\Model\Credential;
 use Netresearch\NrPasskeysBe\Service\CredentialRepository;
 use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;
 use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
@@ -78,7 +79,7 @@ class PasskeyInfoElement extends AbstractFormElement
             $sysConf = \is_array($typo3Conf) ? ($typo3Conf['SYS'] ?? null) : null;
             $systemMaintainers = \is_array($sysConf) ? ($sysConf['systemMaintainers'] ?? []) : [];
             if (\is_array($systemMaintainers) && $systemMaintainers !== []) {
-                $systemMaintainerIds = \array_map('\intval', $systemMaintainers);
+                $systemMaintainerIds = \array_map(\intval(...), $systemMaintainers);
                 $targetIsSystemMaintainer = \in_array($userId, $systemMaintainerIds, true);
                 if ($targetIsSystemMaintainer && !$currentBackendUser->isSystemMaintainer()) {
                     $isManagementAllowed = false;
@@ -89,7 +90,7 @@ class PasskeyInfoElement extends AbstractFormElement
         $credentials = $this->credentialRepository->findAllByBeUser($userId);
         $activeCount = \count(\array_filter(
             $credentials,
-            static fn(\Netresearch\NrPasskeysBe\Domain\Model\Credential $credential): bool => !$credential->isRevoked(),
+            static fn(Credential $credential): bool => !$credential->isRevoked(),
         ));
 
         $enabledLabel = $lang->sL('LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang.xlf:admin.passkeys.enabled');
@@ -166,6 +167,7 @@ class PasskeyInfoElement extends AbstractFormElement
 
                 $childHtml[] = '</li>';
             }
+
             $childHtml[] = '</ul>';
         }
 

--- a/Classes/Middleware/PasskeySetupInterstitial.php
+++ b/Classes/Middleware/PasskeySetupInterstitial.php
@@ -23,6 +23,7 @@ use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Localization\Locale;
 
 /**
  * Intercepts backend requests to enforce passkey setup when required.
@@ -31,7 +32,7 @@ use TYPO3\CMS\Core\Localization\LanguageService;
  * when their enforcement policy demands it and they have none yet.
  * Supports grace periods and session-based skip for dismissible prompts.
  */
-final class PasskeySetupInterstitial implements MiddlewareInterface
+final readonly class PasskeySetupInterstitial implements MiddlewareInterface
 {
     use TranslationTrait;
 
@@ -80,9 +81,9 @@ final class PasskeySetupInterstitial implements MiddlewareInterface
     ];
 
     public function __construct(
-        private readonly EnforcementService $enforcementService,
-        private readonly UriBuilder $uriBuilder,
-        private readonly LoggerInterface $logger,
+        private EnforcementService $enforcementService,
+        private UriBuilder $uriBuilder,
+        private LoggerInterface $logger,
     ) {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -298,7 +299,7 @@ final class PasskeySetupInterstitial implements MiddlewareInterface
         $escapedSetupUrl = \htmlspecialchars($setupUrl, ENT_QUOTES, 'UTF-8');
 
         $title = $this->translate('interstitial.title', 'Set up your passkey');
-        $description = $this->translate('interstitial.description', 'Passkeys provide a more secure and convenient way to sign in without passwords. They use your device\'s built-in biometric sensors or security keys to verify your identity, making your account resistant to phishing attacks.');
+        $description = $this->translate('interstitial.description', "Passkeys provide a more secure and convenient way to sign in without passwords. They use your device's built-in biometric sensors or security keys to verify your identity, making your account resistant to phishing attacks.");
         $setupLabel = $this->translate('interstitial.button.setup', 'Set up now');
 
         if ($remainingDays > 0 && $canSkip) {
@@ -321,6 +322,7 @@ final class PasskeySetupInterstitial implements MiddlewareInterface
             } else {
                 $skipLabel = $this->translate('interstitial.button.skip', 'Skip for now');
             }
+
             $escapedSkipLabel = \htmlspecialchars($skipLabel, ENT_QUOTES, 'UTF-8');
 
             $skipButton = <<<HTML
@@ -336,13 +338,14 @@ HTML;
         $lang = $GLOBALS['LANG'] ?? null;
         if ($lang instanceof LanguageService) {
             $locale = $lang->getLocale();
-            if ($locale !== null) {
+            if ($locale instanceof Locale) {
                 $langCode = $locale->getLanguageCode();
                 if ($langCode !== '') {
                     $htmlLang = $langCode;
                 }
             }
         }
+
         $escapedHtmlLang = \htmlspecialchars($htmlLang, ENT_QUOTES, 'UTF-8');
         $escapedColorScheme = \htmlspecialchars($colorScheme, ENT_QUOTES, 'UTF-8');
 

--- a/Classes/Middleware/PublicRouteResolver.php
+++ b/Classes/Middleware/PublicRouteResolver.php
@@ -25,12 +25,12 @@ use TYPO3\CMS\Backend\Routing\Route;
  * the login page. This middleware short-circuits authentication for our
  * public passkeys endpoints by dispatching them directly.
  */
-final class PublicRouteResolver implements MiddlewareInterface
+final readonly class PublicRouteResolver implements MiddlewareInterface
 {
     private const PASSKEYS_ROUTE_PREFIX = 'passkeys_login_';
 
     public function __construct(
-        private readonly RouteDispatcher $dispatcher,
+        private RouteDispatcher $dispatcher,
     ) {}
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface

--- a/Classes/Service/AdoptionStatsService.php
+++ b/Classes/Service/AdoptionStatsService.php
@@ -20,10 +20,12 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
  * Aggregates user counts, per-group enforcement details, and identifies
  * users who have not yet registered passkeys.
  */
-final class AdoptionStatsService
+final readonly class AdoptionStatsService
 {
     private const TABLE_USERS = 'be_users';
+
     private const TABLE_CREDENTIALS = 'tx_nrpasskeysbe_credential';
+
     private const TABLE_GROUPS = 'be_groups';
 
     /**
@@ -34,8 +36,8 @@ final class AdoptionStatsService
     public const USERS_WITHOUT_PASSKEYS_LIMIT = 500;
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool,
-        private readonly EnforcementService $enforcementService,
+        private ConnectionPool $connectionPool,
+        private EnforcementService $enforcementService,
     ) {}
 
     /**
@@ -424,7 +426,7 @@ final class AdoptionStatsService
             return '';
         }
 
-        $uids = \array_filter(\array_map('trim', \explode(',', $uidList)));
+        $uids = \array_filter(\array_map(trim(...), \explode(',', $uidList)));
         $titles = [];
 
         foreach ($uids as $uid) {

--- a/Classes/Service/AssertionService.php
+++ b/Classes/Service/AssertionService.php
@@ -29,7 +29,7 @@ use Webauthn\TrustPath\EmptyTrustPath;
  * username-first, discoverable, and decoy login variants, resolving the backend
  * user from a discoverable assertion, and verifying the browser's assertion response.
  */
-final class AssertionService
+final readonly class AssertionService
 {
     /**
      * Realistic credential-ID byte lengths. A single fixed length made every decoy
@@ -56,11 +56,11 @@ final class AssertionService
     ];
 
     public function __construct(
-        private readonly ExtensionConfigurationService $configService,
-        private readonly ChallengeService $challengeService,
-        private readonly CredentialRepository $credentialRepository,
-        private readonly LoggerInterface $logger,
-        private readonly WebAuthnCeremonyFactory $ceremonyFactory,
+        private ExtensionConfigurationService $configService,
+        private ChallengeService $challengeService,
+        private CredentialRepository $credentialRepository,
+        private LoggerInterface $logger,
+        private WebAuthnCeremonyFactory $ceremonyFactory,
     ) {}
 
     /**
@@ -204,7 +204,7 @@ final class AssertionService
 
             $descriptors[] = PublicKeyCredentialDescriptor::create(
                 type: PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY,
-                id: self::deriveDecoyId($derivedKey, $username . '|' . $index . '|id', $length),
+                id: $this->deriveDecoyId($derivedKey, $username . '|' . $index . '|id', $length),
                 transports: $transports,
             );
         }
@@ -222,7 +222,7 @@ final class AssertionService
      * holds for every such decoy and for no real credential. Without the key, no byte
      * of the result predicts any other.
      */
-    private static function deriveDecoyId(string $derivedKey, string $label, int $length): string
+    private function deriveDecoyId(string $derivedKey, string $label, int $length): string
     {
         $id = '';
         $block = 0;
@@ -254,7 +254,7 @@ final class AssertionService
             }
 
             $credential = $this->credentialRepository->findByCredentialId($publicKeyCredential->rawId);
-            if ($credential === null || $credential->isRevoked()) {
+            if (!$credential instanceof Credential || $credential->isRevoked()) {
                 return null;
             }
 
@@ -297,7 +297,7 @@ final class AssertionService
         $credentialId = $publicKeyCredential->rawId;
         $credential = $this->credentialRepository->findByCredentialId($credentialId);
 
-        if ($credential === null) {
+        if (!$credential instanceof Credential) {
             $this->logger->warning('Assertion with unknown credential ID', [
                 'be_user_uid' => $beUserUid,
             ]);

--- a/Classes/Service/AttestationService.php
+++ b/Classes/Service/AttestationService.php
@@ -29,7 +29,7 @@ use Webauthn\PublicKeyCredentialUserEntity;
  * WebAuthn attestation (registration) ceremony: building creation options,
  * verifying the browser's attestation response, and persisting the credential.
  */
-final class AttestationService
+final readonly class AttestationService
 {
     private const ALGORITHM_MAP = [
         'ES256' => -7,
@@ -39,11 +39,11 @@ final class AttestationService
     ];
 
     public function __construct(
-        private readonly ExtensionConfigurationService $configService,
-        private readonly ChallengeService $challengeService,
-        private readonly CredentialRepository $credentialRepository,
-        private readonly LoggerInterface $logger,
-        private readonly WebAuthnCeremonyFactory $ceremonyFactory,
+        private ExtensionConfigurationService $configService,
+        private ChallengeService $challengeService,
+        private CredentialRepository $credentialRepository,
+        private LoggerInterface $logger,
+        private WebAuthnCeremonyFactory $ceremonyFactory,
     ) {}
 
     /**

--- a/Classes/Service/ChallengeService.php
+++ b/Classes/Service/ChallengeService.php
@@ -18,15 +18,15 @@ use TYPO3\CMS\Core\Locking\LockingStrategyInterface;
 /**
  * Manages HMAC-signed, single-use, time-limited WebAuthn challenge tokens.
  */
-final class ChallengeService
+final readonly class ChallengeService
 {
     private const HMAC_ALGO = 'sha256';
 
     public function __construct(
-        private readonly FrontendInterface $nonceCache,
-        private readonly ExtensionConfigurationService $configService,
-        private readonly LockFactory $lockFactory,
-        private readonly LoggerInterface $logger,
+        private FrontendInterface $nonceCache,
+        private ExtensionConfigurationService $configService,
+        private LockFactory $lockFactory,
+        private LoggerInterface $logger,
     ) {}
 
     public function generateChallenge(): string

--- a/Classes/Service/CredentialRepository.php
+++ b/Classes/Service/CredentialRepository.php
@@ -13,17 +13,18 @@ use Doctrine\DBAL\ParameterType;
 use Netresearch\NrPasskeysBe\Domain\Model\Credential;
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 
 /**
  * Data access layer for WebAuthn passkey credentials (tx_nrpasskeysbe_credential).
  */
-final class CredentialRepository
+final readonly class CredentialRepository
 {
     private const TABLE = 'tx_nrpasskeysbe_credential';
 
     public function __construct(
-        private readonly ConnectionPool $connectionPool,
-        private readonly LoggerInterface $logger,
+        private ConnectionPool $connectionPool,
+        private LoggerInterface $logger,
     ) {}
 
     public function findByCredentialId(string $credentialId): ?Credential
@@ -74,7 +75,7 @@ final class CredentialRepository
             ->fetchAllAssociative();
 
         return \array_map(
-            static fn(array $row): Credential => Credential::fromArray($row),
+            Credential::fromArray(...),
             $rows,
         );
     }
@@ -232,7 +233,7 @@ final class CredentialRepository
             ->fetchAllAssociative();
 
         return \array_map(
-            static fn(array $row): Credential => Credential::fromArray($row),
+            Credential::fromArray(...),
             $rows,
         );
     }
@@ -264,7 +265,7 @@ final class CredentialRepository
         return Credential::fromArray($row);
     }
 
-    private function getQueryBuilder(): \TYPO3\CMS\Core\Database\Query\QueryBuilder
+    private function getQueryBuilder(): QueryBuilder
     {
         return $this->connectionPool->getQueryBuilderForTable(self::TABLE);
     }

--- a/Classes/Service/EnforcementService.php
+++ b/Classes/Service/EnforcementService.php
@@ -23,12 +23,12 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * level, and combines it with grace-period and passkey-count information
  * into an EnforcementStatus snapshot.
  */
-final class EnforcementService
+final readonly class EnforcementService
 {
     public function __construct(
-        private readonly ConnectionPool $connectionPool,
-        private readonly CredentialRepository $credentialRepository,
-        private readonly LoggerInterface $logger,
+        private ConnectionPool $connectionPool,
+        private CredentialRepository $credentialRepository,
+        private LoggerInterface $logger,
     ) {}
 
     /**

--- a/Classes/Service/ExtensionConfigurationService.php
+++ b/Classes/Service/ExtensionConfigurationService.php
@@ -15,18 +15,20 @@ use RuntimeException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Http\NormalizedParams;
 
-final class ExtensionConfigurationService
+final readonly class ExtensionConfigurationService
 {
     use TypeCastTrait;
-    private readonly \Netresearch\NrPasskeysBe\Configuration\ExtensionConfiguration $config;
+
+    private \Netresearch\NrPasskeysBe\Configuration\ExtensionConfiguration $config;
 
     public function __construct(
-        private readonly ExtensionConfiguration $extensionConfiguration,
+        private ExtensionConfiguration $extensionConfiguration,
     ) {
         $settings = $this->extensionConfiguration->get('nr_passkeys_be');
         if (!\is_array($settings)) {
             $settings = [];
         }
+
         $this->config = new \Netresearch\NrPasskeysBe\Configuration\ExtensionConfiguration(
             rpId: self::stringVal($settings['rpId'] ?? null),
             rpName: self::stringVal($settings['rpName'] ?? null, 'TYPO3 Backend'),

--- a/Classes/Service/RateLimiterService.php
+++ b/Classes/Service/RateLimiterService.php
@@ -18,13 +18,13 @@ use TYPO3\CMS\Core\Locking\LockingStrategyInterface;
 /**
  * Per-endpoint rate limiting and per-account lockout using TYPO3 caching with atomic locking.
  */
-final class RateLimiterService
+final readonly class RateLimiterService
 {
     public function __construct(
-        private readonly FrontendInterface $rateLimitCache,
-        private readonly ExtensionConfigurationService $configService,
-        private readonly LockFactory $lockFactory,
-        private readonly LoggerInterface $logger,
+        private FrontendInterface $rateLimitCache,
+        private ExtensionConfigurationService $configService,
+        private LockFactory $lockFactory,
+        private LoggerInterface $logger,
     ) {}
 
     /**

--- a/Classes/Service/WebAuthnCeremonyFactory.php
+++ b/Classes/Service/WebAuthnCeremonyFactory.php
@@ -40,7 +40,7 @@ final class WebAuthnCeremonyFactory
 
     public function getSerializer(): SerializerInterface
     {
-        if ($this->serializer === null) {
+        if (!$this->serializer instanceof SerializerInterface) {
             $attestationManager = $this->createAttestationStatementSupportManager();
             $factory = new WebauthnSerializerFactory($attestationManager);
             $this->serializer = $factory->create();

--- a/Classes/Service/WebAuthnService.php
+++ b/Classes/Service/WebAuthnService.php
@@ -27,11 +27,11 @@ use Webauthn\PublicKeyCredentialRequestOptions;
  * and {@see AssertionService}. This preserves the public surface used across the
  * extension; the ceremony detail lives in the dedicated services.
  */
-final class WebAuthnService
+final readonly class WebAuthnService
 {
     public function __construct(
-        private readonly AttestationService $attestationService,
-        private readonly AssertionService $assertionService,
+        private AttestationService $attestationService,
+        private AssertionService $assertionService,
     ) {}
 
     /**

--- a/Classes/Widgets/DataProvider/PasskeyAdoptionChartDataProvider.php
+++ b/Classes/Widgets/DataProvider/PasskeyAdoptionChartDataProvider.php
@@ -20,7 +20,7 @@ use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
  * backend (be_users) always, frontend (fe_users) when nr_passkeys_fe is present.
  * Populations differ, so segments are NEVER summed into one ratio.
  */
-final class PasskeyAdoptionChartDataProvider implements ChartDataProviderInterface
+final readonly class PasskeyAdoptionChartDataProvider implements ChartDataProviderInterface
 {
     use TranslationTrait;
 
@@ -43,7 +43,7 @@ final class PasskeyAdoptionChartDataProvider implements ChartDataProviderInterfa
      * @param iterable<PasskeyAdoptionStatsProviderInterface> $statsProviders
      */
     public function __construct(
-        private readonly iterable $statsProviders,
+        private iterable $statsProviders,
     ) {}
 
     /**

--- a/Classes/Widgets/DataProvider/PasskeyCredentialsCountDataProvider.php
+++ b/Classes/Widgets/DataProvider/PasskeyCredentialsCountDataProvider.php
@@ -18,13 +18,13 @@ use TYPO3\CMS\Dashboard\Widgets\NumberWithIconDataProviderInterface;
  * homogeneous, so a combined count is meaningful; the segment breakdown is
  * carried by the widget subtitle. Degrades to backend-only automatically.
  */
-final class PasskeyCredentialsCountDataProvider implements NumberWithIconDataProviderInterface
+final readonly class PasskeyCredentialsCountDataProvider implements NumberWithIconDataProviderInterface
 {
     /**
      * @param iterable<PasskeyAdoptionStatsProviderInterface> $statsProviders
      */
     public function __construct(
-        private readonly iterable $statsProviders,
+        private iterable $statsProviders,
     ) {}
 
     public function getNumber(): int

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -7,10 +7,13 @@
 
 declare(strict_types=1);
 
+use Netresearch\NrPasskeysBe\Middleware\PasskeySetupInterstitial;
+use Netresearch\NrPasskeysBe\Middleware\PublicRouteResolver;
+
 return [
     'backend' => [
         'netresearch/nr-passkeys-be/public-route-resolver' => [
-            'target' => \Netresearch\NrPasskeysBe\Middleware\PublicRouteResolver::class,
+            'target' => PublicRouteResolver::class,
             'after' => [
                 'typo3/cms-backend/backend-routing',
             ],
@@ -19,7 +22,7 @@ return [
             ],
         ],
         'netresearch/nr-passkeys-be/passkey-setup-interstitial' => [
-            'target' => \Netresearch\NrPasskeysBe\Middleware\PasskeySetupInterstitial::class,
+            'target' => PasskeySetupInterstitial::class,
             'after' => [
                 'typo3/cms-backend/authentication',
             ],

--- a/Configuration/TCA/Overrides/be_groups.php
+++ b/Configuration/TCA/Overrides/be_groups.php
@@ -7,7 +7,9 @@
 
 declare(strict_types=1);
 
-\defined('TYPO3') or die();
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+\defined('TYPO3') || die();
 
 $tempColumns = [
     'passkey_enforcement' => [
@@ -38,9 +40,9 @@ $tempColumns = [
     ],
 ];
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('be_groups', $tempColumns);
+ExtensionManagementUtility::addTCAcolumns('be_groups', $tempColumns);
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+ExtensionManagementUtility::addToAllTCAtypes(
     'be_groups',
     '--div--;LLL:EXT:nr_passkeys_be/Resources/Private/Language/locallang_db.xlf:be_groups.tab.passkeys,passkey_enforcement,passkey_grace_period_days',
 );

--- a/Configuration/TCA/Overrides/be_users.php
+++ b/Configuration/TCA/Overrides/be_users.php
@@ -7,7 +7,9 @@
 
 declare(strict_types=1);
 
-\defined('TYPO3') or die();
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+\defined('TYPO3') || die();
 
 $tempColumns = [
     'passkeys' => [
@@ -20,10 +22,10 @@ $tempColumns = [
     ],
 ];
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('be_users', $tempColumns);
+ExtensionManagementUtility::addTCAcolumns('be_users', $tempColumns);
 
 // Add passkeys field after mfa in be_users form
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes(
+ExtensionManagementUtility::addToAllTCAtypes(
     'be_users',
     'passkeys',
     '',

--- a/Tests/Build/FunctionalTestsBootstrap.php
+++ b/Tests/Build/FunctionalTestsBootstrap.php
@@ -7,8 +7,11 @@
 
 declare(strict_types=1);
 
+use DG\BypassFinals;
+use TYPO3\TestingFramework\Core\Testbase;
+
 (static function (): void {
-    $testbase = new \TYPO3\TestingFramework\Core\Testbase();
+    $testbase = new Testbase();
     $testbase->defineOriginalRootPath();
     $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/tests');
     $testbase->createDirectory(ORIGINAL_ROOT . 'typo3temp/var/transient');
@@ -17,4 +20,4 @@ declare(strict_types=1);
 // Strip the "final" keyword at runtime so PHPUnit can double classes like
 // WebAuthnService (final for production safety) in functional tests. This
 // matches the unit-test bootstrap behaviour.
-DG\BypassFinals::enable();
+BypassFinals::enable();

--- a/Tests/Functional/Authentication/PasskeyAuthenticationServiceMfaBypassTest.php
+++ b/Tests/Functional/Authentication/PasskeyAuthenticationServiceMfaBypassTest.php
@@ -17,7 +17,7 @@ use Netresearch\NrPasskeysBe\Service\RateLimiterService;
 use Netresearch\NrPasskeysBe\Service\WebAuthnService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Cache\Backend\NullBackend;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration as Typo3ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -48,10 +48,10 @@ final class PasskeyAuthenticationServiceMfaBypassTest extends FunctionalTestCase
             'caching' => [
                 'cacheConfigurations' => [
                     'nr_passkeys_be_nonce' => [
-                        'backend' => \TYPO3\CMS\Core\Cache\Backend\NullBackend::class,
+                        'backend' => NullBackend::class,
                     ],
                     'nr_passkeys_be_ratelimit' => [
-                        'backend' => \TYPO3\CMS\Core\Cache\Backend\NullBackend::class,
+                        'backend' => NullBackend::class,
                     ],
                 ],
             ],

--- a/Tests/Functional/Controller/AdminControllerTest.php
+++ b/Tests/Functional/Controller/AdminControllerTest.php
@@ -12,7 +12,10 @@ namespace Netresearch\NrPasskeysBe\Tests\Functional\Controller;
 use Netresearch\NrPasskeysBe\Controller\AdminController;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Cache\Backend\NullBackend;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\ServerRequest;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
@@ -37,10 +40,10 @@ final class AdminControllerTest extends FunctionalTestCase
             'caching' => [
                 'cacheConfigurations' => [
                     'nr_passkeys_be_nonce' => [
-                        'backend' => \TYPO3\CMS\Core\Cache\Backend\NullBackend::class,
+                        'backend' => NullBackend::class,
                     ],
                     'nr_passkeys_be_ratelimit' => [
-                        'backend' => \TYPO3\CMS\Core\Cache\Backend\NullBackend::class,
+                        'backend' => NullBackend::class,
                     ],
                 ],
             ],
@@ -105,7 +108,7 @@ final class AdminControllerTest extends FunctionalTestCase
     /**
      * @return array<string, mixed>
      */
-    private function decodeJsonResponse(\Psr\Http\Message\ResponseInterface $response): array
+    private function decodeJsonResponse(ResponseInterface $response): array
     {
         $content = (string) $response->getBody();
         $data = \json_decode($content, true, 16, JSON_THROW_ON_ERROR);
@@ -196,7 +199,7 @@ final class AdminControllerTest extends FunctionalTestCase
         self::assertSame('ok', $data['status']);
 
         // Verify the credential is now revoked in the database
-        $queryBuilder = $this->get(\TYPO3\CMS\Core\Database\ConnectionPool::class)
+        $queryBuilder = $this->get(ConnectionPool::class)
             ->getQueryBuilderForTable('tx_nrpasskeysbe_credential');
         $queryBuilder->getRestrictions()->removeAll();
         $row = $queryBuilder
@@ -317,7 +320,7 @@ final class AdminControllerTest extends FunctionalTestCase
         self::assertSame(2, $data['revokedCount']);
 
         // Verify all active credentials are now revoked
-        $queryBuilder = $this->get(\TYPO3\CMS\Core\Database\ConnectionPool::class)
+        $queryBuilder = $this->get(ConnectionPool::class)
             ->getQueryBuilderForTable('tx_nrpasskeysbe_credential');
         $queryBuilder->getRestrictions()->removeAll();
         $activeCount = $queryBuilder
@@ -364,7 +367,7 @@ final class AdminControllerTest extends FunctionalTestCase
         self::assertSame('enforced', $data['enforcement']);
 
         // Verify the group enforcement was updated in database
-        $queryBuilder = $this->get(\TYPO3\CMS\Core\Database\ConnectionPool::class)
+        $queryBuilder = $this->get(ConnectionPool::class)
             ->getQueryBuilderForTable('be_groups');
         $row = $queryBuilder
             ->select('passkey_enforcement')
@@ -442,7 +445,7 @@ final class AdminControllerTest extends FunctionalTestCase
         self::assertGreaterThanOrEqual($expectedMin, $data['nudgeUntil']);
 
         // Verify the nudge timestamp was set in database
-        $queryBuilder = $this->get(\TYPO3\CMS\Core\Database\ConnectionPool::class)
+        $queryBuilder = $this->get(ConnectionPool::class)
             ->getQueryBuilderForTable('be_users');
         $row = $queryBuilder
             ->select('passkey_nudge_until')

--- a/Tests/Functional/Repository/CredentialRepositoryTest.php
+++ b/Tests/Functional/Repository/CredentialRepositoryTest.php
@@ -13,6 +13,8 @@ use Netresearch\NrPasskeysBe\Domain\Model\Credential;
 use Netresearch\NrPasskeysBe\Service\CredentialRepository;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\Backend\NullBackend;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 #[CoversClass(CredentialRepository::class)]
@@ -31,10 +33,10 @@ final class CredentialRepositoryTest extends FunctionalTestCase
             'caching' => [
                 'cacheConfigurations' => [
                     'nr_passkeys_be_nonce' => [
-                        'backend' => \TYPO3\CMS\Core\Cache\Backend\NullBackend::class,
+                        'backend' => NullBackend::class,
                     ],
                     'nr_passkeys_be_ratelimit' => [
-                        'backend' => \TYPO3\CMS\Core\Cache\Backend\NullBackend::class,
+                        'backend' => NullBackend::class,
                     ],
                 ],
             ],
@@ -262,7 +264,7 @@ final class CredentialRepositoryTest extends FunctionalTestCase
         $row = $queryBuilder
             ->select('*')
             ->from('tx_nrpasskeysbe_credential')
-            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, \TYPO3\CMS\Core\Database\Connection::PARAM_INT)))
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)))
             ->executeQuery()
             ->fetchAssociative();
 

--- a/Tests/Functional/Service/AdoptionStatsServiceTest.php
+++ b/Tests/Functional/Service/AdoptionStatsServiceTest.php
@@ -9,9 +9,13 @@ declare(strict_types=1);
 
 namespace Netresearch\NrPasskeysBe\Tests\Functional\Service;
 
+use Netresearch\NrPasskeysBe\Domain\Dto\GroupEnforcementInfo;
+use Netresearch\NrPasskeysBe\Domain\Dto\UserPasskeyStatus;
 use Netresearch\NrPasskeysBe\Service\AdoptionStatsService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\Backend\NullBackend;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
@@ -36,10 +40,10 @@ final class AdoptionStatsServiceTest extends FunctionalTestCase
             'caching' => [
                 'cacheConfigurations' => [
                     'nr_passkeys_be_nonce' => [
-                        'backend' => \TYPO3\CMS\Core\Cache\Backend\NullBackend::class,
+                        'backend' => NullBackend::class,
                     ],
                     'nr_passkeys_be_ratelimit' => [
-                        'backend' => \TYPO3\CMS\Core\Cache\Backend\NullBackend::class,
+                        'backend' => NullBackend::class,
                     ],
                 ],
             ],
@@ -94,7 +98,7 @@ final class AdoptionStatsServiceTest extends FunctionalTestCase
         // be_groups.csv has 3 groups: Editors (required), Content Managers (encourage), No Enforcement (off)
         self::assertCount(3, $stats->groups);
 
-        $groupTitles = \array_map(static fn($g) => $g->title, $stats->groups);
+        $groupTitles = \array_map(static fn(GroupEnforcementInfo $g): string => $g->title, $stats->groups);
         self::assertContains('Editors', $groupTitles);
         self::assertContains('Content Managers', $groupTitles);
         self::assertContains('No Enforcement', $groupTitles);
@@ -165,7 +169,7 @@ final class AdoptionStatsServiceTest extends FunctionalTestCase
         // (Users 1 and 2 both have active credentials)
         self::assertCount(3, $stats->usersWithoutPasskeys);
 
-        $usernames = \array_map(static fn($u) => $u->username, $stats->usersWithoutPasskeys);
+        $usernames = \array_map(static fn(UserPasskeyStatus $u): string => $u->username, $stats->usersWithoutPasskeys);
         self::assertContains('adminuser', $usernames);
         self::assertContains('revokeadmin', $usernames);
         self::assertContains('testuser99', $usernames);
@@ -206,7 +210,7 @@ final class AdoptionStatsServiceTest extends FunctionalTestCase
     public function getStatsExcludesDeletedUsers(): void
     {
         // Add a deleted user to verify it's excluded
-        $connection = $this->get(\TYPO3\CMS\Core\Database\ConnectionPool::class)
+        $connection = $this->get(ConnectionPool::class)
             ->getConnectionForTable('be_users');
         $connection->insert('be_users', [
             'uid' => 100,
@@ -223,7 +227,7 @@ final class AdoptionStatsServiceTest extends FunctionalTestCase
 
         // Deleted user should NOT be counted
         self::assertSame(5, $stats->totalUsers);
-        $usernames = \array_map(static fn($u) => $u->username, $stats->usersWithoutPasskeys);
+        $usernames = \array_map(static fn(UserPasskeyStatus $u): string => $u->username, $stats->usersWithoutPasskeys);
         self::assertNotContains('deleteduser', $usernames);
     }
 
@@ -231,7 +235,7 @@ final class AdoptionStatsServiceTest extends FunctionalTestCase
     public function getStatsExcludesDisabledUsers(): void
     {
         // Add a disabled user
-        $connection = $this->get(\TYPO3\CMS\Core\Database\ConnectionPool::class)
+        $connection = $this->get(ConnectionPool::class)
             ->getConnectionForTable('be_users');
         $connection->insert('be_users', [
             'uid' => 101,
@@ -258,7 +262,7 @@ final class AdoptionStatsServiceTest extends FunctionalTestCase
         self::assertSame(3, $this->subject->countActiveCredentials());
 
         // A leftover active credential of a disabled user must not count
-        $connectionPool = $this->get(\TYPO3\CMS\Core\Database\ConnectionPool::class);
+        $connectionPool = $this->get(ConnectionPool::class);
         $connectionPool->getConnectionForTable('be_users')->insert('be_users', [
             'uid' => 102,
             'pid' => 0,

--- a/Tests/Functional/Service/EnforcementServiceTest.php
+++ b/Tests/Functional/Service/EnforcementServiceTest.php
@@ -13,6 +13,8 @@ use Netresearch\NrPasskeysBe\Domain\Enum\EnforcementLevel;
 use Netresearch\NrPasskeysBe\Service\EnforcementService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Cache\Backend\NullBackend;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
@@ -38,10 +40,10 @@ final class EnforcementServiceTest extends FunctionalTestCase
             'caching' => [
                 'cacheConfigurations' => [
                     'nr_passkeys_be_nonce' => [
-                        'backend' => \TYPO3\CMS\Core\Cache\Backend\NullBackend::class,
+                        'backend' => NullBackend::class,
                     ],
                     'nr_passkeys_be_ratelimit' => [
-                        'backend' => \TYPO3\CMS\Core\Cache\Backend\NullBackend::class,
+                        'backend' => NullBackend::class,
                     ],
                 ],
             ],
@@ -147,7 +149,7 @@ final class EnforcementServiceTest extends FunctionalTestCase
 
         $this->subject->startGracePeriod(99);
 
-        $queryBuilder = $this->get(\TYPO3\CMS\Core\Database\ConnectionPool::class)
+        $queryBuilder = $this->get(ConnectionPool::class)
             ->getQueryBuilderForTable('be_users');
         $queryBuilder->getRestrictions()->removeAll();
         $row = $queryBuilder

--- a/Tests/Fuzz/ChallengeTokenFuzzTest.php
+++ b/Tests/Fuzz/ChallengeTokenFuzzTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrPasskeysBe\Tests\Fuzz;
 
+use Netresearch\NrPasskeysBe\Configuration\ExtensionConfiguration;
 use Netresearch\NrPasskeysBe\Service\ChallengeService;
 use Netresearch\NrPasskeysBe\Service\ExtensionConfigurationService;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -36,7 +37,7 @@ final class ChallengeTokenFuzzTest extends TestCase
         $cache->method('get')->willReturn('valid');
 
         $configService = $this->createMock(ExtensionConfigurationService::class);
-        $config = new \Netresearch\NrPasskeysBe\Configuration\ExtensionConfiguration(
+        $config = new ExtensionConfiguration(
             challengeTtlSeconds: 120,
         );
         $configService->method('getConfiguration')->willReturn($config);

--- a/Tests/Unit/Authentication/PasskeyAuthenticationServiceTest.php
+++ b/Tests/Unit/Authentication/PasskeyAuthenticationServiceTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrPasskeysBe\Tests\Unit\Authentication;
 
+use Doctrine\DBAL\Result;
 use Netresearch\NrPasskeysBe\Authentication\PasskeyAuthenticationService;
 use Netresearch\NrPasskeysBe\Configuration\ExtensionConfiguration;
 use Netresearch\NrPasskeysBe\Domain\Dto\EnforcementStatus;
@@ -26,6 +27,9 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use RuntimeException;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Cache\CacheManager;
+use TYPO3\CMS\Core\Cache\Frontend\FrontendInterface;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -37,7 +41,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
 {
     private PasskeyAuthenticationService $subject;
 
-    private \TYPO3\CMS\Core\Authentication\BackendUserAuthentication&MockObject $pObj;
+    private BackendUserAuthentication&MockObject $pObj;
 
     private WebAuthnService&MockObject $webAuthnService;
 
@@ -88,7 +92,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
         $this->injectLogger($this->subject, $this->logger);
 
         // Set pObj (parent auth object) for session data access in passkey auth success path
-        $this->pObj = $this->createMock(\TYPO3\CMS\Core\Authentication\BackendUserAuthentication::class);
+        $this->pObj = $this->createMock(BackendUserAuthentication::class);
         $this->pObj->method('getSessionData')->willReturn(null);
         $this->subject->pObj = $this->pObj;
     }
@@ -107,7 +111,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
      *
      * @param array<string, mixed> $assertion
      */
-    private static function buildPasskeyUident(array $assertion, string $challengeToken = 'challenge-token-123'): string
+    private function buildPasskeyUident(array $assertion, string $challengeToken = 'challenge-token-123'): string
     {
         return \json_encode([
             '_type' => 'passkey',
@@ -120,7 +124,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
      * Build a passkey_token payload JSON string as the JS puts into userident
      * after the /passkeys/login/verify endpoint returned a login token.
      */
-    private static function buildTokenUident(string $token): string
+    private function buildTokenUident(string $token): string
     {
         return \json_encode(['_type' => 'passkey_token', 'token' => $token], JSON_THROW_ON_ERROR);
     }
@@ -129,7 +133,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
      * Build the cached login-token value as LoginController::issueLoginToken()
      * writes it. A negative $expiresIn produces an already-expired token.
      */
-    private static function buildTokenValue(int $uid, int $expiresIn = 120): string
+    private function buildTokenValue(int $uid, int $expiresIn = 120): string
     {
         return \json_encode(
             ['uid' => $uid, 'expiresAt' => \time() + $expiresIn],
@@ -143,13 +147,13 @@ final class PasskeyAuthenticationServiceTest extends TestCase
      *
      * Returns the cache mock so a test can assert on remove().
      */
-    private function stubTokenCache(string $token, string|false $value): \TYPO3\CMS\Core\Cache\Frontend\FrontendInterface&MockObject
+    private function stubTokenCache(string $token, string|false $value): FrontendInterface&MockObject
     {
-        $cache = $this->createMock(\TYPO3\CMS\Core\Cache\Frontend\FrontendInterface::class);
+        $cache = $this->createMock(FrontendInterface::class);
         $cache->method('get')->with('passkey_login_' . $token)->willReturn($value);
-        $cacheManager = $this->createStub(\TYPO3\CMS\Core\Cache\CacheManager::class);
+        $cacheManager = $this->createStub(CacheManager::class);
         $cacheManager->method('getCache')->willReturn($cache);
-        GeneralUtility::setSingletonInstance(\TYPO3\CMS\Core\Cache\CacheManager::class, $cacheManager);
+        GeneralUtility::setSingletonInstance(CacheManager::class, $cacheManager);
 
         return $cache;
     }
@@ -159,10 +163,10 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     #[Test]
     public function authUserAcceptsValidLoginToken(): void
     {
-        $this->stubTokenCache('tok123', self::buildTokenValue(42));
+        $this->stubTokenCache('tok123', $this->buildTokenValue(42));
         $this->subject->login = [
             'uname' => '',
-            'uident' => self::buildTokenUident('tok123'),
+            'uident' => $this->buildTokenUident('tok123'),
         ];
 
         $result = $this->subject->authUser(['uid' => 42, 'username' => 'admin']);
@@ -177,12 +181,12 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     #[Test]
     public function authUserRejectsExpiredLoginTokenEvenWhenTheCacheStillReturnsIt(): void
     {
-        $cache = $this->stubTokenCache('tok123', self::buildTokenValue(42, -1));
+        $cache = $this->stubTokenCache('tok123', $this->buildTokenValue(42, -1));
         $cache->expects(self::atLeastOnce())->method('remove')->with('passkey_login_tok123');
 
         $this->subject->login = [
             'uname' => '',
-            'uident' => self::buildTokenUident('tok123'),
+            'uident' => $this->buildTokenUident('tok123'),
         ];
 
         $result = $this->subject->authUser(['uid' => 42, 'username' => 'admin']);
@@ -199,7 +203,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
 
         $this->subject->login = [
             'uname' => '',
-            'uident' => self::buildTokenUident('tok123'),
+            'uident' => $this->buildTokenUident('tok123'),
         ];
 
         $result = $this->subject->authUser(['uid' => 42, 'username' => 'admin']);
@@ -214,7 +218,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
 
         $this->subject->login = [
             'uname' => '',
-            'uident' => self::buildTokenUident('tok123'),
+            'uident' => $this->buildTokenUident('tok123'),
         ];
 
         $result = $this->subject->authUser(['uid' => 42, 'username' => 'admin']);
@@ -227,10 +231,10 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     {
         // Token maps to uid 99; authUser runs for uid 42 → must not accept it as
         // a passkey login (falls through to the password-enforcement path).
-        $this->stubTokenCache('tok123', self::buildTokenValue(99));
+        $this->stubTokenCache('tok123', $this->buildTokenValue(99));
         $this->subject->login = [
             'uname' => '',
-            'uident' => self::buildTokenUident('tok123'),
+            'uident' => $this->buildTokenUident('tok123'),
         ];
 
         $result = $this->subject->authUser(['uid' => 42, 'username' => 'admin']);
@@ -244,7 +248,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
         $this->stubTokenCache('tok123', false);
         $this->subject->login = [
             'uname' => '',
-            'uident' => self::buildTokenUident('tok123'),
+            'uident' => $this->buildTokenUident('tok123'),
         ];
 
         $result = $this->subject->authUser(['uid' => 42, 'username' => 'admin']);
@@ -260,7 +264,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
         $credential = new Credential(uid: 10, beUser: 1, label: 'Test Key');
         $this->subject->login = [
             'uname' => 'admin',
-            'uident' => self::buildPasskeyUident(['valid' => 'assertion']),
+            'uident' => $this->buildPasskeyUident(['valid' => 'assertion']),
         ];
 
         $this->rateLimiterService
@@ -330,7 +334,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
         $subject = new PasskeyAuthenticationService();
         $this->injectLogger($subject, $this->logger);
 
-        $pObj = $this->createMock(\TYPO3\CMS\Core\Authentication\BackendUserAuthentication::class);
+        $pObj = $this->createMock(BackendUserAuthentication::class);
         // Only the tx_nrpasskeysbe marker — never the 'mfa' key.
         $pObj
             ->expects(self::once())
@@ -340,7 +344,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
 
         $subject->login = [
             'uname' => 'admin',
-            'uident' => self::buildPasskeyUident(['ok' => 'assertion']),
+            'uident' => $this->buildPasskeyUident(['ok' => 'assertion']),
         ];
 
         $result = $subject->authUser(['uid' => 42, 'username' => 'admin']);
@@ -353,7 +357,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     {
         $this->subject->login = [
             'uname' => 'admin',
-            'uident' => self::buildPasskeyUident(['bad' => 'data']),
+            'uident' => $this->buildPasskeyUident(['bad' => 'data']),
         ];
 
         $this->webAuthnService
@@ -421,7 +425,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     {
         $this->subject->login = [
             'uname' => 'admin',
-            'uident' => self::buildPasskeyUident(['bad' => 'data']),
+            'uident' => $this->buildPasskeyUident(['bad' => 'data']),
         ];
 
         $this->rateLimiterService
@@ -900,7 +904,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     {
         $this->subject->login = [
             'uname' => 'testuser',
-            'uident' => self::buildPasskeyUident(['bad' => 'data']),
+            'uident' => $this->buildPasskeyUident(['bad' => 'data']),
         ];
 
         $this->webAuthnService
@@ -930,7 +934,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
         $credential = new Credential(uid: 10, beUser: 1, label: 'Test Key');
         $this->subject->login = [
             'uname' => 'admin',
-            'uident' => self::buildPasskeyUident(['ok' => 'assertion'], 'token-abc'),
+            'uident' => $this->buildPasskeyUident(['ok' => 'assertion'], 'token-abc'),
         ];
 
         $this->webAuthnService
@@ -957,7 +961,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     {
         $this->subject->login = [
             'uname' => 'locked_user',
-            'uident' => self::buildPasskeyUident(['ok' => 'assertion'], 'token-abc'),
+            'uident' => $this->buildPasskeyUident(['ok' => 'assertion'], 'token-abc'),
         ];
 
         $this->rateLimiterService
@@ -992,7 +996,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
 
         $service->login = [
             'uname' => 'admin',
-            'uident' => self::buildPasskeyUident(['assertion' => 'data'], 'token-123'),
+            'uident' => $this->buildPasskeyUident(['assertion' => 'data'], 'token-123'),
         ];
         $this->injectLogger($service, $this->logger);
 
@@ -1039,7 +1043,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     {
         $this->subject->login = [
             'uname' => '',
-            'uident' => self::buildPasskeyUident(['assertion' => 'data'], 'token-123'),
+            'uident' => $this->buildPasskeyUident(['assertion' => 'data'], 'token-123'),
         ];
 
         $this->webAuthnService
@@ -1066,7 +1070,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
 
         $this->subject->login = [
             'uname' => '',
-            'uident' => self::buildPasskeyUident(['assertion' => 'data'], 'token-123'),
+            'uident' => $this->buildPasskeyUident(['assertion' => 'data'], 'token-123'),
         ];
 
         // Policy gate must short-circuit before any credential resolution.
@@ -1082,7 +1086,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     {
         $this->subject->login = [
             'uname' => '',
-            'uident' => self::buildPasskeyUident(['assertion' => 'data'], 'token-123'),
+            'uident' => $this->buildPasskeyUident(['assertion' => 'data'], 'token-123'),
         ];
 
         $this->webAuthnService
@@ -1105,7 +1109,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     {
         $this->subject->login = [
             'uname' => '',
-            'uident' => self::buildPasskeyUident(['assertion' => 'data'], 'token-123'),
+            'uident' => $this->buildPasskeyUident(['assertion' => 'data'], 'token-123'),
         ];
 
         $this->webAuthnService
@@ -1130,7 +1134,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
 
         $service->login = [
             'uname' => 'nonexistent',
-            'uident' => self::buildPasskeyUident(['assertion' => 'data'], 'token-123'),
+            'uident' => $this->buildPasskeyUident(['assertion' => 'data'], 'token-123'),
         ];
         $this->injectLogger($service, $this->logger);
 
@@ -1174,7 +1178,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     public function getUserWithMissingUnameKeyAttemptsDiscoverableLogin(): void
     {
         $this->subject->login = [
-            'uident' => self::buildPasskeyUident(['assertion' => 'data'], 'token-123'),
+            'uident' => $this->buildPasskeyUident(['assertion' => 'data'], 'token-123'),
         ];
 
         // Empty uname key defaults to '' which triggers discoverable flow
@@ -1306,10 +1310,10 @@ final class PasskeyAuthenticationServiceTest extends TestCase
 
         $service->login = [
             'uname' => 'admin',
-            'uident' => self::buildPasskeyUident(['cached' => 'test'], 'cached-token'),
+            'uident' => $this->buildPasskeyUident(['cached' => 'test'], 'cached-token'),
         ];
         $this->injectLogger($service, $this->logger);
-        $service->pObj = $this->createMock(\TYPO3\CMS\Core\Authentication\BackendUserAuthentication::class);
+        $service->pObj = $this->createMock(BackendUserAuthentication::class);
 
         GeneralUtility::addInstance(ExtensionConfigurationService::class, $this->configService);
         GeneralUtility::addInstance(WebAuthnService::class, $this->webAuthnService);
@@ -1368,7 +1372,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
         $expressionBuilder = $this->createMock(ExpressionBuilder::class);
         $expressionBuilder->method('eq')->willReturn('1=1');
 
-        $result = $this->createMock(\Doctrine\DBAL\Result::class);
+        $result = $this->createMock(Result::class);
         $result->method('fetchOne')->willReturn($count);
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
@@ -1398,7 +1402,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
         $expressionBuilder = $this->createMock(ExpressionBuilder::class);
         $expressionBuilder->method('eq')->willReturn('1=1');
 
-        $result = $this->createMock(\Doctrine\DBAL\Result::class);
+        $result = $this->createMock(Result::class);
         $result->method('fetchAssociative')->willReturn($userRow ?? false);
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
@@ -1428,6 +1432,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
                 $prop->setValue($service, $logger);
                 return;
             }
+
             $parent = $parent->getParentClass();
         }
     }

--- a/Tests/Unit/Authentication/PasskeyAuthenticationServiceTest.php
+++ b/Tests/Unit/Authentication/PasskeyAuthenticationServiceTest.php
@@ -20,6 +20,7 @@ use Netresearch\NrPasskeysBe\Service\EnforcementService;
 use Netresearch\NrPasskeysBe\Service\ExtensionConfigurationService;
 use Netresearch\NrPasskeysBe\Service\RateLimiterService;
 use Netresearch\NrPasskeysBe\Service\WebAuthnService;
+use Netresearch\NrPasskeysBe\Tests\Unit\QueryBuilderMockTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -39,6 +40,8 @@ use Webauthn\CredentialRecord;
 #[CoversClass(PasskeyAuthenticationService::class)]
 final class PasskeyAuthenticationServiceTest extends TestCase
 {
+    use QueryBuilderMockTrait;
+
     private PasskeyAuthenticationService $subject;
 
     private BackendUserAuthentication&MockObject $pObj;
@@ -696,25 +699,12 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     #[Test]
     public function authUserBlocksPasswordWhenGroupEnforcementIsEnforcedAndUserHasPasskeys(): void
     {
-        GeneralUtility::purgeInstances();
-
-        $configService = $this->createMock(ExtensionConfigurationService::class);
-        $configService
-            ->method('getConfiguration')
-            ->willReturn(new ExtensionConfiguration(disablePasswordLogin: false));
-        GeneralUtility::addInstance(ExtensionConfigurationService::class, $configService);
-
-        $enforcementService = $this->createMock(EnforcementService::class);
-        $enforcementService
-            ->expects(self::once())
-            ->method('getStatus')
-            ->willReturn(new EnforcementStatus(
-                level: EnforcementLevel::Enforced,
-                gracePeriodDays: 0,
-                gracePeriodStart: 0,
-                hasPasskeys: true,
-            ));
-        GeneralUtility::addInstance(EnforcementService::class, $enforcementService);
+        $this->addEnforcementStatus(new EnforcementStatus(
+            level: EnforcementLevel::Enforced,
+            gracePeriodDays: 0,
+            gracePeriodStart: 0,
+            hasPasskeys: true,
+        ));
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger
@@ -740,26 +730,13 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     #[Test]
     public function authUserBlocksPasswordWhenGroupRequiredGracePeriodExpiredAndUserHasPasskeys(): void
     {
-        GeneralUtility::purgeInstances();
-
-        $configService = $this->createMock(ExtensionConfigurationService::class);
-        $configService
-            ->method('getConfiguration')
-            ->willReturn(new ExtensionConfiguration(disablePasswordLogin: false));
-        GeneralUtility::addInstance(ExtensionConfigurationService::class, $configService);
-
         // Grace period started 31 days ago with 30-day grace => expired
-        $enforcementService = $this->createMock(EnforcementService::class);
-        $enforcementService
-            ->expects(self::once())
-            ->method('getStatus')
-            ->willReturn(new EnforcementStatus(
-                level: EnforcementLevel::Required,
-                gracePeriodDays: 30,
-                gracePeriodStart: \time() - (31 * 86_400),
-                hasPasskeys: true,
-            ));
-        GeneralUtility::addInstance(EnforcementService::class, $enforcementService);
+        $this->addEnforcementStatus(new EnforcementStatus(
+            level: EnforcementLevel::Required,
+            gracePeriodDays: 30,
+            gracePeriodStart: \time() - (31 * 86_400),
+            hasPasskeys: true,
+        ));
 
         $logger = $this->createMock(LoggerInterface::class);
         $logger
@@ -785,26 +762,13 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     #[Test]
     public function authUserAllowsPasswordWhenGroupRequiredButGracePeriodStillActive(): void
     {
-        GeneralUtility::purgeInstances();
-
-        $configService = $this->createMock(ExtensionConfigurationService::class);
-        $configService
-            ->method('getConfiguration')
-            ->willReturn(new ExtensionConfiguration(disablePasswordLogin: false));
-        GeneralUtility::addInstance(ExtensionConfigurationService::class, $configService);
-
         // Grace period started 10 days ago with 30-day grace => still active
-        $enforcementService = $this->createMock(EnforcementService::class);
-        $enforcementService
-            ->expects(self::once())
-            ->method('getStatus')
-            ->willReturn(new EnforcementStatus(
-                level: EnforcementLevel::Required,
-                gracePeriodDays: 30,
-                gracePeriodStart: \time() - (10 * 86_400),
-                hasPasskeys: true,
-            ));
-        GeneralUtility::addInstance(EnforcementService::class, $enforcementService);
+        $this->addEnforcementStatus(new EnforcementStatus(
+            level: EnforcementLevel::Required,
+            gracePeriodDays: 30,
+            gracePeriodStart: \time() - (10 * 86_400),
+            hasPasskeys: true,
+        ));
 
         $subject = new PasskeyAuthenticationService();
         $this->injectLogger($subject, $this->logger);
@@ -824,26 +788,13 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     #[Test]
     public function authUserAllowsPasswordWhenGroupEncourageAndUserHasPasskeys(): void
     {
-        GeneralUtility::purgeInstances();
-
-        $configService = $this->createMock(ExtensionConfigurationService::class);
-        $configService
-            ->method('getConfiguration')
-            ->willReturn(new ExtensionConfiguration(disablePasswordLogin: false));
-        GeneralUtility::addInstance(ExtensionConfigurationService::class, $configService);
-
         // Encourage level never blocks password login
-        $enforcementService = $this->createMock(EnforcementService::class);
-        $enforcementService
-            ->expects(self::once())
-            ->method('getStatus')
-            ->willReturn(new EnforcementStatus(
-                level: EnforcementLevel::Encourage,
-                gracePeriodDays: 0,
-                gracePeriodStart: 0,
-                hasPasskeys: true,
-            ));
-        GeneralUtility::addInstance(EnforcementService::class, $enforcementService);
+        $this->addEnforcementStatus(new EnforcementStatus(
+            level: EnforcementLevel::Encourage,
+            gracePeriodDays: 0,
+            gracePeriodStart: 0,
+            hasPasskeys: true,
+        ));
 
         $subject = new PasskeyAuthenticationService();
         $this->injectLogger($subject, $this->logger);
@@ -863,26 +814,13 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     #[Test]
     public function authUserAllowsPasswordWhenGroupRequiredButUserHasNoPasskeys(): void
     {
-        GeneralUtility::purgeInstances();
-
-        $configService = $this->createMock(ExtensionConfigurationService::class);
-        $configService
-            ->method('getConfiguration')
-            ->willReturn(new ExtensionConfiguration(disablePasswordLogin: false));
-        GeneralUtility::addInstance(ExtensionConfigurationService::class, $configService);
-
         // Required enforcement but user has no passkeys yet — password must be allowed
-        $enforcementService = $this->createMock(EnforcementService::class);
-        $enforcementService
-            ->expects(self::once())
-            ->method('getStatus')
-            ->willReturn(new EnforcementStatus(
-                level: EnforcementLevel::Required,
-                gracePeriodDays: 30,
-                gracePeriodStart: \time() - (31 * 86_400),
-                hasPasskeys: false,
-            ));
-        GeneralUtility::addInstance(EnforcementService::class, $enforcementService);
+        $this->addEnforcementStatus(new EnforcementStatus(
+            level: EnforcementLevel::Required,
+            gracePeriodDays: 30,
+            gracePeriodStart: \time() - (31 * 86_400),
+            hasPasskeys: false,
+        ));
 
         $subject = new PasskeyAuthenticationService();
         $this->injectLogger($subject, $this->logger);
@@ -1365,6 +1303,28 @@ final class PasskeyAuthenticationServiceTest extends TestCase
     }
 
     /**
+     * Register the two instances authUser() resolves for a group-enforcement decision:
+     * password login enabled at extension level, and the given per-group status.
+     */
+    private function addEnforcementStatus(EnforcementStatus $status): void
+    {
+        GeneralUtility::purgeInstances();
+
+        $configService = $this->createMock(ExtensionConfigurationService::class);
+        $configService
+            ->method('getConfiguration')
+            ->willReturn(new ExtensionConfiguration(disablePasswordLogin: false));
+        GeneralUtility::addInstance(ExtensionConfigurationService::class, $configService);
+
+        $enforcementService = $this->createMock(EnforcementService::class);
+        $enforcementService
+            ->expects(self::once())
+            ->method('getStatus')
+            ->willReturn($status);
+        GeneralUtility::addInstance(EnforcementService::class, $enforcementService);
+    }
+
+    /**
      * Set up ConnectionPool mock for hasRegisteredPasskeys (credential count query).
      */
     private function setUpCredentialCount(int $beUserUid, int $count): void
@@ -1399,19 +1359,7 @@ final class PasskeyAuthenticationServiceTest extends TestCase
      */
     private function setUpFetchUserByUid(int $uid, ?array $userRow): void
     {
-        $expressionBuilder = $this->createMock(ExpressionBuilder::class);
-        $expressionBuilder->method('eq')->willReturn('1=1');
-
-        $result = $this->createMock(Result::class);
-        $result->method('fetchAssociative')->willReturn($userRow ?? false);
-
-        $queryBuilder = $this->createMock(QueryBuilder::class);
-        $queryBuilder->method('select')->willReturnSelf();
-        $queryBuilder->method('from')->willReturnSelf();
-        $queryBuilder->method('where')->willReturnSelf();
-        $queryBuilder->method('expr')->willReturn($expressionBuilder);
-        $queryBuilder->method('createNamedParameter')->willReturn((string) $uid);
-        $queryBuilder->method('executeQuery')->willReturn($result);
+        $queryBuilder = $this->createSingleRowQueryBuilder($uid, $userRow);
 
         $connectionPool = $this->createMock(ConnectionPool::class);
         $connectionPool

--- a/Tests/Unit/Configuration/AjaxRoutesTest.php
+++ b/Tests/Unit/Configuration/AjaxRoutesTest.php
@@ -39,7 +39,7 @@ final class AjaxRoutesTest extends TestCase
     /**
      * @return array<string, mixed>
      */
-    private static function routes(): array
+    private function routes(): array
     {
         if (self::$routes === null) {
             $routes = require_once \dirname(__DIR__, 3) . '/Configuration/Backend/AjaxRoutes.php';
@@ -73,7 +73,7 @@ final class AjaxRoutesTest extends TestCase
     #[DataProvider('writeRouteProvider')]
     public function writeRouteRequiresSudoMode(string $identifier): void
     {
-        $routes = self::routes();
+        $routes = $this->routes();
         self::assertArrayHasKey($identifier, $routes);
 
         $route = $routes[$identifier];
@@ -94,8 +94,12 @@ final class AjaxRoutesTest extends TestCase
     public function everyPostRouteRequiresSudoMode(): void
     {
         $missing = [];
-        foreach (self::routes() as $identifier => $route) {
-            if (!\is_array($route) || !\in_array('POST', (array) ($route['methods'] ?? []), true)) {
+        foreach ($this->routes() as $identifier => $route) {
+            if (!\is_array($route)) {
+                continue;
+            }
+
+            if (!\in_array('POST', (array) ($route['methods'] ?? []), true)) {
                 continue;
             }
 
@@ -114,7 +118,7 @@ final class AjaxRoutesTest extends TestCase
     #[Test]
     public function readRoutesAreNotGated(): void
     {
-        $routes = self::routes();
+        $routes = $this->routes();
 
         foreach (['passkeys_manage_list', 'passkeys_admin_list', 'passkeys_enforcement_status'] as $identifier) {
             self::assertArrayHasKey($identifier, $routes);

--- a/Tests/Unit/Configuration/ExtLocalconfCacheTest.php
+++ b/Tests/Unit/Configuration/ExtLocalconfCacheTest.php
@@ -87,7 +87,7 @@ final class ExtLocalconfCacheTest extends TestCase
         self::assertNotSame(
             SimpleFileBackend::class,
             (new ReflectionMethod($backend, 'collectGarbage'))->getDeclaringClass()->getName(),
-            $backend . '::collectGarbage() must not be SimpleFileBackend\'s empty implementation',
+            $backend . "::collectGarbage() must not be SimpleFileBackend's empty implementation",
         );
         self::assertNotSame(
             SimpleFileBackend::class,

--- a/Tests/Unit/Controller/AdminControllerTest.php
+++ b/Tests/Unit/Controller/AdminControllerTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrPasskeysBe\Tests\Unit\Controller;
 
+use Doctrine\DBAL\Result;
 use Netresearch\NrPasskeysBe\Controller\AdminController;
 use Netresearch\NrPasskeysBe\Domain\Model\Credential;
 use Netresearch\NrPasskeysBe\Service\CredentialRepository;
@@ -21,9 +22,12 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionContainerInterface;
 
 #[CoversClass(AdminController::class)]
 final class AdminControllerTest extends TestCase
@@ -158,11 +162,9 @@ final class AdminControllerTest extends TestCase
         $this->logger
             ->expects(self::once())
             ->method('info')
-            ->with('Admin revoked passkey', self::callback(static function (array $context): bool {
-                return $context['admin_uid'] === 1
-                    && $context['be_user_uid'] === 42
-                    && $context['credential_uid'] === 10;
-            }));
+            ->with('Admin revoked passkey', self::callback(static fn(array $context): bool => $context['admin_uid'] === 1
+                && $context['be_user_uid'] === 42
+                && $context['credential_uid'] === 10));
 
         $response = $this->subject->removeAction($request);
 
@@ -363,11 +365,9 @@ final class AdminControllerTest extends TestCase
         $this->logger
             ->expects(self::once())
             ->method('info')
-            ->with('Admin unlocked user account', self::callback(static function (array $context): bool {
-                return $context['admin_uid'] === 1
-                    && $context['be_user_uid'] === 42
-                    && $context['username'] === 'lockeduser';
-            }));
+            ->with('Admin unlocked user account', self::callback(static fn(array $context): bool => $context['admin_uid'] === 1
+                && $context['be_user_uid'] === 42
+                && $context['username'] === 'lockeduser'));
 
         $response = $this->subject->unlockAction($request);
 
@@ -425,7 +425,7 @@ final class AdminControllerTest extends TestCase
      */
     private function setUpAdminUser(int $uid, string $username, bool $isSystemMaintainer = false): void
     {
-        $backendUser = $this->createMock(\TYPO3\CMS\Core\Authentication\BackendUserAuthentication::class);
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
         $backendUser->user = [
             'uid' => $uid,
             'username' => $username,
@@ -462,7 +462,7 @@ final class AdminControllerTest extends TestCase
      */
     private function setUpNonAdminUser(int $uid, string $username): void
     {
-        $backendUser = $this->createMock(\TYPO3\CMS\Core\Authentication\BackendUserAuthentication::class);
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
         $backendUser->user = [
             'uid' => $uid,
             'username' => $username,
@@ -482,7 +482,7 @@ final class AdminControllerTest extends TestCase
         $expressionBuilder = $this->createMock(ExpressionBuilder::class);
         $expressionBuilder->method('eq')->willReturn('1=1');
 
-        $result = $this->createMock(\Doctrine\DBAL\Result::class);
+        $result = $this->createMock(Result::class);
         $result->method('fetchAssociative')->willReturn($userRow ?? false);
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
@@ -700,7 +700,7 @@ final class AdminControllerTest extends TestCase
     #[Test]
     public function requireAdminReturnsNullWhenUserDataIsNotArray(): void
     {
-        $backendUser = $this->createMock(\TYPO3\CMS\Core\Authentication\BackendUserAuthentication::class);
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
         $backendUser->user = null; // not an array
         $backendUser->method('isAdmin')->willReturn(true);
         $GLOBALS['BE_USER'] = $backendUser;
@@ -718,7 +718,7 @@ final class AdminControllerTest extends TestCase
     #[Test]
     public function requireAdminReturnsNullWhenUserHasNoUid(): void
     {
-        $backendUser = $this->createMock(\TYPO3\CMS\Core\Authentication\BackendUserAuthentication::class);
+        $backendUser = $this->createMock(BackendUserAuthentication::class);
         $backendUser->user = ['username' => 'admin']; // no uid
         $backendUser->method('isAdmin')->willReturn(true);
         $GLOBALS['BE_USER'] = $backendUser;
@@ -832,11 +832,9 @@ final class AdminControllerTest extends TestCase
         $this->logger
             ->expects(self::once())
             ->method('info')
-            ->with('Admin revoked all passkeys', self::callback(static function (array $context): bool {
-                return $context['admin_uid'] === 1
-                    && $context['be_user_uid'] === 42
-                    && $context['revoked_count'] === 2;
-            }));
+            ->with('Admin revoked all passkeys', self::callback(static fn(array $context): bool => $context['admin_uid'] === 1
+                && $context['be_user_uid'] === 42
+                && $context['revoked_count'] === 2));
 
         $response = $this->subject->revokeAllAction($request);
 
@@ -928,7 +926,7 @@ final class AdminControllerTest extends TestCase
         $this->setUpAdminUser(1, 'superadmin');
         $this->setUpGroupLookup(5, ['uid' => 5]);
 
-        $connection = $this->createMock(\TYPO3\CMS\Core\Database\Connection::class);
+        $connection = $this->createMock(Connection::class);
         $connection->expects(self::once())
             ->method('update')
             ->with('be_groups', ['passkey_enforcement' => 'encourage'], ['uid' => 5]);
@@ -946,11 +944,9 @@ final class AdminControllerTest extends TestCase
         $this->logger
             ->expects(self::once())
             ->method('info')
-            ->with('Admin updated group enforcement', self::callback(static function (array $context): bool {
-                return $context['admin_uid'] === 1
-                    && $context['group_uid'] === 5
-                    && $context['enforcement'] === 'encourage';
-            }));
+            ->with('Admin updated group enforcement', self::callback(static fn(array $context): bool => $context['admin_uid'] === 1
+                && $context['group_uid'] === 5
+                && $context['enforcement'] === 'encourage'));
 
         $response = $this->subject->updateEnforcementAction($request);
 
@@ -1066,16 +1062,14 @@ final class AdminControllerTest extends TestCase
         $this->setUpAdminUser(1, 'superadmin');
         $this->setUpFindActiveBeUserByUid(42, ['uid' => 42, 'username' => 'editor']);
 
-        $connection = $this->createMock(\TYPO3\CMS\Core\Database\Connection::class);
+        $connection = $this->createMock(Connection::class);
         $connection->expects(self::once())
             ->method('update')
             ->with(
                 'be_users',
-                self::callback(static function (array $data): bool {
-                    return isset($data['passkey_nudge_until'])
-                        && \is_int($data['passkey_nudge_until'])
-                        && $data['passkey_nudge_until'] > \time();
-                }),
+                self::callback(static fn(array $data): bool => isset($data['passkey_nudge_until'])
+                    && \is_int($data['passkey_nudge_until'])
+                    && $data['passkey_nudge_until'] > \time()),
                 ['uid' => 42],
             );
 
@@ -1091,13 +1085,11 @@ final class AdminControllerTest extends TestCase
         $this->logger
             ->expects(self::once())
             ->method('info')
-            ->with('Admin sent passkey reminder', self::callback(static function (array $context): bool {
-                return $context['admin_uid'] === 1
-                    && $context['be_user_uid'] === 42
-                    && $context['username'] === 'editor'
-                    && \is_int($context['nudge_until'])
-                    && $context['nudge_until'] > \time();
-            }));
+            ->with('Admin sent passkey reminder', self::callback(static fn(array $context): bool => $context['admin_uid'] === 1
+                && $context['be_user_uid'] === 42
+                && $context['username'] === 'editor'
+                && \is_int($context['nudge_until'])
+                && $context['nudge_until'] > \time()));
 
         $response = $this->subject->sendReminderAction($request);
 
@@ -1178,7 +1170,7 @@ final class AdminControllerTest extends TestCase
         $this->setUpAdminUser(1, 'superadmin');
         $this->setUpFindActiveBeUserByUid(42, ['uid' => 42, 'username' => 'editor']);
 
-        $connection = $this->createMock(\TYPO3\CMS\Core\Database\Connection::class);
+        $connection = $this->createMock(Connection::class);
         $connection->expects(self::once())
             ->method('update')
             ->with(
@@ -1199,11 +1191,9 @@ final class AdminControllerTest extends TestCase
         $this->logger
             ->expects(self::once())
             ->method('info')
-            ->with('Admin cleared passkey nudge', self::callback(static function (array $context): bool {
-                return $context['admin_uid'] === 1
-                    && $context['be_user_uid'] === 42
-                    && $context['username'] === 'editor';
-            }));
+            ->with('Admin cleared passkey nudge', self::callback(static fn(array $context): bool => $context['admin_uid'] === 1
+                && $context['be_user_uid'] === 42
+                && $context['username'] === 'editor'));
 
         $response = $this->subject->clearNudgeAction($request);
 
@@ -1281,12 +1271,12 @@ final class AdminControllerTest extends TestCase
      */
     private function setUpGroupLookup(int $uid, ?array $groupRow): void
     {
-        $restrictions = $this->createMock(\TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionContainerInterface::class);
+        $restrictions = $this->createMock(QueryRestrictionContainerInterface::class);
 
         $expressionBuilder = $this->createMock(ExpressionBuilder::class);
         $expressionBuilder->method('eq')->willReturn('1=1');
 
-        $result = $this->createMock(\Doctrine\DBAL\Result::class);
+        $result = $this->createMock(Result::class);
         $result->method('fetchAssociative')->willReturn($groupRow ?? false);
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
@@ -1313,12 +1303,12 @@ final class AdminControllerTest extends TestCase
      */
     private function setUpFindActiveBeUserByUid(int $uid, ?array $userRow): void
     {
-        $restrictions = $this->createMock(\TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionContainerInterface::class);
+        $restrictions = $this->createMock(QueryRestrictionContainerInterface::class);
 
         $expressionBuilder = $this->createMock(ExpressionBuilder::class);
         $expressionBuilder->method('eq')->willReturn('1=1');
 
-        $result = $this->createMock(\Doctrine\DBAL\Result::class);
+        $result = $this->createMock(Result::class);
         $result->method('fetchAssociative')->willReturn($userRow ?? false);
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
@@ -1341,7 +1331,7 @@ final class AdminControllerTest extends TestCase
      *
      * @return array<string, mixed>
      */
-    private function decodeResponse(\Psr\Http\Message\ResponseInterface $response): array
+    private function decodeResponse(ResponseInterface $response): array
     {
         $body = (string) $response->getBody();
         $decoded = \json_decode($body, true, 512, JSON_THROW_ON_ERROR);

--- a/Tests/Unit/Controller/AdminControllerTest.php
+++ b/Tests/Unit/Controller/AdminControllerTest.php
@@ -9,11 +9,11 @@ declare(strict_types=1);
 
 namespace Netresearch\NrPasskeysBe\Tests\Unit\Controller;
 
-use Doctrine\DBAL\Result;
 use Netresearch\NrPasskeysBe\Controller\AdminController;
 use Netresearch\NrPasskeysBe\Domain\Model\Credential;
 use Netresearch\NrPasskeysBe\Service\CredentialRepository;
 use Netresearch\NrPasskeysBe\Service\RateLimiterService;
+use Netresearch\NrPasskeysBe\Tests\Unit\QueryBuilderMockTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -25,13 +25,13 @@ use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
-use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
-use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionContainerInterface;
 
 #[CoversClass(AdminController::class)]
 final class AdminControllerTest extends TestCase
 {
+    use QueryBuilderMockTrait;
+
     private AdminController $subject;
 
     private CredentialRepository&MockObject $credentialRepository;
@@ -479,19 +479,7 @@ final class AdminControllerTest extends TestCase
      */
     private function setUpFindBeUserByUid(int $uid, ?array $userRow): void
     {
-        $expressionBuilder = $this->createMock(ExpressionBuilder::class);
-        $expressionBuilder->method('eq')->willReturn('1=1');
-
-        $result = $this->createMock(Result::class);
-        $result->method('fetchAssociative')->willReturn($userRow ?? false);
-
-        $queryBuilder = $this->createMock(QueryBuilder::class);
-        $queryBuilder->method('select')->willReturnSelf();
-        $queryBuilder->method('from')->willReturnSelf();
-        $queryBuilder->method('where')->willReturnSelf();
-        $queryBuilder->method('expr')->willReturn($expressionBuilder);
-        $queryBuilder->method('createNamedParameter')->willReturn((string) $uid);
-        $queryBuilder->method('executeQuery')->willReturn($result);
+        $queryBuilder = $this->createSingleRowQueryBuilder($uid, $userRow);
 
         $this->connectionPool
             ->method('getQueryBuilderForTable')
@@ -1271,22 +1259,10 @@ final class AdminControllerTest extends TestCase
      */
     private function setUpGroupLookup(int $uid, ?array $groupRow): void
     {
-        $restrictions = $this->createMock(QueryRestrictionContainerInterface::class);
-
-        $expressionBuilder = $this->createMock(ExpressionBuilder::class);
-        $expressionBuilder->method('eq')->willReturn('1=1');
-
-        $result = $this->createMock(Result::class);
-        $result->method('fetchAssociative')->willReturn($groupRow ?? false);
-
-        $queryBuilder = $this->createMock(QueryBuilder::class);
-        $queryBuilder->method('select')->willReturnSelf();
-        $queryBuilder->method('from')->willReturnSelf();
-        $queryBuilder->method('where')->willReturnSelf();
-        $queryBuilder->method('expr')->willReturn($expressionBuilder);
-        $queryBuilder->method('createNamedParameter')->willReturn((string) $uid);
-        $queryBuilder->method('executeQuery')->willReturn($result);
-        $queryBuilder->method('getRestrictions')->willReturn($restrictions);
+        $queryBuilder = $this->createSingleRowQueryBuilder($uid, $groupRow);
+        $queryBuilder->method('getRestrictions')->willReturn(
+            $this->createMock(QueryRestrictionContainerInterface::class),
+        );
 
         $this->connectionPool
             ->method('getQueryBuilderForTable')
@@ -1303,22 +1279,10 @@ final class AdminControllerTest extends TestCase
      */
     private function setUpFindActiveBeUserByUid(int $uid, ?array $userRow): void
     {
-        $restrictions = $this->createMock(QueryRestrictionContainerInterface::class);
-
-        $expressionBuilder = $this->createMock(ExpressionBuilder::class);
-        $expressionBuilder->method('eq')->willReturn('1=1');
-
-        $result = $this->createMock(Result::class);
-        $result->method('fetchAssociative')->willReturn($userRow ?? false);
-
-        $queryBuilder = $this->createMock(QueryBuilder::class);
-        $queryBuilder->method('select')->willReturnSelf();
-        $queryBuilder->method('from')->willReturnSelf();
-        $queryBuilder->method('where')->willReturnSelf();
-        $queryBuilder->method('expr')->willReturn($expressionBuilder);
-        $queryBuilder->method('createNamedParameter')->willReturn((string) $uid);
-        $queryBuilder->method('executeQuery')->willReturn($result);
-        $queryBuilder->method('getRestrictions')->willReturn($restrictions);
+        $queryBuilder = $this->createSingleRowQueryBuilder($uid, $userRow);
+        $queryBuilder->method('getRestrictions')->willReturn(
+            $this->createMock(QueryRestrictionContainerInterface::class),
+        );
 
         $this->connectionPool
             ->method('getQueryBuilderForTable')

--- a/Tests/Unit/Controller/AdminModuleControllerTest.php
+++ b/Tests/Unit/Controller/AdminModuleControllerTest.php
@@ -158,21 +158,19 @@ final class AdminModuleControllerTest extends TestCase
 
         $moduleTemplate->expects(self::once())
             ->method('assignMultiple')
-            ->with(self::callback(static function (array $variables): bool {
-                return $variables['totalUsers'] === 10
-                    && $variables['usersWithPasskeys'] === 6
-                    && $variables['adoptionPercentage'] === 60.0
-                    && $variables['groups'] === []
-                    && $variables['usersWithoutPasskeys'] === []
-                    && \is_array($variables['enforcementLevels'])
-                    && isset($variables['enforcementLevels']['off'])
-                    && isset($variables['enforcementLevels']['encourage'])
-                    && isset($variables['enforcementLevels']['required'])
-                    && isset($variables['enforcementLevels']['enforced'])
-                    && \array_key_exists('helpUrl', $variables)
-                    && \array_key_exists('configRpId', $variables)
-                    && \array_key_exists('isNewInstallation', $variables);
-            }));
+            ->with(self::callback(static fn(array $variables): bool => $variables['totalUsers'] === 10
+                && $variables['usersWithPasskeys'] === 6
+                && $variables['adoptionPercentage'] === 60.0
+                && $variables['groups'] === []
+                && $variables['usersWithoutPasskeys'] === []
+                && \is_array($variables['enforcementLevels'])
+                && isset($variables['enforcementLevels']['off'])
+                && isset($variables['enforcementLevels']['encourage'])
+                && isset($variables['enforcementLevels']['required'])
+                && isset($variables['enforcementLevels']['enforced'])
+                && \array_key_exists('helpUrl', $variables)
+                && \array_key_exists('configRpId', $variables)
+                && \array_key_exists('isNewInstallation', $variables)));
 
         $expectedResponse = new HtmlResponse('<html></html>');
         $moduleTemplate->expects(self::once())

--- a/Tests/Unit/Controller/JsonBodyTraitTest.php
+++ b/Tests/Unit/Controller/JsonBodyTraitTest.php
@@ -183,6 +183,7 @@ final class JsonBodyTraitTest extends TestCase
         for ($i = 0; $i < 18; $i++) {
             $nested .= '{"a":';
         }
+
         $nested .= '"v"';
         for ($i = 0; $i < 19; $i++) {
             $nested .= '}';

--- a/Tests/Unit/Controller/LoginControllerTest.php
+++ b/Tests/Unit/Controller/LoginControllerTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrPasskeysBe\Tests\Unit\Controller;
 
+use Doctrine\DBAL\Result;
 use Error;
 use Netresearch\NrPasskeysBe\Configuration\ExtensionConfiguration;
 use Netresearch\NrPasskeysBe\Controller\LoginController;
@@ -20,6 +21,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
@@ -30,6 +32,7 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Webauthn\Exception\InvalidDataException;
 use Webauthn\PublicKeyCredentialRequestOptions;
 
 #[CoversClass(LoginController::class)]
@@ -132,7 +135,7 @@ final class LoginControllerTest extends TestCase
         $this->stubAssertionOptionGeneration();
         $this->setUpFindBeUser('admin', ['uid' => 42, 'username' => 'admin']);
 
-        self::assertTimingBudgetSpent($this->timeOptionsAction('admin'));
+        $this->assertTimingBudgetSpent($this->timeOptionsAction('admin'));
     }
 
     #[Test]
@@ -141,7 +144,7 @@ final class LoginControllerTest extends TestCase
         $this->stubAssertionOptionGeneration();
         $this->setUpFindBeUser('nosuchuser', null);
 
-        self::assertTimingBudgetSpent($this->timeOptionsAction('nosuchuser'));
+        $this->assertTimingBudgetSpent($this->timeOptionsAction('nosuchuser'));
     }
 
     /**
@@ -153,7 +156,7 @@ final class LoginControllerTest extends TestCase
      * tight ceiling would flake on a loaded CI runner, where scheduling noise, not the
      * controller, decides the last few milliseconds.
      */
-    private static function assertTimingBudgetSpent(float $elapsedNs): void
+    private function assertTimingBudgetSpent(float $elapsedNs): void
     {
         $budgetNs = 150_000_000.0;
 
@@ -406,7 +409,7 @@ final class LoginControllerTest extends TestCase
         $this->webAuthnService
             ->expects(self::once())
             ->method('verifyAssertionResponse')
-            ->willThrowException(new \Webauthn\Exception\InvalidDataException(
+            ->willThrowException(new InvalidDataException(
                 null,
                 'Invalid input',
             ));
@@ -889,7 +892,7 @@ final class LoginControllerTest extends TestCase
         $expressionBuilder = $this->createMock(ExpressionBuilder::class);
         $expressionBuilder->method('eq')->willReturn('1=1');
 
-        $result = $this->createMock(\Doctrine\DBAL\Result::class);
+        $result = $this->createMock(Result::class);
         $result->method('fetchAssociative')->willReturn($userRow ?? false);
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
@@ -911,7 +914,7 @@ final class LoginControllerTest extends TestCase
      *
      * @return array<string, mixed>
      */
-    private function decodeResponse(\Psr\Http\Message\ResponseInterface $response): array
+    private function decodeResponse(ResponseInterface $response): array
     {
         $body = (string) $response->getBody();
         $decoded = \json_decode($body, true, 512, JSON_THROW_ON_ERROR);

--- a/Tests/Unit/Controller/ManagementControllerTest.php
+++ b/Tests/Unit/Controller/ManagementControllerTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
@@ -1206,7 +1207,7 @@ final class ManagementControllerTest extends TestCase
      *
      * @return array<string, mixed>
      */
-    private function decodeResponse(\Psr\Http\Message\ResponseInterface $response): array
+    private function decodeResponse(ResponseInterface $response): array
     {
         $body = (string) $response->getBody();
         $decoded = \json_decode($body, true, 512, JSON_THROW_ON_ERROR);

--- a/Tests/Unit/EventListener/InjectPasskeyLoginFieldsTest.php
+++ b/Tests/Unit/EventListener/InjectPasskeyLoginFieldsTest.php
@@ -116,6 +116,30 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
             ->willReturn($origin);
     }
 
+    /**
+     * Expect the injected window.NrPasskeysBeConfig to carry $expected under $key.
+     */
+    private function expectInjectedConfigValue(string $key, mixed $expected): void
+    {
+        $this->pageRenderer->method('loadJavaScriptModule');
+
+        $this->pageRenderer
+            ->expects(self::once())
+            ->method('addJsInlineCode')
+            ->with(
+                self::anything(),
+                self::callback(static function (string $code) use ($key, $expected): bool {
+                    $jsonPart = \rtrim(\str_replace('window.NrPasskeysBeConfig = ', '', $code), ';');
+
+                    $decoded = \json_decode($jsonPart, true);
+                    self::assertIsArray($decoded);
+                    self::assertSame($expected, $decoded[$key]);
+
+                    return true;
+                }),
+            );
+    }
+
     #[Test]
     public function constructorAcceptsRequiredDependencies(): void
     {
@@ -232,22 +256,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
     {
         $this->setUpConfigService(rpId: 'fallback.example.com');
 
-        $this->pageRenderer->method('loadJavaScriptModule');
-
-        $this->pageRenderer
-            ->expects(self::once())
-            ->method('addJsInlineCode')
-            ->with(
-                self::anything(),
-                self::callback(static function (string $code): bool {
-                    $jsonPart = \str_replace('window.NrPasskeysBeConfig = ', '', $code);
-                    $jsonPart = \rtrim($jsonPart, ';');
-
-                    $decoded = \json_decode($jsonPart, true);
-                    self::assertSame('fallback.example.com', $decoded['rpId']);
-                    return true;
-                }),
-            );
+        $this->expectInjectedConfigValue('rpId', 'fallback.example.com');
 
         ($this->subject)($this->createEvent());
     }
@@ -257,22 +266,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
     {
         $this->setUpConfigService(origin: 'https://custom-origin.example.com');
 
-        $this->pageRenderer->method('loadJavaScriptModule');
-
-        $this->pageRenderer
-            ->expects(self::once())
-            ->method('addJsInlineCode')
-            ->with(
-                self::anything(),
-                self::callback(static function (string $code): bool {
-                    $jsonPart = \str_replace('window.NrPasskeysBeConfig = ', '', $code);
-                    $jsonPart = \rtrim($jsonPart, ';');
-
-                    $decoded = \json_decode($jsonPart, true);
-                    self::assertSame('https://custom-origin.example.com', $decoded['origin']);
-                    return true;
-                }),
-            );
+        $this->expectInjectedConfigValue('origin', 'https://custom-origin.example.com');
 
         ($this->subject)($this->createEvent());
     }
@@ -282,22 +276,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
     {
         $this->setUpConfigService(discoverableEnabled: false);
 
-        $this->pageRenderer->method('loadJavaScriptModule');
-
-        $this->pageRenderer
-            ->expects(self::once())
-            ->method('addJsInlineCode')
-            ->with(
-                self::anything(),
-                self::callback(static function (string $code): bool {
-                    $jsonPart = \str_replace('window.NrPasskeysBeConfig = ', '', $code);
-                    $jsonPart = \rtrim($jsonPart, ';');
-
-                    $decoded = \json_decode($jsonPart, true);
-                    self::assertFalse($decoded['discoverableEnabled']);
-                    return true;
-                }),
-            );
+        $this->expectInjectedConfigValue('discoverableEnabled', false);
 
         ($this->subject)($this->createEvent());
     }
@@ -307,22 +286,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
     {
         $this->setUpConfigService();
 
-        $this->pageRenderer->method('loadJavaScriptModule');
-
-        $this->pageRenderer
-            ->expects(self::once())
-            ->method('addJsInlineCode')
-            ->with(
-                self::anything(),
-                self::callback(static function (string $code): bool {
-                    $jsonPart = \str_replace('window.NrPasskeysBeConfig = ', '', $code);
-                    $jsonPart = \rtrim($jsonPart, ';');
-
-                    $decoded = \json_decode($jsonPart, true);
-                    self::assertSame('/typo3/passkeys/login/options', $decoded['loginOptionsUrl']);
-                    return true;
-                }),
-            );
+        $this->expectInjectedConfigValue('loginOptionsUrl', '/typo3/passkeys/login/options');
 
         ($this->subject)($this->createEvent());
     }

--- a/Tests/Unit/EventListener/InjectPasskeyLoginFieldsTest.php
+++ b/Tests/Unit/EventListener/InjectPasskeyLoginFieldsTest.php
@@ -14,6 +14,7 @@ use Netresearch\NrPasskeysBe\EventListener\InjectPasskeyLoginFields;
 use Netresearch\NrPasskeysBe\Service\ExtensionConfigurationService;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use ReflectionMethod;
@@ -28,9 +29,12 @@ use TYPO3\CMS\Core\View\ViewInterface;
 #[CoversClass(InjectPasskeyLoginFields::class)]
 final class InjectPasskeyLoginFieldsTest extends TestCase
 {
-    private ExtensionConfigurationService $configService;
-    private PageRenderer $pageRenderer;
-    private UriBuilder $uriBuilder;
+    private MockObject $configService;
+
+    private MockObject $pageRenderer;
+
+    private MockObject $uriBuilder;
+
     private InjectPasskeyLoginFields $subject;
 
     protected function setUp(): void
@@ -176,6 +180,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
                     // Extract and decode JSON from the JS assignment
                     $jsonPart = \str_replace('window.NrPasskeysBeConfig = ', '', $code);
                     $jsonPart = \rtrim($jsonPart, ';');
+
                     $decoded = \json_decode($jsonPart, true);
                     self::assertIsArray($decoded);
                     self::assertSame('/typo3/passkeys/login/options', $decoded['loginOptionsUrl']);
@@ -237,6 +242,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
                 self::callback(static function (string $code): bool {
                     $jsonPart = \str_replace('window.NrPasskeysBeConfig = ', '', $code);
                     $jsonPart = \rtrim($jsonPart, ';');
+
                     $decoded = \json_decode($jsonPart, true);
                     self::assertSame('fallback.example.com', $decoded['rpId']);
                     return true;
@@ -261,6 +267,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
                 self::callback(static function (string $code): bool {
                     $jsonPart = \str_replace('window.NrPasskeysBeConfig = ', '', $code);
                     $jsonPart = \rtrim($jsonPart, ';');
+
                     $decoded = \json_decode($jsonPart, true);
                     self::assertSame('https://custom-origin.example.com', $decoded['origin']);
                     return true;
@@ -285,6 +292,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
                 self::callback(static function (string $code): bool {
                     $jsonPart = \str_replace('window.NrPasskeysBeConfig = ', '', $code);
                     $jsonPart = \rtrim($jsonPart, ';');
+
                     $decoded = \json_decode($jsonPart, true);
                     self::assertFalse($decoded['discoverableEnabled']);
                     return true;
@@ -309,6 +317,7 @@ final class InjectPasskeyLoginFieldsTest extends TestCase
                 self::callback(static function (string $code): bool {
                     $jsonPart = \str_replace('window.NrPasskeysBeConfig = ', '', $code);
                     $jsonPart = \rtrim($jsonPart, ';');
+
                     $decoded = \json_decode($jsonPart, true);
                     self::assertSame('/typo3/passkeys/login/options', $decoded['loginOptionsUrl']);
                     return true;

--- a/Tests/Unit/EventListener/InjectPasskeyLoginFieldsTest.php
+++ b/Tests/Unit/EventListener/InjectPasskeyLoginFieldsTest.php
@@ -29,11 +29,11 @@ use TYPO3\CMS\Core\View\ViewInterface;
 #[CoversClass(InjectPasskeyLoginFields::class)]
 final class InjectPasskeyLoginFieldsTest extends TestCase
 {
-    private MockObject $configService;
+    private ExtensionConfigurationService&MockObject $configService;
 
-    private MockObject $pageRenderer;
+    private PageRenderer&MockObject $pageRenderer;
 
-    private MockObject $uriBuilder;
+    private UriBuilder&MockObject $uriBuilder;
 
     private InjectPasskeyLoginFields $subject;
 

--- a/Tests/Unit/Middleware/PasskeySetupInterstitialTest.php
+++ b/Tests/Unit/Middleware/PasskeySetupInterstitialTest.php
@@ -20,6 +20,7 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Backend\Routing\Route;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Http\HtmlResponse;
@@ -33,6 +34,7 @@ use TYPO3\CMS\Core\Localization\Locale;
 final class PasskeySetupInterstitialTest extends TestCase
 {
     private EnforcementService&MockObject $enforcementService;
+
     private PasskeySetupInterstitial $subject;
 
     protected function setUp(): void
@@ -902,15 +904,9 @@ final class PasskeySetupInterstitialTest extends TestCase
         );
         $this->enforcementService->method('getStatus')->willReturn($status);
 
-        $route = $this->createMock(\TYPO3\CMS\Backend\Routing\Route::class);
+        $route = $this->createMock(Route::class);
         $route->method('getOption')
-            ->willReturnCallback(static function (string $option): mixed {
-                if ($option === '_identifier') {
-                    return null;
-                }
-
-                return null;
-            });
+            ->willReturnCallback(static fn(string $option): mixed => null);
 
         $request = $this->createMock(ServerRequestInterface::class);
         $request->method('getAttribute')
@@ -951,7 +947,7 @@ final class PasskeySetupInterstitialTest extends TestCase
             }
         };
 
-        $route = $this->createMock(\TYPO3\CMS\Backend\Routing\Route::class);
+        $route = $this->createMock(Route::class);
         $route->method('getOption')
             ->willReturnCallback(static function (string $option): mixed {
                 if ($option === '_identifier') {
@@ -1124,7 +1120,7 @@ final class PasskeySetupInterstitialTest extends TestCase
         string $method = 'GET',
         ?array $parsedBody = null,
     ): ServerRequestInterface&MockObject {
-        $route = $this->createMock(\TYPO3\CMS\Backend\Routing\Route::class);
+        $route = $this->createMock(Route::class);
         $route->method('getOption')
             ->willReturnCallback(static function (string $option) use ($routeIdentifier): mixed {
                 if ($option === '_identifier') {

--- a/Tests/Unit/Middleware/PublicRouteResolverTest.php
+++ b/Tests/Unit/Middleware/PublicRouteResolverTest.php
@@ -35,16 +35,51 @@ final class PublicRouteResolverTest extends TestCase
         $this->subject = new PublicRouteResolver($this->dispatcher);
     }
 
-    #[Test]
-    public function dispatchesPublicPasskeyLoginRoute(): void
+    /**
+     * A backend route reporting the given `access` and `_identifier` options.
+     */
+    private function createRoute(mixed $access, mixed $identifier): Route&MockObject
     {
         $route = $this->createMock(Route::class);
         $route->method('getOption')
             ->willReturnCallback(static fn(string $option): mixed => match ($option) {
-                'access' => 'public',
-                '_identifier' => 'passkeys_login_options',
+                'access' => $access,
+                '_identifier' => $identifier,
                 default => null,
             });
+
+        return $route;
+    }
+
+    /**
+     * Assert the request is handed to the next handler untouched, and that the
+     * middleware dispatches nothing itself.
+     */
+    private function assertPassesThrough(?Route $route): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getAttribute')
+            ->with('route')
+            ->willReturn($route);
+
+        $expectedResponse = $this->createMock(ResponseInterface::class);
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects(self::once())
+            ->method('handle')
+            ->with($request)
+            ->willReturn($expectedResponse);
+
+        $this->dispatcher->expects(self::never())->method('dispatch');
+
+        $response = $this->subject->process($request, $handler);
+
+        self::assertSame($expectedResponse, $response);
+    }
+
+    #[Test]
+    public function dispatchesPublicPasskeyLoginRoute(): void
+    {
+        $route = $this->createRoute('public', 'passkeys_login_options');
 
         $request = $this->createMock(ServerRequestInterface::class);
         $request->method('getAttribute')
@@ -69,112 +104,24 @@ final class PublicRouteResolverTest extends TestCase
     #[Test]
     public function passesThroughWhenRouteIsNull(): void
     {
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getAttribute')
-            ->with('route')
-            ->willReturn(null);
-
-        $expectedResponse = $this->createMock(ResponseInterface::class);
-        $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler->expects(self::once())
-            ->method('handle')
-            ->with($request)
-            ->willReturn($expectedResponse);
-
-        $this->dispatcher->expects(self::never())->method('dispatch');
-
-        $response = $this->subject->process($request, $handler);
-
-        self::assertSame($expectedResponse, $response);
+        $this->assertPassesThrough(null);
     }
 
     #[Test]
     public function passesThroughWhenRouteIsNotPublic(): void
     {
-        $route = $this->createMock(Route::class);
-        $route->method('getOption')
-            ->willReturnCallback(static fn(string $option): mixed => match ($option) {
-                'access' => 'something_else',
-                '_identifier' => 'passkeys_login_options',
-                default => null,
-            });
-
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getAttribute')
-            ->with('route')
-            ->willReturn($route);
-
-        $expectedResponse = $this->createMock(ResponseInterface::class);
-        $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler->expects(self::once())
-            ->method('handle')
-            ->with($request)
-            ->willReturn($expectedResponse);
-
-        $this->dispatcher->expects(self::never())->method('dispatch');
-
-        $response = $this->subject->process($request, $handler);
-
-        self::assertSame($expectedResponse, $response);
+        $this->assertPassesThrough($this->createRoute('something_else', 'passkeys_login_options'));
     }
 
     #[Test]
     public function passesThroughWhenIdentifierDoesNotMatchPrefix(): void
     {
-        $route = $this->createMock(Route::class);
-        $route->method('getOption')
-            ->willReturnCallback(static fn(string $option): mixed => match ($option) {
-                'access' => 'public',
-                '_identifier' => 'main',
-                default => null,
-            });
-
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getAttribute')
-            ->with('route')
-            ->willReturn($route);
-
-        $expectedResponse = $this->createMock(ResponseInterface::class);
-        $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler->expects(self::once())
-            ->method('handle')
-            ->with($request)
-            ->willReturn($expectedResponse);
-
-        $this->dispatcher->expects(self::never())->method('dispatch');
-
-        $response = $this->subject->process($request, $handler);
-
-        self::assertSame($expectedResponse, $response);
+        $this->assertPassesThrough($this->createRoute('public', 'main'));
     }
 
     #[Test]
     public function passesThroughWhenIdentifierIsNotString(): void
     {
-        $route = $this->createMock(Route::class);
-        $route->method('getOption')
-            ->willReturnCallback(static fn(string $option): mixed => match ($option) {
-                'access' => 'public',
-                '_identifier' => null,
-                default => null,
-            });
-
-        $request = $this->createMock(ServerRequestInterface::class);
-        $request->method('getAttribute')
-            ->with('route')
-            ->willReturn($route);
-
-        $expectedResponse = $this->createMock(ResponseInterface::class);
-        $handler = $this->createMock(RequestHandlerInterface::class);
-        $handler->expects(self::once())
-            ->method('handle')
-            ->with($request)
-            ->willReturn($expectedResponse);
-
-        $this->dispatcher->expects(self::never())->method('dispatch');
-
-        $response = $this->subject->process($request, $handler);
-
-        self::assertSame($expectedResponse, $response);
+        $this->assertPassesThrough($this->createRoute('public', null));
     }
 }

--- a/Tests/Unit/Middleware/PublicRouteResolverTest.php
+++ b/Tests/Unit/Middleware/PublicRouteResolverTest.php
@@ -40,12 +40,10 @@ final class PublicRouteResolverTest extends TestCase
     {
         $route = $this->createMock(Route::class);
         $route->method('getOption')
-            ->willReturnCallback(static function (string $option): mixed {
-                return match ($option) {
-                    'access' => 'public',
-                    '_identifier' => 'passkeys_login_options',
-                    default => null,
-                };
+            ->willReturnCallback(static fn(string $option): mixed => match ($option) {
+                'access' => 'public',
+                '_identifier' => 'passkeys_login_options',
+                default => null,
             });
 
         $request = $this->createMock(ServerRequestInterface::class);
@@ -95,12 +93,10 @@ final class PublicRouteResolverTest extends TestCase
     {
         $route = $this->createMock(Route::class);
         $route->method('getOption')
-            ->willReturnCallback(static function (string $option): mixed {
-                return match ($option) {
-                    'access' => 'something_else',
-                    '_identifier' => 'passkeys_login_options',
-                    default => null,
-                };
+            ->willReturnCallback(static fn(string $option): mixed => match ($option) {
+                'access' => 'something_else',
+                '_identifier' => 'passkeys_login_options',
+                default => null,
             });
 
         $request = $this->createMock(ServerRequestInterface::class);
@@ -127,12 +123,10 @@ final class PublicRouteResolverTest extends TestCase
     {
         $route = $this->createMock(Route::class);
         $route->method('getOption')
-            ->willReturnCallback(static function (string $option): mixed {
-                return match ($option) {
-                    'access' => 'public',
-                    '_identifier' => 'main',
-                    default => null,
-                };
+            ->willReturnCallback(static fn(string $option): mixed => match ($option) {
+                'access' => 'public',
+                '_identifier' => 'main',
+                default => null,
             });
 
         $request = $this->createMock(ServerRequestInterface::class);
@@ -159,12 +153,10 @@ final class PublicRouteResolverTest extends TestCase
     {
         $route = $this->createMock(Route::class);
         $route->method('getOption')
-            ->willReturnCallback(static function (string $option): mixed {
-                return match ($option) {
-                    'access' => 'public',
-                    '_identifier' => null,
-                    default => null,
-                };
+            ->willReturnCallback(static fn(string $option): mixed => match ($option) {
+                'access' => 'public',
+                '_identifier' => null,
+                default => null,
             });
 
         $request = $this->createMock(ServerRequestInterface::class);

--- a/Tests/Unit/QueryBuilderMockTrait.php
+++ b/Tests/Unit/QueryBuilderMockTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Tests\Unit;
+
+use Doctrine\DBAL\Result;
+use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+
+/**
+ * Builds the QueryBuilder mock every single-row lookup in this extension needs.
+ *
+ * The fluent chain (select/from/where/expr/createNamedParameter/executeQuery)
+ * is identical for each of those lookups, so it lives here once instead of per
+ * test class. getRestrictions() is deliberately NOT stubbed: a caller that
+ * expects the code under test to clear restrictions adds that stub itself, and
+ * the ones that do not keep failing loudly if the code starts touching
+ * restrictions.
+ */
+trait QueryBuilderMockTrait
+{
+    /**
+     * A QueryBuilder whose query resolves to $row, or to no row when null.
+     *
+     * @param array<string, mixed>|null $row
+     */
+    private function createSingleRowQueryBuilder(int $uid, ?array $row): QueryBuilder&MockObject
+    {
+        $expressionBuilder = $this->createMock(ExpressionBuilder::class);
+        $expressionBuilder->method('eq')->willReturn('1=1');
+
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAssociative')->willReturn($row ?? false);
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('expr')->willReturn($expressionBuilder);
+        $queryBuilder->method('createNamedParameter')->willReturn((string) $uid);
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        return $queryBuilder;
+    }
+}

--- a/Tests/Unit/Service/ChallengeServiceTest.php
+++ b/Tests/Unit/Service/ChallengeServiceTest.php
@@ -26,9 +26,13 @@ use TYPO3\CMS\Core\Locking\LockingStrategyInterface;
 final class ChallengeServiceTest extends TestCase
 {
     private FrontendInterface&MockObject $nonceCacheMock;
+
     private LockFactory&MockObject $lockFactoryMock;
+
     private ExtensionConfigurationService $configService;
+
     private LoggerInterface&MockObject $loggerMock;
+
     private ChallengeService $subject;
 
     protected function setUp(): void

--- a/Tests/Unit/Service/EnforcementServiceTest.php
+++ b/Tests/Unit/Service/EnforcementServiceTest.php
@@ -210,11 +210,9 @@ final class EnforcementServiceTest extends TestCase
             ->method('update')
             ->with(
                 'be_users',
-                self::callback(static function (array $data): bool {
-                    return isset($data['passkey_grace_period_start'])
-                        && \is_int($data['passkey_grace_period_start'])
-                        && $data['passkey_grace_period_start'] > 0;
-                }),
+                self::callback(static fn(array $data): bool => isset($data['passkey_grace_period_start'])
+                    && \is_int($data['passkey_grace_period_start'])
+                    && $data['passkey_grace_period_start'] > 0),
                 ['uid' => 42],
             );
 

--- a/Tests/Unit/Service/RateLimiterServiceTest.php
+++ b/Tests/Unit/Service/RateLimiterServiceTest.php
@@ -26,10 +26,15 @@ use TYPO3\CMS\Core\Locking\LockingStrategyInterface;
 final class RateLimiterServiceTest extends TestCase
 {
     private FrontendInterface&MockObject $rateLimitCacheMock;
+
     private ExtensionConfigurationService $configService;
+
     private LockFactory&MockObject $lockFactoryMock;
+
     private LockingStrategyInterface&MockObject $lockerMock;
+
     private LoggerInterface&MockObject $loggerMock;
+
     private RateLimiterService $subject;
 
     protected function setUp(): void
@@ -267,9 +272,11 @@ final class RateLimiterServiceTest extends TestCase
                 if ($key === $ipKey) {
                     return '2';
                 }
+
                 if ($key === $userKey) {
                     return '10';
                 }
+
                 return false;
             });
 
@@ -338,9 +345,7 @@ final class RateLimiterServiceTest extends TestCase
             ->with(
                 self::isType('string'),
                 '3',
-                self::callback(static function (array $tags): bool {
-                    return \count($tags) === 1 && \str_starts_with($tags[0], 'lockout_');
-                }),
+                self::callback(static fn(array $tags): bool => \count($tags) === 1 && \str_starts_with($tags[0], 'lockout_')),
                 900,
             );
 
@@ -356,9 +361,7 @@ final class RateLimiterServiceTest extends TestCase
         $this->rateLimitCacheMock
             ->expects(self::exactly(2))
             ->method('remove')
-            ->with(self::callback(static function (string $key) use ($ipKey, $userKey): bool {
-                return $key === $ipKey || $key === $userKey;
-            }));
+            ->with(self::callback(static fn(string $key): bool => $key === $ipKey || $key === $userKey));
 
         $this->subject->recordSuccess('admin', '192.168.1.1');
     }
@@ -428,7 +431,6 @@ final class RateLimiterServiceTest extends TestCase
 
         $expectedIpKey = 'lo_' . \hash('sha256', 'user@example.com|2001:db8::1');
         $expectedUserKey = 'lou_' . \hash('sha256', 'user@example.com');
-        $expectedTag = 'lockout_' . \hash('sha256', 'user@example.com');
 
         $setCalls = [];
         $this->rateLimitCacheMock
@@ -517,9 +519,7 @@ final class RateLimiterServiceTest extends TestCase
             ->with(
                 self::isType('string'),
                 '2',
-                self::callback(static function (array $tags): bool {
-                    return \count($tags) === 1 && \str_starts_with($tags[0], 'lockout_');
-                }),
+                self::callback(static fn(array $tags): bool => \count($tags) === 1 && \str_starts_with($tags[0], 'lockout_')),
                 900,
             );
 

--- a/Tests/Unit/Service/WebAuthnServiceTest.php
+++ b/Tests/Unit/Service/WebAuthnServiceTest.php
@@ -9,6 +9,11 @@ declare(strict_types=1);
 
 namespace Netresearch\NrPasskeysBe\Tests\Unit\Service;
 
+use CBOR\ByteStringObject;
+use CBOR\MapObject;
+use CBOR\NegativeIntegerObject;
+use CBOR\UnsignedIntegerObject;
+use Cose\Algorithm\Algorithm;
 use Cose\Algorithm\Manager as AlgorithmManager;
 use Netresearch\NrPasskeysBe\Configuration\ExtensionConfiguration;
 use Netresearch\NrPasskeysBe\Domain\Dto\AssertionOptions;
@@ -31,10 +36,13 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use ReflectionMethod;
 use RuntimeException;
+use Symfony\Component\Uid\Uuid;
 use Throwable;
 use Webauthn\CredentialRecord;
 use Webauthn\PublicKeyCredentialCreationOptions;
+use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\PublicKeyCredentialRequestOptions;
+use Webauthn\TrustPath\EmptyTrustPath;
 
 #[CoversClass(WebAuthnService::class)]
 #[CoversClass(AttestationService::class)]
@@ -43,12 +51,19 @@ use Webauthn\PublicKeyCredentialRequestOptions;
 final class WebAuthnServiceTest extends TestCase
 {
     private ExtensionConfigurationService&MockObject $configServiceMock;
+
     private ChallengeService&MockObject $challengeServiceMock;
+
     private CredentialRepository&MockObject $credentialRepositoryMock;
+
     private LoggerInterface&MockObject $loggerMock;
+
     private WebAuthnCeremonyFactory $ceremonyFactory;
+
     private AttestationService $attestationService;
+
     private AssertionService $assertionService;
+
     private WebAuthnService $subject;
 
     protected function setUp(): void
@@ -313,8 +328,8 @@ final class WebAuthnServiceTest extends TestCase
             type: 'public-key',
             transports: ['usb', 'nfc'],
             attestationType: 'none',
-            trustPath: new \Webauthn\TrustPath\EmptyTrustPath(),
-            aaguid: \Symfony\Component\Uid\Uuid::v4(),
+            trustPath: new EmptyTrustPath(),
+            aaguid: Uuid::v4(),
             credentialPublicKey: 'cose-public-key-data',
             userHandle: 'user-handle-hash',
             counter: 0,
@@ -323,15 +338,13 @@ final class WebAuthnServiceTest extends TestCase
         $this->credentialRepositoryMock
             ->expects(self::once())
             ->method('save')
-            ->with(self::callback(function (Credential $cred) use ($beUserUid, $label, $source): bool {
-                return $cred->getBeUser() === $beUserUid
-                    && $cred->getLabel() === $label
-                    && $cred->getCredentialId() === $source->publicKeyCredentialId
-                    && $cred->getPublicKeyCose() === $source->credentialPublicKey
-                    && $cred->getUserHandle() === $source->userHandle
-                    && $cred->getSignCount() === $source->counter
-                    && $cred->getAaguid() === $source->aaguid->toString();
-            }))
+            ->with(self::callback(fn(Credential $cred): bool => $cred->getBeUser() === $beUserUid
+                && $cred->getLabel() === $label
+                && $cred->getCredentialId() === $source->publicKeyCredentialId
+                && $cred->getPublicKeyCose() === $source->credentialPublicKey
+                && $cred->getUserHandle() === $source->userHandle
+                && $cred->getSignCount() === $source->counter
+                && $cred->getAaguid() === $source->aaguid->toString()))
             ->willReturn($expectedUid);
 
         $result = $this->subject->storeCredential($source, $beUserUid, $label);
@@ -492,13 +505,13 @@ final class WebAuthnServiceTest extends TestCase
         $label = 'Security Key';
         $expectedUid = 55;
 
-        $uuid = \Symfony\Component\Uid\Uuid::v4();
+        $uuid = Uuid::v4();
         $source = CredentialRecord::create(
             publicKeyCredentialId: 'test-cred-id',
             type: 'public-key',
             transports: ['usb', 'ble', 'nfc'],
             attestationType: 'none',
-            trustPath: new \Webauthn\TrustPath\EmptyTrustPath(),
+            trustPath: new EmptyTrustPath(),
             aaguid: $uuid,
             credentialPublicKey: 'public-key-cose',
             userHandle: 'user-handle',
@@ -726,8 +739,8 @@ final class WebAuthnServiceTest extends TestCase
             type: 'public-key',
             transports: [],
             attestationType: 'none',
-            trustPath: new \Webauthn\TrustPath\EmptyTrustPath(),
-            aaguid: \Symfony\Component\Uid\Uuid::v4(),
+            trustPath: new EmptyTrustPath(),
+            aaguid: Uuid::v4(),
             credentialPublicKey: 'cose',
             userHandle: 'handle',
             counter: 42,
@@ -736,9 +749,7 @@ final class WebAuthnServiceTest extends TestCase
         $this->credentialRepositoryMock
             ->expects(self::once())
             ->method('save')
-            ->with(self::callback(function (Credential $cred): bool {
-                return $cred->getSignCount() === 42;
-            }))
+            ->with(self::callback(fn(Credential $cred): bool => $cred->getSignCount() === 42))
             ->willReturn(1);
 
         $result = $this->subject->storeCredential($source, $beUserUid, $label);
@@ -959,8 +970,8 @@ final class WebAuthnServiceTest extends TestCase
             type: 'public-key',
             transports: [],
             attestationType: 'none',
-            trustPath: new \Webauthn\TrustPath\EmptyTrustPath(),
-            aaguid: \Symfony\Component\Uid\Uuid::v4(),
+            trustPath: new EmptyTrustPath(),
+            aaguid: Uuid::v4(),
             credentialPublicKey: 'cose',
             userHandle: 'handle',
             counter: 0,
@@ -969,9 +980,7 @@ final class WebAuthnServiceTest extends TestCase
         $this->credentialRepositoryMock
             ->expects(self::once())
             ->method('save')
-            ->with(self::callback(function (Credential $cred): bool {
-                return $cred->getTransports() === '[]';
-            }))
+            ->with(self::callback(fn(Credential $cred): bool => $cred->getTransports() === '[]'))
             ->willReturn(1);
 
         $result = $this->subject->storeCredential($source, $beUserUid, $label);
@@ -1003,11 +1012,11 @@ final class WebAuthnServiceTest extends TestCase
         self::assertNotEmpty($result->options->allowCredentials);
         self::assertSame(
             \array_map(
-                static fn(\Webauthn\PublicKeyCredentialDescriptor $d): string => $d->id,
+                static fn(PublicKeyCredentialDescriptor $d): string => $d->id,
                 \array_values($this->subject->createDecoyAssertionOptions('user')->options->allowCredentials),
             ),
             \array_map(
-                static fn(\Webauthn\PublicKeyCredentialDescriptor $d): string => $d->id,
+                static fn(PublicKeyCredentialDescriptor $d): string => $d->id,
                 \array_values($result->options->allowCredentials),
             ),
         );
@@ -1145,12 +1154,12 @@ final class WebAuthnServiceTest extends TestCase
         $y = \str_pad($details['ec']['y'], 32, "\0", STR_PAD_LEFT);
 
         // Create COSE-encoded public key (EC2 / ES256)
-        $coseKey = \CBOR\MapObject::create()
-            ->add(\CBOR\UnsignedIntegerObject::create(1), \CBOR\UnsignedIntegerObject::create(2))
-            ->add(\CBOR\UnsignedIntegerObject::create(3), \CBOR\NegativeIntegerObject::create(-7))
-            ->add(\CBOR\NegativeIntegerObject::create(-1), \CBOR\UnsignedIntegerObject::create(1))
-            ->add(\CBOR\NegativeIntegerObject::create(-2), \CBOR\ByteStringObject::create($x))
-            ->add(\CBOR\NegativeIntegerObject::create(-3), \CBOR\ByteStringObject::create($y));
+        $coseKey = MapObject::create()
+            ->add(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(2))
+            ->add(UnsignedIntegerObject::create(3), NegativeIntegerObject::create(-7))
+            ->add(NegativeIntegerObject::create(-1), UnsignedIntegerObject::create(1))
+            ->add(NegativeIntegerObject::create(-2), ByteStringObject::create($x))
+            ->add(NegativeIntegerObject::create(-3), ByteStringObject::create($y));
         $publicKeyCose = (string) $coseKey;
 
         $credentialId = \random_bytes(32);
@@ -1202,11 +1211,11 @@ final class WebAuthnServiceTest extends TestCase
             beUser: $beUserUid,
             credentialId: $credentialId,
             publicKeyCose: $publicKeyCose,
-            transports: '[]',
-            label: 'Test Key',
             signCount: 0,
             userHandle: $userHandle,
-            aaguid: \Symfony\Component\Uid\Uuid::v4()->toString(),
+            aaguid: Uuid::v4()->toString(),
+            transports: '[]',
+            label: 'Test Key',
         );
 
         $this->credentialRepositoryMock
@@ -1292,12 +1301,12 @@ final class WebAuthnServiceTest extends TestCase
         $x = \str_pad($details['ec']['x'], 32, "\0", STR_PAD_LEFT);
         $y = \str_pad($details['ec']['y'], 32, "\0", STR_PAD_LEFT);
 
-        $coseKey = \CBOR\MapObject::create()
-            ->add(\CBOR\UnsignedIntegerObject::create(1), \CBOR\UnsignedIntegerObject::create(2))
-            ->add(\CBOR\UnsignedIntegerObject::create(3), \CBOR\NegativeIntegerObject::create(-7))
-            ->add(\CBOR\NegativeIntegerObject::create(-1), \CBOR\UnsignedIntegerObject::create(1))
-            ->add(\CBOR\NegativeIntegerObject::create(-2), \CBOR\ByteStringObject::create($x))
-            ->add(\CBOR\NegativeIntegerObject::create(-3), \CBOR\ByteStringObject::create($y));
+        $coseKey = MapObject::create()
+            ->add(UnsignedIntegerObject::create(1), UnsignedIntegerObject::create(2))
+            ->add(UnsignedIntegerObject::create(3), NegativeIntegerObject::create(-7))
+            ->add(NegativeIntegerObject::create(-1), UnsignedIntegerObject::create(1))
+            ->add(NegativeIntegerObject::create(-2), ByteStringObject::create($x))
+            ->add(NegativeIntegerObject::create(-3), ByteStringObject::create($y));
 
         return (string) $coseKey;
     }
@@ -1499,11 +1508,11 @@ final class WebAuthnServiceTest extends TestCase
             beUser: $beUserUid,
             credentialId: $credentialId,
             publicKeyCose: $wrongCoseKey,
-            transports: '[]',
-            label: 'Test Key',
             signCount: 0,
             userHandle: $userHandle,
-            aaguid: \Symfony\Component\Uid\Uuid::v4()->toString(),
+            aaguid: Uuid::v4()->toString(),
+            transports: '[]',
+            label: 'Test Key',
         );
 
         $this->credentialRepositoryMock
@@ -1551,7 +1560,7 @@ final class WebAuthnServiceTest extends TestCase
         // Verify all four algorithms are registered by checking their COSE identifiers
         // ES256 = -7, ES384 = -35, ES512 = -36, RS256 = -257
         $algorithms = \iterator_to_array($manager->all());
-        $identifiers = \array_map(static fn($algo) => $algo->identifier(), $algorithms);
+        $identifiers = \array_map(static fn(Algorithm $algo): int => $algo->identifier(), $algorithms);
         \sort($identifiers);
 
         self::assertContains(-7, $identifiers, 'ES256 (identifier -7) should be registered');
@@ -1569,11 +1578,11 @@ final class WebAuthnServiceTest extends TestCase
             beUser: 42,
             credentialId: 'cred-id-123',
             publicKeyCose: 'cose-public-key',
-            transports: '["usb"]',
-            label: 'Test Key',
             signCount: 5,
             userHandle: 'user-handle',
             aaguid: '',
+            transports: '["usb"]',
+            label: 'Test Key',
         );
 
         $reflection = new ReflectionMethod($this->assertionService, 'credentialToSource');
@@ -1606,11 +1615,11 @@ final class WebAuthnServiceTest extends TestCase
             beUser: 99,
             credentialId: 'cred-id-abc',
             publicKeyCose: 'cose-key',
-            transports: '[]',
-            label: 'Known Authenticator',
             signCount: 3,
             userHandle: 'handle-abc',
             aaguid: $fixedAaguid,
+            transports: '[]',
+            label: 'Known Authenticator',
         );
 
         $reflection = new ReflectionMethod($this->assertionService, 'credentialToSource');

--- a/Tests/Unit/UserSettings/PasskeySettingsPanelElementTest.php
+++ b/Tests/Unit/UserSettings/PasskeySettingsPanelElementTest.php
@@ -27,8 +27,11 @@ use TYPO3\CMS\Core\Page\PageRenderer;
 final class PasskeySettingsPanelElementTest extends TestCase
 {
     private CredentialRepository&MockObject $credentialRepository;
+
     private UriBuilder&MockObject $uriBuilder;
+
     private PageRenderer&MockObject $pageRenderer;
+
     private PasskeySettingsPanel $panel;
 
     protected function setUp(): void
@@ -46,9 +49,7 @@ final class PasskeySettingsPanelElementTest extends TestCase
         $this->uriBuilder = $this->createMock(UriBuilder::class);
         $this->uriBuilder
             ->method('buildUriFromRoute')
-            ->willReturnCallback(static function (string $routeName): Uri {
-                return new Uri('/typo3/ajax/passkeys/' . $routeName . '?token=test');
-            });
+            ->willReturnCallback(static fn(string $routeName): Uri => new Uri('/typo3/ajax/passkeys/' . $routeName . '?token=test'));
 
         $this->panel = new PasskeySettingsPanel();
 

--- a/Tests/Unit/UserSettings/PasskeySettingsPanelTest.php
+++ b/Tests/Unit/UserSettings/PasskeySettingsPanelTest.php
@@ -26,11 +26,11 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 #[CoversClass(PasskeySettingsPanel::class)]
 final class PasskeySettingsPanelTest extends TestCase
 {
-    private MockObject $pageRenderer;
+    private PageRenderer&MockObject $pageRenderer;
 
-    private MockObject $credentialRepository;
+    private CredentialRepository&MockObject $credentialRepository;
 
-    private MockObject $uriBuilder;
+    private UriBuilder&MockObject $uriBuilder;
 
     private PasskeySettingsPanel $subject;
 

--- a/Tests/Unit/UserSettings/PasskeySettingsPanelTest.php
+++ b/Tests/Unit/UserSettings/PasskeySettingsPanelTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrPasskeysBe\Service\CredentialRepository;
 use Netresearch\NrPasskeysBe\UserSettings\PasskeySettingsPanel;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 use TYPO3\CMS\Backend\Routing\UriBuilder;
@@ -25,9 +26,12 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 #[CoversClass(PasskeySettingsPanel::class)]
 final class PasskeySettingsPanelTest extends TestCase
 {
-    private PageRenderer $pageRenderer;
-    private CredentialRepository $credentialRepository;
-    private UriBuilder $uriBuilder;
+    private MockObject $pageRenderer;
+
+    private MockObject $credentialRepository;
+
+    private MockObject $uriBuilder;
+
     private PasskeySettingsPanel $subject;
 
     protected function setUp(): void

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -7,6 +7,10 @@
 
 declare(strict_types=1);
 
+use DG\BypassFinals;
+use TYPO3\CMS\Core\Core\ApplicationContext;
+use TYPO3\CMS\Core\Core\Environment;
+
 /**
  * PHPUnit bootstrap that enables bypass-finals before autoloading.
  *
@@ -24,13 +28,13 @@ if (!\defined('LF')) {
 
 require __DIR__ . '/../.Build/vendor/autoload.php';
 
-DG\BypassFinals::enable();
+BypassFinals::enable();
 
 // NormalizedParams::createFromServerParams() reads Environment::getCurrentScript()
 // and getPublicPath(); initialize Environment so the fallback path works in tests.
 $projectPath = \dirname(__DIR__);
-\TYPO3\CMS\Core\Core\Environment::initialize(
-    new \TYPO3\CMS\Core\Core\ApplicationContext('Testing'),
+Environment::initialize(
+    new ApplicationContext('Testing'),
     true,
     true,
     $projectPath,

--- a/composer.json
+++ b/composer.json
@@ -83,9 +83,11 @@
     "scripts": {
         "ci:cgl": "php-cs-fixer fix --config Build/.php-cs-fixer.php",
         "ci:mutation": "infection --configuration=Build/infection.json5 --threads=max",
+        "ci:rector": "rector process --config Build/rector.php",
         "ci:test:php:all": [
             "@ci:test:php:cgl",
             "@ci:test:php:phpstan",
+            "@ci:test:php:rector",
             "@ci:test:php:unit",
             "@ci:test:php:fuzz",
             "@ci:test:php:functional"
@@ -93,6 +95,7 @@
         "ci:check": [
             "@ci:test:php:cgl",
             "@ci:test:php:phpstan",
+            "@ci:test:php:rector",
             "@ci:test:php:unit",
             "@ci:test:php:fuzz"
         ],
@@ -100,6 +103,7 @@
         "ci:test:php:functional": "phpunit -c Build/phpunit.functional.xml",
         "ci:test:php:fuzz": "phpunit -c Build/phpunit.xml --testsuite fuzz",
         "ci:test:php:phpstan": "phpstan analyse -c Build/phpstan.neon",
+        "ci:test:php:rector": "rector process --config Build/rector.php --dry-run",
         "ci:test:php:unit": "phpunit -c Build/phpunit.xml --testsuite unit"
     }
 }

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -7,10 +7,16 @@
 
 declare(strict_types=1);
 
+use TYPO3\CMS\Core\Log\LogLevel;
+use TYPO3\CMS\Core\Log\Writer\FileWriter;
+use TYPO3\CMS\Core\Core\Environment;
+use Netresearch\NrPasskeysBe\Form\Element\PasskeyInfoElement;
+use Netresearch\NrPasskeysBe\UserSettings\PasskeySettingsPanelElement;
+use TYPO3\CMS\Core\Cache\Backend\FileBackend;
 use Netresearch\NrPasskeysBe\Authentication\PasskeyAuthenticationService;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
-defined('TYPO3') or die();
+defined('TYPO3') || die();
 
 // Register passkey authentication service with priority 80 (higher than SaltedPasswordService at 50)
 ExtensionManagementUtility::addService(
@@ -39,9 +45,9 @@ ExtensionManagementUtility::addService(
 // in containerized setups, the directory is often not writable by the PHP
 // user — an unwritable FileWriter throws and takes down every request that
 // logs a warning.
-$GLOBALS['TYPO3_CONF_VARS']['LOG']['Netresearch']['NrPasskeysBe']['writerConfiguration'][\TYPO3\CMS\Core\Log\LogLevel::WARNING] ??= [
-    \TYPO3\CMS\Core\Log\Writer\FileWriter::class => [
-        'logFile' => \TYPO3\CMS\Core\Core\Environment::getVarPath() . '/log/passkey_auth.log',
+$GLOBALS['TYPO3_CONF_VARS']['LOG']['Netresearch']['NrPasskeysBe']['writerConfiguration'][LogLevel::WARNING] ??= [
+    FileWriter::class => [
+        'logFile' => Environment::getVarPath() . '/log/passkey_auth.log',
     ],
 ];
 
@@ -49,7 +55,7 @@ $GLOBALS['TYPO3_CONF_VARS']['LOG']['Netresearch']['NrPasskeysBe']['writerConfigu
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1739000000] = [
     'nodeName' => 'passkeyInfo',
     'priority' => 40,
-    'class' => \Netresearch\NrPasskeysBe\Form\Element\PasskeyInfoElement::class,
+    'class' => PasskeyInfoElement::class,
 ];
 
 // Register FormEngine render type for the passkey management panel in User Settings (TYPO3 14+).
@@ -57,7 +63,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1739000000] = [
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1748450000] = [
     'nodeName' => 'nrPasskeySettingsPanel',
     'priority' => 40,
-    'class' => \Netresearch\NrPasskeysBe\UserSettings\PasskeySettingsPanelElement::class,
+    'class' => PasskeySettingsPanelElement::class,
 ];
 
 // Register cache for challenge nonces and single-use login tokens.
@@ -68,7 +74,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1748450000] = [
 // so the backend must actually enforce the requested TTL.
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['nr_passkeys_be_nonce'] ??= [];
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['nr_passkeys_be_nonce']['backend'] ??=
-    \TYPO3\CMS\Core\Cache\Backend\FileBackend::class;
+    FileBackend::class;
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['nr_passkeys_be_nonce']['options'] ??= [
     'defaultLifetime' => 300,
 ];
@@ -76,7 +82,7 @@ $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['nr_passkey
 // Register cache for rate limiting (FileBackend required for flushByTag support)
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['nr_passkeys_be_ratelimit'] ??= [];
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['nr_passkeys_be_ratelimit']['backend'] ??=
-    \TYPO3\CMS\Core\Cache\Backend\FileBackend::class;
+    FileBackend::class;
 $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['nr_passkeys_be_ratelimit']['options'] ??= [
     'defaultLifetime' => 600,
 ];

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -11,7 +11,7 @@ use Netresearch\NrPasskeysBe\UserSettings\PasskeySettingsPanel;
 use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
-\defined('TYPO3') or die();
+\defined('TYPO3') || die();
 
 // Register passkey management panel in User Settings (Setup module).
 // Must be in ext_tables.php because cms-setup/ext_tables.php initializes


### PR DESCRIPTION
This extension had no Rector config and its CI job was switched off (`run-rector: false`), so it never took part in the org-wide rule baseline. Rather than grow another local rule set, `Build/rector.php` requires the shared config from [netresearch/typo3-ci-workflows v1.3.4](https://github.com/netresearch/typo3-ci-workflows/releases/tag/v1.3.4) — after the Rector 2.6.0 fleet breakage the org config is the single place where the baseline is defined and fixed. Same conversion as [t3x-nr-image-optimize#150](https://github.com/netresearch/t3x-nr-image-optimize/pull/150), applied to a repo that starts from nothing. The meta-package and the `remove-dev-deps` guard for the `^12.4` cells were already in place and were verified, not assumed; the Rector job is not TYPO3-matrixed, so it keeps the shared config on all legs.

Everything repo-specific lives in one `paths()` override: `paths()` REPLACES the shared list, so the shared entries are repeated and `Tests/` is added. No TYPO3 level set yet — that is [typo3-ci-workflows#155](https://github.com/netresearch/typo3-ci-workflows/issues/155). Composer gains `ci:rector` plus `ci:test:php:rector` following the sibling repos' naming, and both aggregates pick up the dry-run. The Rector check is not required by the branch ruleset, which is untouched.

`RemoveUnusedPublicMethodParameterRector` is skipped, and this is the one finding worth reading in full: its rewrites here are not dead-code removal but contract breaks. Both `#[AsEventListener]` listeners omit the `event:` argument, so TYPO3 v13/v14 resolves the event from the `__invoke()` parameter type — removing the parameter deregisters the listener outright, and neither the test suite nor PHPStan sees it. The AJAX route actions in `Configuration/Backend/AjaxRoutes.php` and the Setup-module `callUserFunction()` panel are likewise invoked with an argument they must keep declaring. As a side effect the reformatting collateral that came with those signature changes disappeared too.

The remaining 53 files are Rector's output, reviewed for value equality one credential and ceremony path at a time rather than waved through. Worth noting: the `PRIVATIZATION` set is inert here because there is not a single protected property anywhere under `Classes/`, so the `PrivatizeFinalClassPropertyRector` hazard from the sibling PRs cannot fire; all four first-class-callable rewrites are free of the leading backslash that produces unparsable output; the named-argument sort moved no trailing comments; and `\defined('TYPO3') or die()` → `|| die()` is equivalent in statement position. The one genuine finding: `array_map(\intval(...), $systemMaintainers)` in `PasskeyInfoElement` now matches `BackendUserAuthentication::isSystemMaintainer()` character for character, which is exactly what this check must do — narrowing it with `is_numeric`/`is_scalar` would make the extension's maintainer list disagree with core's, a security divergence. PHPStan rejects it only because its `intval()` stub narrows a parameter that PHP itself declares as `mixed`, so a path- and identifier-scoped `ignoreErrors` entry records that reasoning instead of deforming the expression.

Verified with a CI-matched toolchain — `platform.php 8.2.33` (the Rector job's PHP version, `php-versions[0]`), cold install after deleting the vendor tree and lock file, resolving `netresearch/typo3-ci-workflows v1.3.4` with no blocked plugins. Rector and CGL are at a mutual fixpoint, proven with `--clear-cache` so the incremental cache cannot fake it; PHPStan at level 10 reports no errors; 665 unit and 131 fuzz tests pass against a pre-change baseline that was captured first and is identical; `php -l` passes over all 53 changed files; and both PHPStan and the unit suite were re-run on the `^12.4` matrix cell with the meta-package removed the way the ci.yml guard does, because that leg is where the newly introduced `instanceof ComponentFactory` and `instanceof Locale` land. The platform pin was removed again before committing. Functional tests need MySQL and are left to CI.

No version bump and no CHANGELOG entry — that belongs to the release flow.
