### PR TITLE
ci: upload coverage to Codecov again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       run-rector: true
       run-functional-tests: true
       functional-test-db: 'mysql'
-      upload-coverage: false
+      upload-coverage: true
       remove-dev-deps: '[{"dep":"netresearch/typo3-ci-workflows","only-for":"^13.4|^14.3"}]'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Why

[7024d4c](https://github.com/netresearch/t3x-nr-passkeys-be/commit/7024d4cfce85ee379d74cb902afb2d2b6a16052d) turned the Codecov upload off on 2026-03-21, stating in its body: *"Set `upload-coverage: false` explicitly since no CODECOV_TOKEN is configured"*. That premise no longer holds. `CODECOV_TOKEN` exists as an organisation secret with visibility `all`, this workflow already forwards it under `secrets:`, and the sibling extension `nr_passkeys_fe` uploads with that same secret and gets real numbers back from Codecov on every pull request.

This repository was always meant to report. `codecov.yml` carries per-flag paths for `unit`, `functional` and `fuzz` plus five components, the README shows a Codecov badge, and the functional suite has been running here all along — only its results never left CI.

## The badge is measuring a fraction of the extension

Codecov still describes a **21-file, 1416-line snapshot at 93.14 %**, while `Classes/` now holds **47 files and 7220 lines**. Even at the moment the upload was disabled there were 32 files. The number in the README has been describing a small slice of the extension for months, which is worse than showing nothing.

## What changes

One line. The shared workflow derives the PHP coverage driver from this very input — `coverage: ${{ inputs.upload-coverage && inputs.coverage-tool || 'none' }}` — so flipping it also switches xdebug on and moves the phpunit invocations to `--coverage-clover`. No other file needs touching, and `codecov.yml` is deliberately left as it is: no target or threshold is being relaxed.

## Verification

Checked with coverage actually enabled rather than by reading the flag, because turning the driver on is the part that can break a suite:

- unit suite with `XDEBUG_MODE=coverage`: **665 tests, 2234 assertions, green**
- functional suite with coverage, against `mysql:9.6` (the `db-image` default) on `typo3/cms-core` v14.3.5: **80 tests green**, 1 skipped
- neither `Build/phpunit.xml` nor `Build/phpunit.functional.xml` sets `requireCoverageMetadata`, so enabling coverage adds no new risky-test failures despite `failOnRisky="true"`
- measured unit coverage over the current tree: **89.94 % of 2643 statements across 46 files**

## The upload actually runs — checked in this PR's CI

The flag is not the proof; the upload is. In [run 30981757468](https://github.com/netresearch/t3x-nr-passkeys-be/actions/runs/30981757468) all **24 test jobs** (12 unit + 12 functional cells) executed `Upload coverage to Codecov` with conclusion `success`. Reading one job's log rather than trusting that conclusion — the action runs with `CC_FAIL_ON_ERROR: false`, so a rejected upload would not have failed the step:

```
CC_TOKEN: ***
-> Token length: 36
./codecov upload-coverage -t <redacted> --git-service github --sha 9719703 --file coverage-functional.xml --flag functional
info -- Your upload is now queued for processing. When finished, results will be available at: …
info -- Upload queued for processing complete
```

The token reached the step and was 36 characters, the clover file was found, and the flag matches the `functional` entry in `codecov.yml`. Codecov then answered with real numbers on the PR: **`codecov/project` 95.87 % (+2.72 %)** against the stale March base, all five components green, and `Middleware` moving from 0 to 97.50 % — which is the clearest single measure of how much was invisible. `codecov/patch` reports "coverage not affected", correct for a workflow-only change. Every check on the PR passes; `mergeStateStatus` is `CLEAN`.

## Expect one baseline move

Codecov re-baselines on the first upload after this lands, replacing the March snapshot. The `project` status may move once while that happens; `codecov.yml` already sets `require_ci_to_pass: false` and a 2 % project threshold.

No version bump, no CHANGELOG entry, no production code touched.
