### PR TITLE
Point CODEOWNERS at a team that exists

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,17 +3,17 @@
 # Documentation: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owners for everything in the repo
-* @netresearch/typo3-team
+* @netresearch/typo3
 
 # Core source code requires team review
-/Classes/ @netresearch/typo3-team
+/Classes/ @netresearch/typo3
 
 # CI/CD and security-sensitive files require maintainer approval
-/.github/ @netresearch/typo3-team
-/.github/workflows/ @netresearch/typo3-team
+/.github/ @netresearch/typo3
+/.github/workflows/ @netresearch/typo3
 
 # Security policy
-/SECURITY.md @netresearch/typo3-team
+/SECURITY.md @netresearch/typo3
 
 # Tests
-/Tests/ @netresearch/typo3-team
+/Tests/ @netresearch/typo3


### PR DESCRIPTION
GitHub cannot resolve the code owner in this repository's `CODEOWNERS`. Its own validation endpoint (`GET /repos/{owner}/{repo}/codeowners/errors`) reports:

> Unknown owner on line N: make sure the team @netresearch/… exists, is publicly visible, and has write access to the repository

The organisation has three teams — `typo3`, `sec`, `concourseci`. The team named in this file is not among them.

## Why this matters now

An unresolvable owner means code-owner review can never be satisfied. Today that is invisible, because the branch ruleset does not require code-owner review — the file simply has no effect.

It stops being invisible the moment that changes. Turning on `require_code_owner_review` with this file in place would block every pull request in this repository permanently: the gate demands an approval from an owner who does not exist. The defect is only findable before the switch, not after, because afterwards it looks like a ruleset problem.

This was found while surveying the fleet for exactly that change. 8 of 24 repositories are affected — 6 name a team that does not exist, 2 name a real team that lacks write access here.

## The change

Owner name only. No path, scope or ordering was touched.

`@netresearch/typo3` exists, has 8 members, holds write access, and is already the owner in `t3x-cowriter`, `t3x-nr-image-optimize` and `t3x-rte_ckeditor_image` — so this aligns with what the fleet already uses rather than inventing a new convention.

## Verification

After merge, `GET /repos/netresearch/<repo>/codeowners/errors` must return an empty `errors` array. I will check that rather than infer it from the merge.
