### PR TITLE
fix(login): keep the passkey autofill ceremony usable and stop the false failure

### DIFF
--- a/Classes/EventListener/InjectPasskeyLoginFields.php
+++ b/Classes/EventListener/InjectPasskeyLoginFields.php
@@ -46,6 +46,11 @@ final readonly class InjectPasskeyLoginFields
             'rpId' => $this->configService->getEffectiveRpId(),
             'origin' => $this->configService->getEffectiveOrigin(),
             'discoverableEnabled' => $config->isDiscoverableLoginEnabled(),
+            // The conditional-UI (autofill) ceremony holds its challenge from
+            // page load until the user picks a passkey, which can be far later
+            // than the challenge lives. PasskeyLogin.js re-arms the ceremony
+            // with a fresh challenge before that happens, so it needs the TTL.
+            'challengeTtlSeconds' => $config->getChallengeTtlSeconds(),
             // Server-translated UI labels for PasskeyLogin.js (the login screen is
             // pre-authentication, so labels are injected here rather than via
             // addInlineLanguageLabelFile/TYPO3.lang). JS keeps English fallbacks.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@
 ## Features
 
 - **Primary authentication** -- Passkeys replace passwords, not just augment them
-- **Discoverable login** -- Optional username-less login via resident credentials
+- **Discoverable login** -- Optional username-less login via resident credentials, including
+  WebAuthn Conditional UI: the browser offers the passkey directly in the username
+  field's autofill menu, so returning users never touch the passkey button
 - **Per-group enforcement** -- 4 levels (Off, Encourage, Required, Enforced) with configurable grace periods for gradual rollout
 - **Onboarding banner** -- Dismissible banner with passkey explanation, docs link, and administrator contact for encouraged users
 - **Setup interstitial** -- PSR-15 middleware prompts users to register passkeys after login (skippable during grace period)
@@ -118,7 +120,7 @@ Extension settings are available in **Admin Tools > Settings > Extension Configu
 | `rpName` | `TYPO3 Backend` | Display name shown during passkey registration |
 | `origin` | *(auto-detect)* | Full origin URL (e.g., `https://example.com`) |
 | `challengeTtlSeconds` | `120` | Challenge token lifetime in seconds |
-| `discoverableLoginEnabled` | `true` | Allow username-less login via resident credentials |
+| `discoverableLoginEnabled` | `true` | Allow username-less login via resident credentials. Also switches WebAuthn Conditional UI, the passkey entry in the username field's autofill menu |
 | `disablePasswordLogin` | `false` | Block password login for users with registered passkeys |
 | `rateLimitMaxAttempts` | `10` | Requests per IP per endpoint before rate limiting |
 | `rateLimitWindowSeconds` | `300` | Rate limit window duration in seconds |

--- a/Resources/Public/JavaScript/PasskeyLogin.js
+++ b/Resources/Public/JavaScript/PasskeyLogin.js
@@ -26,6 +26,12 @@ const PASSKEY_ICON = '<svg xmlns="http://www.w3.org/2000/svg" height="20" ' +
   '28.5-11.5T780-440q0-17-11.5-28.5T740-480q-17 0-28.5 11.5T700-440q0 ' +
   '17 11.5 28.5T740-400Z"/></svg>';
 
+// How long after submitting an assertion a fresh load of the login page still
+// counts as "that assertion was rejected". A rejected login redirects back
+// within seconds; anything later is a new visit — typically after logging out
+// of a session that the passkey opened successfully.
+const FAILED_ATTEMPT_WINDOW_MS = 60000;
+
 function init() {
   const config = window.NrPasskeysBeConfig;
   if (!config || !config.loginOptionsUrl) return;
@@ -75,6 +81,20 @@ function init() {
   // explicit button click can cancel it first (only one credentials.get() may
   // be in flight at a time).
   let conditionalAbort = null;
+  // Guards against two ceremonies being armed at once (a re-arm racing the
+  // refresh timer), and lets a late-settling ceremony recognise that it has
+  // been superseded.
+  let conditionalGeneration = 0;
+  let conditionalRefreshTimer = null;
+  // Set once the login form is submitted: the page is leaving, so no further
+  // ceremony may be armed.
+  let navigatingAway = false;
+  // A conditional ceremony is armed with a challenge and only consumed when the
+  // user picks a passkey from the autofill menu — arbitrarily later. The server
+  // rejects the assertion once the challenge has expired, so the ceremony is
+  // re-armed with a fresh one at half the TTL, well before that happens.
+  const challengeTtlMs = Math.max(30, Number(config.challengeTtlSeconds) || 120) * 1000;
+  const conditionalRefreshMs = Math.floor(challengeTtlMs / 2);
 
   if (loginBtn) {
     loginBtn.addEventListener('click', handlePasskeyLogin);
@@ -90,6 +110,46 @@ function init() {
     startConditionalLogin();
   }
 
+  /**
+   * Cancel the armed conditional ceremony, if any, and stop its refresh timer.
+   * Safe to call when nothing is armed.
+   */
+  function stopConditionalLogin() {
+    conditionalGeneration++;
+    if (conditionalRefreshTimer !== null) {
+      clearTimeout(conditionalRefreshTimer);
+      conditionalRefreshTimer = null;
+    }
+    if (conditionalAbort) {
+      conditionalAbort.abort();
+      conditionalAbort = null;
+    }
+  }
+
+  /**
+   * Re-arm the conditional ceremony with a fresh challenge.
+   *
+   * Aborting an armed ceremony closes an open autofill menu, so a refresh is
+   * deferred while the username field has focus: the user may be looking at the
+   * menu right now. The ceremony is instead re-armed when the field loses focus.
+   */
+  function scheduleConditionalRefresh() {
+    if (conditionalRefreshTimer !== null) {
+      clearTimeout(conditionalRefreshTimer);
+    }
+    conditionalRefreshTimer = setTimeout(function () {
+      conditionalRefreshTimer = null;
+      if (document.activeElement === usernameInput) {
+        usernameInput.addEventListener('blur', function onBlur() {
+          usernameInput.removeEventListener('blur', onBlur);
+          startConditionalLogin();
+        });
+        return;
+      }
+      startConditionalLogin();
+    }, conditionalRefreshMs);
+  }
+
   async function startConditionalLogin() {
     let available = false;
     try {
@@ -98,6 +158,11 @@ function init() {
       return;
     }
     if (!available) return;
+
+    // Supersede whatever is armed: only one credentials.get() may be in flight,
+    // and a stale ceremony would keep offering an expired challenge.
+    stopConditionalLogin();
+    const generation = conditionalGeneration;
 
     // Advertise WebAuthn autofill on the standard username field without
     // clobbering an existing autocomplete token.
@@ -109,43 +174,87 @@ function init() {
     // Prefetch discoverable assertion options quietly: a 429/rate-limit or any
     // error here must NOT surface on page load — the explicit button remains.
     const optionsData = await fetchAssertionOptions('', true);
-    if (!optionsData) return;
+    if (!optionsData || generation !== conditionalGeneration) return;
 
     const publicKeyOptions = buildPublicKeyOptions(optionsData.options);
-    conditionalAbort = new AbortController();
+    const abort = new AbortController();
+    conditionalAbort = abort;
+    scheduleConditionalRefresh();
     try {
       const assertion = await navigator.credentials.get({
         publicKey: publicKeyOptions,
         mediation: 'conditional',
-        signal: conditionalAbort.signal,
+        signal: abort.signal,
       });
+      if (generation !== conditionalGeneration) return;
       conditionalAbort = null;
       // Discoverable login: username stays empty; the server resolves the user
       // from the credential ID.
       await verifyAndSubmit(encodeAssertion(assertion), optionsData.options, optionsData.challengeToken, '');
+      // verifyAndSubmit navigates away on success. Reaching this line means the
+      // assertion was rejected, and the ceremony this passkey came from is spent
+      // — without re-arming, the autofill menu would offer no passkeys at all
+      // for the rest of the page's life.
+      if (generation === conditionalGeneration) rearmConditionalLogin();
     } catch (err) {
+      if (generation !== conditionalGeneration) return;
       conditionalAbort = null;
       // Abort (explicit button took over) and NotAllowedError (user dismissed
       // the autofill) are normal for conditional UI — stay silent.
       if (err.name !== 'AbortError' && err.name !== 'NotAllowedError') {
         console.error('Passkey conditional login error:', err);
       }
+      // An abort means something else deliberately took over and will decide
+      // what happens next; every other outcome leaves the autofill unarmed.
+      if (err.name !== 'AbortError') rearmConditionalLogin();
     }
   }
 
+  /**
+   * Record that a passkey assertion is being submitted, so the next load of the
+   * login page can tell a rejected assertion from an ordinary visit. The value
+   * is the submission time — see checkForFailedPasskeyLogin().
+   */
+  function markPasskeyAttempt() {
+    try {
+      sessionStorage.setItem('nr_passkey_attempt', String(Date.now()));
+    } catch (e) {
+      // sessionStorage may be unavailable
+    }
+  }
+
+  /**
+   * Show the passkey-specific error when the login page loads again right after
+   * an assertion was submitted.
+   *
+   * The marker cannot say on its own whether the login failed: it is written
+   * before the form is submitted, and a SUCCESSFUL login navigates into the
+   * backend and leaves it behind. Logging out then loads the login page with the
+   * marker still set, which used to report a failure for a login that had
+   * worked. The submission time settles it — a rejected assertion comes back
+   * within seconds, whereas a session that reaches logout has lasted longer.
+   */
   function checkForFailedPasskeyLogin() {
     try {
-      if (sessionStorage.getItem('nr_passkey_attempt')) {
-        sessionStorage.removeItem('nr_passkey_attempt');
-        // Still on the login page after a passkey submission = auth failed.
-        // TYPO3 does a POST-Redirect-GET after failed login, so the generic
-        // error div (#t3-login-error) may not be present on the redirected page.
-        showError(L.errorVerifyFailed || 'Passkey authentication failed. Your passkey was not accepted. Please try again or sign in with your password.');
-        // Hide generic TYPO3 error if it exists
-        const typo3Error = document.getElementById('t3-login-error');
-        if (typo3Error) {
-          typo3Error.style.display = 'none';
-        }
+      const marker = sessionStorage.getItem('nr_passkey_attempt');
+      if (marker === null) return;
+      sessionStorage.removeItem('nr_passkey_attempt');
+
+      const submittedAt = Number(marker);
+      if (!Number.isFinite(submittedAt) || Date.now() - submittedAt > FAILED_ATTEMPT_WINDOW_MS) {
+        // Stale marker from a session that succeeded (or from before this
+        // extension wrote timestamps) — the visit is ordinary, say nothing.
+        return;
+      }
+
+      // Still on the login page seconds after a passkey submission = auth failed.
+      // TYPO3 does a POST-Redirect-GET after failed login, so the generic
+      // error div (#t3-login-error) may not be present on the redirected page.
+      showError(L.errorVerifyFailed || 'Passkey authentication failed. Your passkey was not accepted. Please try again or sign in with your password.');
+      // Hide generic TYPO3 error if it exists
+      const typo3Error = document.getElementById('t3-login-error');
+      if (typo3Error) {
+        typo3Error.style.display = 'none';
       }
     } catch (e) {
       // sessionStorage may be unavailable
@@ -156,15 +265,13 @@ function init() {
     hideError();
     // Cancel a pending conditional get() first — only one credentials.get()
     // ceremony may run at a time.
-    if (conditionalAbort) {
-      conditionalAbort.abort();
-      conditionalAbort = null;
-    }
+    stopConditionalLogin();
     const username = usernameInput ? usernameInput.value.trim() : '';
 
     if (!username && !config.discoverableEnabled) {
       showError(L.errorUsernameRequired || 'Please enter your username.');
       if (usernameInput) usernameInput.focus();
+      rearmConditionalLogin();
       return;
     }
 
@@ -176,6 +283,7 @@ function init() {
       if (!optionsData) {
         // fetchAssertionOptions already surfaced the error to the user
         setLoading(false);
+        rearmConditionalLogin();
         return;
       }
 
@@ -186,10 +294,28 @@ function init() {
       // Step 3: Verify server-side, then submit the resulting login token.
       const credentialResponse = encodeAssertion(assertion);
       await verifyAndSubmit(credentialResponse, optionsData.options, optionsData.challengeToken, username);
+      // Success navigates away; returning here means the assertion was rejected
+      // and the autofill needs a working ceremony again.
+      rearmConditionalLogin();
     } catch (err) {
       setLoading(false);
       handleAuthError(err);
+      rearmConditionalLogin();
     }
+  }
+
+  /**
+   * Put the autofill ceremony back in place after the explicit button flow
+   * cancelled it and then failed. Skipped once the form is on its way out, so
+   * a ceremony is never started into an unloading page.
+   */
+  function rearmConditionalLogin() {
+    if (navigatingAway) return;
+    if (!config.discoverableEnabled || !usernameInput
+        || typeof PublicKeyCredential.isConditionalMediationAvailable !== 'function') {
+      return;
+    }
+    startConditionalLogin();
   }
 
   /**
@@ -263,7 +389,9 @@ function init() {
     if (usernameInput) {
       usernameInput.value = username;
     }
-    try { sessionStorage.setItem('nr_passkey_attempt', '1'); } catch (e) { /* ignore */ }
+    markPasskeyAttempt();
+    navigatingAway = true;
+    stopConditionalLogin();
     loginForm.submit();
   }
 
@@ -412,7 +540,9 @@ function init() {
 
     // Flag this as a passkey attempt so we can show a specific error
     // if the server-side verification fails and the page reloads
-    try { sessionStorage.setItem('nr_passkey_attempt', '1'); } catch (e) { /* ignore */ }
+    markPasskeyAttempt();
+    navigatingAway = true;
+    stopConditionalLogin();
 
     loginForm.submit();
   }

--- a/Tests/JavaScript/PasskeyLoginConditional.test.js
+++ b/Tests/JavaScript/PasskeyLoginConditional.test.js
@@ -1,0 +1,220 @@
+/**
+ * Tests for the conditional-UI (autofill) ceremony and the failed-attempt
+ * marker in the SHIPPED login module.
+ *
+ * These import Resources/Public/JavaScript/PasskeyLogin.js itself and drive it
+ * through a jsdom login form with a stubbed WebAuthn API, so the assertions
+ * cover the real control flow. The module runs init() on import, which is why
+ * each test resets the module registry and rebuilds the DOM first.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const OPTIONS_URL = 'https://example.test/typo3/passkeys/login/options';
+const VERIFY_URL = 'https://example.test/typo3/passkeys/login/verify';
+
+/** Minimal login form matching the ids PasskeyLogin.js looks for. */
+function buildLoginDom() {
+    document.body.innerHTML = `
+        <form id="typo3-login-form">
+            <input id="t3-username" name="username" />
+            <input class="t3js-login-userident-field" name="userident" />
+            <div id="t3-login-submit-section"></div>
+        </form>
+    `;
+    // jsdom has no form submission; record the call instead.
+    const form = document.getElementById('typo3-login-form');
+    form.submit = vi.fn();
+    return form;
+}
+
+/** base64url payload the module can decode without caring about the content. */
+const CHALLENGE_B64 = 'YWJjZGVmZ2hpamtsbW5vcA';
+
+function assertionOptionsResponse() {
+    return {
+        options: {
+            challenge: CHALLENGE_B64,
+            rpId: 'example.test',
+            userVerification: 'required',
+        },
+        challengeToken: 'challenge-token-1',
+    };
+}
+
+/** A credential shaped like the one navigator.credentials.get() resolves with. */
+function fakeAssertion() {
+    const buf = new Uint8Array([1, 2, 3, 4]).buffer;
+    return {
+        rawId: buf,
+        type: 'public-key',
+        response: {
+            clientDataJSON: buf,
+            authenticatorData: buf,
+            signature: buf,
+            userHandle: null,
+        },
+    };
+}
+
+function installWebAuthnStub(getImpl) {
+    window.PublicKeyCredential = function () {};
+    window.PublicKeyCredential.isConditionalMediationAvailable = vi.fn(async () => true);
+    const get = vi.fn(getImpl);
+    Object.defineProperty(navigator, 'credentials', {
+        value: { get },
+        configurable: true,
+        writable: true,
+    });
+    return get;
+}
+
+/** Let queued promise callbacks run; the module chains several awaits. */
+async function settle(rounds = 12) {
+    for (let i = 0; i < rounds; i++) {
+        await Promise.resolve();
+    }
+}
+
+beforeEach(() => {
+    vi.resetModules();
+    vi.useRealTimers();
+    sessionStorage.clear();
+    buildLoginDom();
+    Object.defineProperty(window, 'isSecureContext', { value: true, configurable: true });
+    window.NrPasskeysBeConfig = {
+        loginOptionsUrl: OPTIONS_URL,
+        loginVerifyUrl: VERIFY_URL,
+        rpId: 'example.test',
+        origin: 'https://example.test',
+        discoverableEnabled: true,
+        challengeTtlSeconds: 120,
+        labels: {},
+    };
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+    delete window.NrPasskeysBeConfig;
+});
+
+describe('failed-attempt marker', () => {
+    // The marker is written before the form is submitted, so a SUCCESSFUL login
+    // leaves it behind: the user lands in the backend, works, and logs out. The
+    // login page then loads with the marker still set. Reporting a failure there
+    // is wrong — the login it refers to had worked.
+    it('stays silent when the marker is older than the failure window', async () => {
+        installWebAuthnStub(async () => fakeAssertion());
+        vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) })));
+        sessionStorage.setItem('nr_passkey_attempt', String(Date.now() - 10 * 60 * 1000));
+
+        await import('../../Resources/Public/JavaScript/PasskeyLogin.js');
+        await settle();
+
+        const error = document.getElementById('passkey-error');
+        expect(error.textContent.trim()).toBe('');
+        expect(sessionStorage.getItem('nr_passkey_attempt')).toBeNull();
+    });
+
+    it('reports the failure when the marker is seconds old', async () => {
+        installWebAuthnStub(async () => fakeAssertion());
+        vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) })));
+        sessionStorage.setItem('nr_passkey_attempt', String(Date.now() - 2000));
+
+        await import('../../Resources/Public/JavaScript/PasskeyLogin.js');
+        await settle();
+
+        const error = document.getElementById('passkey-error');
+        expect(error.textContent).toContain('not accepted');
+        expect(sessionStorage.getItem('nr_passkey_attempt')).toBeNull();
+    });
+
+    it('ignores a legacy marker that carries no timestamp', async () => {
+        installWebAuthnStub(async () => fakeAssertion());
+        vi.stubGlobal('fetch', vi.fn(async () => ({ ok: false, status: 500, json: async () => ({}) })));
+        sessionStorage.setItem('nr_passkey_attempt', '1');
+
+        await import('../../Resources/Public/JavaScript/PasskeyLogin.js');
+        await settle();
+
+        expect(document.getElementById('passkey-error').textContent.trim()).toBe('');
+    });
+});
+
+describe('conditional UI ceremony', () => {
+    it('re-arms after the server rejects the picked passkey', async () => {
+        // Without a re-arm the ceremony is spent: the autofill menu then offers
+        // password-manager entries only, and no passkey can be picked again
+        // until the page is reloaded.
+        const get = installWebAuthnStub(async () => fakeAssertion());
+        const fetchMock = vi.fn(async (url) => {
+            if (String(url) === OPTIONS_URL) {
+                return { ok: true, status: 200, json: async () => assertionOptionsResponse() };
+            }
+            return { ok: false, status: 401, json: async () => ({ error: 'Verification failed' }) };
+        });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await import('../../Resources/Public/JavaScript/PasskeyLogin.js');
+        await settle(40);
+
+        expect(get.mock.calls.length).toBeGreaterThanOrEqual(2);
+        expect(get.mock.calls[0][0].mediation).toBe('conditional');
+        expect(get.mock.calls[1][0].mediation).toBe('conditional');
+        // The second ceremony must not reuse the spent challenge.
+        const optionsCalls = fetchMock.mock.calls.filter((c) => String(c[0]) === OPTIONS_URL);
+        expect(optionsCalls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('refreshes the challenge before it expires while the field is unfocused', async () => {
+        vi.useFakeTimers();
+        // Never settles: models the ceremony waiting for the user to pick.
+        const get = installWebAuthnStub(() => new Promise(() => {}));
+        const fetchMock = vi.fn(async () => ({
+            ok: true,
+            status: 200,
+            json: async () => assertionOptionsResponse(),
+        }));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await import('../../Resources/Public/JavaScript/PasskeyLogin.js');
+        await vi.advanceTimersByTimeAsync(0);
+        expect(get).toHaveBeenCalledTimes(1);
+
+        // Half of the 120 s TTL: the armed challenge is swapped for a fresh one
+        // well before the server would reject it as expired.
+        await vi.advanceTimersByTimeAsync(60000);
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(get.mock.calls.length).toBeGreaterThanOrEqual(2);
+        expect(get.mock.calls[0][0].signal.aborted).toBe(true);
+        vi.useRealTimers();
+    });
+
+    it('does not close the autofill menu while the username field has focus', async () => {
+        vi.useFakeTimers();
+        const get = installWebAuthnStub(() => new Promise(() => {}));
+        vi.stubGlobal('fetch', vi.fn(async () => ({
+            ok: true,
+            status: 200,
+            json: async () => assertionOptionsResponse(),
+        })));
+
+        await import('../../Resources/Public/JavaScript/PasskeyLogin.js');
+        await vi.advanceTimersByTimeAsync(0);
+
+        const username = document.getElementById('t3-username');
+        username.focus();
+        await vi.advanceTimersByTimeAsync(60000);
+        await vi.advanceTimersByTimeAsync(0);
+
+        // Aborting here would tear down the menu the user is looking at.
+        expect(get).toHaveBeenCalledTimes(1);
+        expect(get.mock.calls[0][0].signal.aborted).toBe(false);
+
+        // Once focus leaves, the stale challenge is replaced.
+        username.blur();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(get.mock.calls.length).toBeGreaterThanOrEqual(2);
+        vi.useRealTimers();
+    });
+});

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -13,7 +13,7 @@ challengeTtlSeconds = 120
 # cat=security/200/110; type=options[required,preferred,discouraged]; label=User Verification:WebAuthn user verification requirement.
 userVerification = required
 
-# cat=security/200/120; type=boolean; label=Enable Discoverable Login:Allow login without entering a username (passkey identifies the user).
+# cat=security/200/120; type=boolean; label=Enable Discoverable Login:Allow login without entering a username (passkey identifies the user). Also enables WebAuthn Conditional UI, which offers the passkey in the username field's autofill menu.
 discoverableLoginEnabled = 1
 
 # cat=security/200/130; type=boolean; label=Disable Password Login:When enabled, password login is blocked for users who have registered passkeys. Users without passkeys can still log in with a password.

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,6 +1,17 @@
 import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
 
 export default defineConfig({
+    resolve: {
+        alias: {
+            // TYPO3 resolves this import map entry at runtime; vitest needs it
+            // spelled out so a test can import the shipped login module itself
+            // rather than a copy of its logic.
+            '@netresearch/nr-passkeys-be': fileURLToPath(
+                new URL('./Resources/Public/JavaScript', import.meta.url),
+            ),
+        },
+    },
     test: {
         include: ['Tests/JavaScript/**/*.test.{js,ts}'],
         environment: 'jsdom',


### PR DESCRIPTION
Three defects in the conditional-UI (autofill) passkey login, all reproduced from the reported Windows/Chrome + Bitwarden session on the demo instance and all traced to the same area of `PasskeyLogin.js`.

**Picking a passkey from the username field always failed, the button always worked.** The conditional ceremony was armed once on page load and then held its challenge until the user picked a credential — arbitrarily later. `ChallengeService` rejects a challenge older than `challengeTtlSeconds` (120 s by default), so any pick made more than two minutes after page load could not verify, while the button flow fetched fresh options at click time and therefore worked. This also explains why the pick worked right after a logout: that click fell inside the fresh window. The ceremony is now re-armed with a fresh challenge at half the TTL (the TTL is passed to the client for that). A refresh is deferred while the username field has focus — aborting an armed ceremony closes the autofill menu the user may be looking at — and happens on blur instead.

**After a failed pick the autofill offered no passkeys at all.** A conditional ceremony is spent once it settles, and nothing re-armed it: not after a rejected assertion, not after the explicit button aborted it. That left the username field with password-manager entries only for the rest of the page's life. Every non-abort outcome now re-arms; an abort is left alone because whatever aborted it deliberately took over.

**Logging out after a successful passkey login reported a failure.** The `nr_passkey_attempt` marker is written immediately before the form is submitted, so it cannot know the outcome — and a successful login navigates into the backend and leaves it behind. The next load of the login page is the logout landing, where the marker was read as proof of failure and produced "Passkey authentication failed. Your passkey was not accepted." The marker now carries its submission time and only counts inside a 60 s window: a rejected assertion redirects back within seconds, a session that reaches logout never does.

**On the tests.** `Tests/JavaScript/PasskeyLogin.test.js` only imported the base64 helpers and re-implemented the marker logic inline, so none of this behaviour was guarded. The new `PasskeyLoginConditional.test.js` imports the shipped module and drives it through a jsdom login form with a stubbed WebAuthn API. Each fix was verified by re-injecting its defect and confirming the matching tests fail in that position: marker → 2 failed, re-arm → 1 failed, refresh timer → 2 failed. Full suite 77 passed; PHP side unchanged apart from the config value (CGL, Rector, PHPStan, 665 unit tests all green).

Not covered here: the E2E suite cannot drive conditional mediation (no browser automation offers a virtual authenticator through the autofill menu), so the ceremony lifecycle is guarded at unit level and the real-device behaviour still needs the manual check that found it.
