### PR TITLE
ci: sync checks.yml with current organisation template

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -15,6 +15,13 @@ permissions: {}
 # extension-specific test matrix lives in ci.yml (intentional-drift). Every
 # `uses:` job grants exactly the reusable's caller contract; no reliance on
 # default_workflow_permissions.
+#
+# ANY JOB ADDED BELOW MUST ALSO BE ADDED TO `gate.needs`. The gate is the only
+# context a ruleset requires, so a job missing from that list is a job whose
+# failure cannot block a merge — the coverage loss is silent, and nothing in CI
+# catches it. GitHub Actions does not support YAML anchors in workflow files,
+# so the list cannot be shared with the job definitions; it has to be kept in
+# step by hand.
 jobs:
   security:
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
@@ -44,12 +51,20 @@ jobs:
     permissions:
       contents: read
 
+  # `auto` rather than the `actions` default: a TYPO3 extension that ships
+  # JavaScript had none of it analysed, because the default scans workflows
+  # only and GitHub disables code-scanning default setup — which did cover
+  # javascript-typescript — as soon as an advanced configuration uploads its
+  # first SARIF. Merging this file is what triggers that handover, so the
+  # narrow default silently removed a control that had been in place.
   codeql:
     uses: netresearch/.github/.github/workflows/codeql.yml@main
     permissions:
       contents: read
       security-events: write
       actions: read
+    with:
+      languages: auto
 
   scorecard:
     if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)


### PR DESCRIPTION
Syncs `.github/workflows/checks.yml` with the current `netresearch/.github` template revision. The file is copied byte-identically from `templates/typo3-extension/.github/workflows/checks.yml`, so `git hash-object` on the two files returns the same object id.

Two substantive changes over the revision this repository carried:

- **`codeql` is now called with `languages: auto`.** The previous revision passed no `with:` block, so `languages` fell back to its `actions` default and only workflow files were analysed. GitHub disables code-scanning *default* setup the moment an advanced configuration uploads its first SARIF, and merging `checks.yml` is exactly what triggers that handover — so the narrow default silently removed a control that had been in place. `auto` detects `actions` always, `go` on a `go.mod` or any `.go` file, and `javascript-typescript` on a `package.json` or any JS/TS source.
- **A comment records that any job added to this workflow must also be added to `gate.needs`.** The gate is the only context a ruleset requires, so a job missing from that list is a job whose failure cannot block a merge, and nothing in CI catches the omission.

**This extension ships JavaScript, so this PR restores JavaScript analysis that was silently switched off.** `auto` resolves to `actions` plus `javascript-typescript` here. Expect first-time `javascript-typescript` findings on this pull request; they are being triaged on their merits rather than blanket-suppressed.

No version bump or CHANGELOG entry: this is CI configuration only.
