### PR TITLE
feat(rector): add the TYPO3 v13 level set

### DIFF
--- a/Build/rector.php
+++ b/Build/rector.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector;
+use Ssch\TYPO3Rector\TYPO312\v0\RemoveAddLLrefForTCAdescrMethodCallRector;
+use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 
 $configure = require_once __DIR__ . '/../.Build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
 
@@ -27,6 +29,10 @@ return static function (RectorConfig $rectorConfig) use ($configure): void {
     ]);
 
     $rectorConfig->skip([
+        // ext_tables.php guards addLLrefForTCAdescr() with method_exists so
+        // CSH still registers on TYPO3 v12, which this extension supports.
+        // The v13 level set would empty that guarded call.
+        RemoveAddLLrefForTCAdescrMethodCallRector::class,
         // Every public method here is a framework entry point whose signature IS
         // the contract, so an unused parameter is not dead code. The decisive
         // case: both #[AsEventListener] listeners omit the `event:` argument, so
@@ -36,5 +42,11 @@ return static function (RectorConfig $rectorConfig) use ($configure): void {
         // callUserFunction() panel are invoked with a request/params argument
         // they must keep declaring.
         RemoveUnusedPublicMethodParameterRector::class,
+    ]);
+
+    // TYPO3 migration level: v13, the lowest still-supported major
+    // (typo3-ci-workflows#155); raise when v13 support is dropped.
+    $rectorConfig->sets([
+        Typo3LevelSetList::UP_TO_TYPO3_13,
     ]);
 };


### PR DESCRIPTION
Adds `Typo3LevelSetList::UP_TO_TYPO3_13` per the fleet convention recorded on [typo3-ci-workflows#155](https://github.com/netresearch/typo3-ci-workflows/issues/155) — v13 is the lowest fully-migratable target while the extension also supports v12. `RemoveAddLLrefForTCAdescrMethodCallRector` is skipped with a rationale comment: `ext_tables.php` deliberately guards `addLLrefForTCAdescr()` with `method_exists` so context-sensitive help still registers on TYPO3 v12; the rule would empty that guarded call. With the skip in place rector is at its fixpoint (zero code changes).
