### PR TITLE
Adopt the shared Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>netresearch/renovate-config"
+  ]
+}


### PR DESCRIPTION
Gives this repository the same Renovate defaults the rest of the fleet uses.

## Why

Dependency PRs here are opened by Dependabot and merged by the `auto-merge-deps` workflow, which runs as `github-actions`. Since the branch rulesets started requiring a code-owner review, that path no longer completes: `github-actions` is built into GitHub rather than installed into the organisation, so it cannot be granted a ruleset bypass — GitHub rejects it with `422 must be part of the ruleset source or owner organization`.

Renovate can. It holds `contents:write` and `pull_requests:write`, is accepted as a bypass actor, and — measured across the fleet — merges its own PRs directly rather than delegating to a workflow.

## Why adding rather than switching

`.github/dependabot.yml` stays. It is managed by the org template, and removing it would mean an `intentional-drift:` entry in `.github/template.yaml` to stop the sync restoring it.

That is unnecessary, because the two do not actually compete. Measured over the last 60 PRs per repository:

| repositories | Dependabot PRs | Renovate PRs |
|---|---|---|
| with a `renovate.json` | 0–2 | 16–26 |
| without one | 7–11 | 1–7 |

Renovate runs continuously and Dependabot weekly, so whatever Renovate has already bumped, Dependabot no longer proposes. Adding the config here makes Renovate primary; Dependabot goes quiet on its own.

## The change

Renovate already runs against this repository through the org-wide installation, but with no config file it uses stock defaults. Extending `github>netresearch/renovate-config` adds `stabilityDays: 3`, `internalChecksFilter: strict`, the axios deny-list from the 2026-03-31 incident, and automerge for patch/minor/pin/digest (pending netresearch/renovate-config#5).

Automerge is not a loosening: the stability delay and the internal-checks filter both gate it, and the ruleset's status checks are deliberately not bypassable by any bot, so a red PR still cannot merge.

## Verification

`jq empty renovate.json` passes. One new file, four lines, nothing else touched.
