### PR TITLE
feat(registration): record whether a passkey is discoverable

### DIFF
--- a/Classes/Controller/ManagementController.php
+++ b/Classes/Controller/ManagementController.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrPasskeysBe\Controller;
 
 use Netresearch\NrPasskeysBe\Domain\Dto\AuthenticatedUser;
 use Netresearch\NrPasskeysBe\Domain\Dto\CredentialInfo;
+use Netresearch\NrPasskeysBe\Domain\Enum\CredentialDiscoverability;
 use Netresearch\NrPasskeysBe\Domain\Model\Credential;
 use Netresearch\NrPasskeysBe\Service\CredentialRepository;
 use Netresearch\NrPasskeysBe\Service\EnforcementService;
@@ -115,6 +116,12 @@ final readonly class ManagementController
         $rawLabel = $body['label'] ?? 'Passkey';
         $label = \is_string($rawLabel) ? $rawLabel : 'Passkey';
 
+        // credProps.rk, forwarded by the browser from getClientExtensionResults().
+        // Absent whenever the authenticator stayed silent, which stays null rather
+        // than being guessed — "not reported" and "not discoverable" are different
+        // answers, and only the second one is worth warning about.
+        $discoverable = CredentialDiscoverability::fromClientExtensionResult($body['discoverable'] ?? null);
+
         if ($credentialJson === '' || $challengeToken === '') {
             return new JsonResponse(['error' => 'Missing required fields'], 400);
         }
@@ -138,6 +145,7 @@ final readonly class ManagementController
                 source: $source,
                 beUserUid: $user->uid,
                 label: $label,
+                discoverable: $discoverable,
             );
 
             $this->logger->info('Passkey registered', [

--- a/Classes/Domain/Dto/CredentialInfo.php
+++ b/Classes/Domain/Dto/CredentialInfo.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrPasskeysBe\Domain\Dto;
 
 use JsonSerializable;
+use Netresearch\NrPasskeysBe\Domain\Enum\CredentialDiscoverability;
 
 /**
  * Read-only projection of a credential for user-facing API responses.
@@ -22,10 +23,11 @@ final readonly class CredentialInfo implements JsonSerializable
         public int $createdAt,
         public int $lastUsedAt,
         public bool $isRevoked,
+        public CredentialDiscoverability $discoverability = CredentialDiscoverability::Unknown,
     ) {}
 
     /**
-     * @return array{uid: int, label: string, createdAt: int, lastUsedAt: int, isRevoked: bool}
+     * @return array{uid: int, label: string, createdAt: int, lastUsedAt: int, isRevoked: bool, discoverable: bool|null}
      */
     public function jsonSerialize(): array
     {
@@ -35,6 +37,9 @@ final readonly class CredentialInfo implements JsonSerializable
             'createdAt' => $this->createdAt,
             'lastUsedAt' => $this->lastUsedAt,
             'isRevoked' => $this->isRevoked,
+            'discoverable' => $this->discoverability->toDatabaseValue() === null
+                ? null
+                : $this->discoverability === CredentialDiscoverability::Discoverable,
         ];
     }
 }

--- a/Classes/Domain/Dto/CredentialInfo.php
+++ b/Classes/Domain/Dto/CredentialInfo.php
@@ -37,9 +37,7 @@ final readonly class CredentialInfo implements JsonSerializable
             'createdAt' => $this->createdAt,
             'lastUsedAt' => $this->lastUsedAt,
             'isRevoked' => $this->isRevoked,
-            'discoverable' => $this->discoverability->toDatabaseValue() === null
-                ? null
-                : $this->discoverability === CredentialDiscoverability::Discoverable,
+            'discoverable' => $this->discoverability->toJsonValue(),
         ];
     }
 }

--- a/Classes/Domain/Enum/CredentialDiscoverability.php
+++ b/Classes/Domain/Enum/CredentialDiscoverability.php
@@ -62,11 +62,18 @@ enum CredentialDiscoverability: string
     }
 
     /**
-     * True only when the authenticator positively reported a non-discoverable
-     * credential — the one case worth telling the user about.
+     * Tri-state for API responses: true discoverable, false not, null unknown.
+     *
+     * The client warns only on false. Collapsing "unknown" into false there
+     * would tell users their passkey cannot do autofill when nobody ever
+     * established that.
      */
-    public function isKnownUnusableForAutofill(): bool
+    public function toJsonValue(): ?bool
     {
-        return $this === self::NotDiscoverable;
+        return match ($this) {
+            self::Discoverable => true,
+            self::NotDiscoverable => false,
+            self::Unknown => null,
+        };
     }
 }

--- a/Classes/Domain/Enum/CredentialDiscoverability.php
+++ b/Classes/Domain/Enum/CredentialDiscoverability.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Domain\Enum;
+
+/**
+ * Whether a credential is stored discoverably (a "resident key") on the
+ * authenticator.
+ *
+ * Only a discoverable credential can be offered in the browser's autofill menu,
+ * so this decides whether a passkey participates in conditional UI at all. The
+ * answer comes from the credProps extension at registration; authenticators may
+ * stay silent, which is why "unknown" is a state of its own — it is not the same
+ * as "not discoverable" and must not be reported to the user as a limitation.
+ */
+enum CredentialDiscoverability: string
+{
+    case Discoverable = 'discoverable';
+    case NotDiscoverable = 'not_discoverable';
+    case Unknown = 'unknown';
+
+    /**
+     * Map the persisted tinyint column: 1 discoverable, 0 not, NULL unknown.
+     */
+    public static function fromDatabaseValue(mixed $value): self
+    {
+        if ($value === null || $value === '') {
+            return self::Unknown;
+        }
+
+        return (bool) $value ? self::Discoverable : self::NotDiscoverable;
+    }
+
+    /**
+     * Map the credProps.rk answer the browser forwards, if it sent one.
+     */
+    public static function fromClientExtensionResult(mixed $rk): self
+    {
+        if (!\is_bool($rk)) {
+            return self::Unknown;
+        }
+
+        return $rk ? self::Discoverable : self::NotDiscoverable;
+    }
+
+    /**
+     * Column value: null keeps "unknown" distinguishable from "not discoverable".
+     */
+    public function toDatabaseValue(): ?int
+    {
+        return match ($this) {
+            self::Discoverable => 1,
+            self::NotDiscoverable => 0,
+            self::Unknown => null,
+        };
+    }
+
+    /**
+     * True only when the authenticator positively reported a non-discoverable
+     * credential — the one case worth telling the user about.
+     */
+    public function isKnownUnusableForAutofill(): bool
+    {
+        return $this === self::NotDiscoverable;
+    }
+}

--- a/Classes/Domain/Model/Credential.php
+++ b/Classes/Domain/Model/Credential.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrPasskeysBe\Domain\Model;
 
 use Netresearch\NrPasskeysBe\Domain\Dto\AdminCredentialInfo;
 use Netresearch\NrPasskeysBe\Domain\Dto\CredentialInfo;
+use Netresearch\NrPasskeysBe\Domain\Enum\CredentialDiscoverability;
 use Netresearch\NrPasskeysBe\Utility\TypeCastTrait;
 
 /**
@@ -30,6 +31,7 @@ final class Credential
         private string $userHandle = '',
         private string $aaguid = '',
         private string $transports = '[]',
+        private CredentialDiscoverability $discoverable = CredentialDiscoverability::Unknown,
         private string $label = '',
         private int $createdAt = 0,
         private int $lastUsedAt = 0,
@@ -120,6 +122,17 @@ final class Credential
     public function getTransports(): string
     {
         return $this->transports;
+    }
+
+    /**
+     * Whether the authenticator reported a discoverable (resident) credential.
+     * Unknown covers credentials registered before this was recorded and
+     * authenticators that stayed silent. Only a discoverable credential can be
+     * offered in the browser's autofill menu (conditional UI).
+     */
+    public function getDiscoverability(): CredentialDiscoverability
+    {
+        return $this->discoverable;
     }
 
     public function setTransports(string $transports): void
@@ -218,6 +231,7 @@ final class Credential
             'user_handle' => $this->userHandle,
             'aaguid' => $this->aaguid,
             'transports' => $this->transports,
+            'discoverable' => $this->discoverable->toDatabaseValue(),
             'label' => $this->label,
             'created_at' => $this->createdAt,
             'last_used_at' => $this->lastUsedAt,
@@ -241,6 +255,7 @@ final class Credential
             userHandle: self::stringVal($data['user_handle'] ?? null),
             aaguid: self::stringVal($data['aaguid'] ?? null),
             transports: self::stringVal($data['transports'] ?? null, '[]'),
+            discoverable: CredentialDiscoverability::fromDatabaseValue($data['discoverable'] ?? null),
             label: self::stringVal($data['label'] ?? null),
             createdAt: self::intVal($data['created_at'] ?? null),
             lastUsedAt: self::intVal($data['last_used_at'] ?? null),
@@ -257,6 +272,7 @@ final class Credential
             createdAt: $this->createdAt,
             lastUsedAt: $this->lastUsedAt,
             isRevoked: $this->isRevoked(),
+            discoverability: $this->discoverable,
         );
     }
 

--- a/Classes/Service/AttestationService.php
+++ b/Classes/Service/AttestationService.php
@@ -10,10 +10,13 @@ declare(strict_types=1);
 namespace Netresearch\NrPasskeysBe\Service;
 
 use Netresearch\NrPasskeysBe\Domain\Dto\RegistrationOptions;
+use Netresearch\NrPasskeysBe\Domain\Enum\CredentialDiscoverability;
 use Netresearch\NrPasskeysBe\Domain\Model\Credential;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Throwable;
+use Webauthn\AuthenticationExtensions\AuthenticationExtension;
+use Webauthn\AuthenticationExtensions\AuthenticationExtensions;
 use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\AuthenticatorAttestationResponseValidator;
 use Webauthn\AuthenticatorSelectionCriteria;
@@ -85,6 +88,16 @@ final readonly class AttestationService
             residentKey: AuthenticatorSelectionCriteria::RESIDENT_KEY_REQUIREMENT_PREFERRED,
         );
 
+        // credProps asks the authenticator to report whether it actually created a
+        // discoverable (resident) credential. residentKey PREFERRED lets it decline
+        // silently, and a non-discoverable passkey can never appear in the browser's
+        // autofill menu — without this the extension cannot tell the difference, and
+        // the user is left wondering why one passkey is offered there and another is
+        // not. The answer arrives client-side via getClientExtensionResults().
+        $extensions = AuthenticationExtensions::create([
+            AuthenticationExtension::create('credProps', true),
+        ]);
+
         $options = PublicKeyCredentialCreationOptions::create(
             rp: $rp,
             user: $user,
@@ -94,6 +107,7 @@ final readonly class AttestationService
             attestation: PublicKeyCredentialCreationOptions::ATTESTATION_CONVEYANCE_PREFERENCE_NONE,
             excludeCredentials: $excludeCredentials,
             timeout: 60000,
+            extensions: $extensions,
         );
 
         return new RegistrationOptions(
@@ -191,6 +205,7 @@ final readonly class AttestationService
         CredentialRecord $source,
         int $beUserUid,
         string $label,
+        CredentialDiscoverability $discoverable = CredentialDiscoverability::Unknown,
     ): Credential {
         $credential = new Credential(
             beUser: $beUserUid,
@@ -200,6 +215,7 @@ final readonly class AttestationService
             userHandle: $source->userHandle,
             aaguid: $source->aaguid->toString(),
             transports: \json_encode($source->transports, JSON_THROW_ON_ERROR),
+            discoverable: $discoverable,
             label: $label,
         );
 

--- a/Classes/Service/WebAuthnService.php
+++ b/Classes/Service/WebAuthnService.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrPasskeysBe\Service;
 use Netresearch\NrPasskeysBe\Domain\Dto\AssertionOptions;
 use Netresearch\NrPasskeysBe\Domain\Dto\RegistrationOptions;
 use Netresearch\NrPasskeysBe\Domain\Dto\VerifiedAssertion;
+use Netresearch\NrPasskeysBe\Domain\Enum\CredentialDiscoverability;
 use Netresearch\NrPasskeysBe\Domain\Model\Credential;
 use RuntimeException;
 use Webauthn\CredentialRecord;
@@ -115,8 +116,9 @@ final readonly class WebAuthnService
         CredentialRecord $source,
         int $beUserUid,
         string $label,
+        CredentialDiscoverability $discoverable = CredentialDiscoverability::Unknown,
     ): Credential {
-        return $this->attestationService->storeCredential($source, $beUserUid, $label);
+        return $this->attestationService->storeCredential($source, $beUserUid, $label, $discoverable);
     }
 
     /**

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -467,6 +467,12 @@
             <trans-unit id="js.manage.never" resname="js.manage.never">
                 <source>Never</source>
             </trans-unit>
+            <trans-unit id="js.manage.notDiscoverable" resname="js.manage.notDiscoverable">
+                <source>No autofill</source>
+            </trans-unit>
+            <trans-unit id="js.manage.notDiscoverable.title" resname="js.manage.notDiscoverable.title">
+                <source>This passkey is not stored as a discoverable credential, so it cannot be offered in the username field. Use the passkey button, or register it again to get autofill.</source>
+            </trans-unit>
             <trans-unit id="js.manage.rename" resname="js.manage.rename">
                 <source>Rename</source>
             </trans-unit>

--- a/Resources/Public/JavaScript/PasskeyManagement.js
+++ b/Resources/Public/JavaScript/PasskeyManagement.js
@@ -140,6 +140,23 @@ class PasskeyManagement {
       labelSpan.dataset.uid = cred.uid;
       labelSpan.addEventListener('dblclick', () => this.startRename(labelSpan, cred.uid));
       labelCell.appendChild(labelSpan);
+
+      // A non-discoverable passkey works on the button, but the browser can
+      // never offer it in the username field's autofill menu — say so here
+      // rather than leaving the user to wonder why one passkey appears there
+      // and another does not. `null` means the authenticator never reported,
+      // which is not the same as "not discoverable" and stays unmarked.
+      if (cred.discoverable === false) {
+        const hint = document.createElement('span');
+        hint.className = 'badge bg-secondary ms-2';
+        hint.textContent = this.translate('js.manage.notDiscoverable', 'No autofill');
+        hint.title = this.translate(
+          'js.manage.notDiscoverable.title',
+          'This passkey is not stored as a discoverable credential, so it cannot be offered in the username field. Use the passkey button, or register it again to get autofill.',
+        );
+        labelCell.appendChild(hint);
+      }
+
       row.appendChild(labelCell);
 
       // Created date cell
@@ -229,13 +246,31 @@ class PasskeyManagement {
         credentialResponse.response.transports = credential.response.getTransports();
       }
 
+      // credProps.rk says whether the authenticator stored a discoverable
+      // credential. It travels outside the attestation object, so the server
+      // cannot read it from the response — it has to be forwarded. Undefined
+      // when the authenticator stayed silent; that stays undefined rather than
+      // being turned into false, because "did not say" is not "did not".
+      let discoverable;
+      if (typeof credential.getClientExtensionResults === 'function') {
+        const extensionResults = credential.getClientExtensionResults() || {};
+        if (extensionResults.credProps && typeof extensionResults.credProps.rk === 'boolean') {
+          discoverable = extensionResults.credProps.rk;
+        }
+      }
+
+      const verifyPayload = {
+        credential: credentialResponse,
+        challengeToken: challengeToken,
+        label: label || 'Passkey',
+      };
+      if (typeof discoverable === 'boolean') {
+        verifyPayload.discoverable = discoverable;
+      }
+
       const verifyResponse = await new AjaxRequest(this.registerVerifyUrl)
         .addMiddleware(sudoModeInterceptor)
-        .post({
-          credential: credentialResponse,
-          challengeToken: challengeToken,
-          label: label || 'Passkey',
-        });
+        .post(verifyPayload);
       const verifyData = await verifyResponse.resolve();
       if (verifyData.status === 'ok') {
         Notification.success(

--- a/Tests/Unit/Domain/Enum/CredentialDiscoverabilityTest.php
+++ b/Tests/Unit/Domain/Enum/CredentialDiscoverabilityTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrPasskeysBe\Tests\Unit\Domain\Enum;
+
+use Netresearch\NrPasskeysBe\Domain\Enum\CredentialDiscoverability;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The whole point of this enum is that "unknown" is a third state and not a
+ * synonym for "not discoverable": an authenticator may decline to report, and
+ * every credential registered before credProps was requested has no answer at
+ * all. Reporting those as non-discoverable would tell users their passkey
+ * cannot do autofill when nobody ever established that.
+ */
+#[CoversClass(CredentialDiscoverability::class)]
+final class CredentialDiscoverabilityTest extends TestCase
+{
+    /**
+     * @return list<array{mixed, CredentialDiscoverability}>
+     */
+    public static function databaseValueProvider(): array
+    {
+        return [
+            [null, CredentialDiscoverability::Unknown],
+            ['', CredentialDiscoverability::Unknown],
+            [1, CredentialDiscoverability::Discoverable],
+            ['1', CredentialDiscoverability::Discoverable],
+            [0, CredentialDiscoverability::NotDiscoverable],
+            ['0', CredentialDiscoverability::NotDiscoverable],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('databaseValueProvider')]
+    public function fromDatabaseValueMapsTheColumn(mixed $column, CredentialDiscoverability $expected): void
+    {
+        self::assertSame($expected, CredentialDiscoverability::fromDatabaseValue($column));
+    }
+
+    /**
+     * @return list<array{mixed, CredentialDiscoverability}>
+     */
+    public static function clientExtensionProvider(): array
+    {
+        return [
+            [true, CredentialDiscoverability::Discoverable],
+            [false, CredentialDiscoverability::NotDiscoverable],
+            // Everything that is not a boolean means the authenticator said
+            // nothing usable — including a missing key, which arrives as null.
+            [null, CredentialDiscoverability::Unknown],
+            ['true', CredentialDiscoverability::Unknown],
+            [1, CredentialDiscoverability::Unknown],
+            [[], CredentialDiscoverability::Unknown],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('clientExtensionProvider')]
+    public function fromClientExtensionResultAcceptsOnlyABoolean(
+        mixed $rk,
+        CredentialDiscoverability $expected,
+    ): void {
+        self::assertSame($expected, CredentialDiscoverability::fromClientExtensionResult($rk));
+    }
+
+    #[Test]
+    public function everyStateRoundTripsThroughTheColumn(): void
+    {
+        foreach (CredentialDiscoverability::cases() as $case) {
+            self::assertSame(
+                $case,
+                CredentialDiscoverability::fromDatabaseValue($case->toDatabaseValue()),
+                $case->value . ' does not survive a write/read cycle',
+            );
+        }
+    }
+
+    #[Test]
+    public function unknownIsNullInBothProjectionsAndNeverFalse(): void
+    {
+        // The distinction this enum exists for: a client that warns on false
+        // must not be handed false for a credential nobody asked about.
+        self::assertNull(CredentialDiscoverability::Unknown->toDatabaseValue());
+        self::assertNull(CredentialDiscoverability::Unknown->toJsonValue());
+        self::assertNotFalse(CredentialDiscoverability::Unknown->toJsonValue());
+    }
+
+    #[Test]
+    public function jsonProjectionSeparatesTheTwoKnownStates(): void
+    {
+        self::assertTrue(CredentialDiscoverability::Discoverable->toJsonValue());
+        self::assertFalse(CredentialDiscoverability::NotDiscoverable->toJsonValue());
+    }
+}

--- a/Tests/Unit/Domain/Model/CredentialTest.php
+++ b/Tests/Unit/Domain/Model/CredentialTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrPasskeysBe\Tests\Unit\Domain\Model;
 
 use Netresearch\NrPasskeysBe\Domain\Dto\AdminCredentialInfo;
 use Netresearch\NrPasskeysBe\Domain\Dto\CredentialInfo;
+use Netresearch\NrPasskeysBe\Domain\Enum\CredentialDiscoverability;
 use Netresearch\NrPasskeysBe\Domain\Model\Credential;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -287,6 +288,7 @@ final class CredentialTest extends TestCase
             'user_handle' => 'handle-abc',
             'aaguid' => '00000000-0000-0000-0000-000000000001',
             'transports' => '["usb"]',
+            'discoverable' => null,
             'label' => 'Test Key',
             'created_at' => 1700000000,
             'last_used_at' => 1700001000,
@@ -443,7 +445,7 @@ final class CredentialTest extends TestCase
     }
 
     #[Test]
-    public function toCredentialInfoHasExactlyFiveProperties(): void
+    public function toCredentialInfoHasExactlySixProperties(): void
     {
         $credential = new Credential(uid: 1, label: 'Test');
         $info = $credential->toCredentialInfo();
@@ -451,12 +453,44 @@ final class CredentialTest extends TestCase
         self::assertInstanceOf(CredentialInfo::class, $info);
 
         $serialized = $info->jsonSerialize();
-        self::assertCount(5, $serialized);
+        self::assertCount(6, $serialized);
         self::assertArrayHasKey('uid', $serialized);
         self::assertArrayHasKey('label', $serialized);
         self::assertArrayHasKey('createdAt', $serialized);
         self::assertArrayHasKey('lastUsedAt', $serialized);
         self::assertArrayHasKey('isRevoked', $serialized);
+        self::assertArrayHasKey('discoverable', $serialized);
+    }
+
+    #[Test]
+    public function credentialInfoReportsDiscoverabilityAsTristate(): void
+    {
+        // The management UI only warns on a positive "not discoverable"; an
+        // authenticator that stayed silent must not be reported as limited.
+        $unknown = (new Credential(uid: 1, label: 'Test'))->toCredentialInfo();
+        self::assertNull($unknown->jsonSerialize()['discoverable']);
+
+        $yes = (new Credential(uid: 2, discoverable: CredentialDiscoverability::Discoverable, label: 'Test'))
+            ->toCredentialInfo();
+        self::assertTrue($yes->jsonSerialize()['discoverable']);
+
+        $no = (new Credential(uid: 3, discoverable: CredentialDiscoverability::NotDiscoverable, label: 'Test'))
+            ->toCredentialInfo();
+        self::assertFalse($no->jsonSerialize()['discoverable']);
+    }
+
+    #[Test]
+    public function discoverabilityRoundTripsThroughTheDatabaseColumn(): void
+    {
+        foreach ([
+            [null, CredentialDiscoverability::Unknown],
+            [1, CredentialDiscoverability::Discoverable],
+            [0, CredentialDiscoverability::NotDiscoverable],
+        ] as [$column, $expected]) {
+            $credential = Credential::fromArray(['discoverable' => $column]);
+            self::assertSame($expected, $credential->getDiscoverability());
+            self::assertSame($column, $credential->toArray()['discoverable']);
+        }
     }
 
     #[Test]

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -6,6 +6,10 @@ CREATE TABLE tx_nrpasskeysbe_credential (
     user_handle varbinary(64) DEFAULT NULL,
     aaguid char(36) DEFAULT NULL,
     transports text DEFAULT NULL,
+    -- credProps.rk from registration: 1 discoverable, 0 not, NULL unknown
+    -- (registered before this was recorded, or authenticator stayed silent).
+    -- A non-discoverable passkey cannot appear in the browser's autofill menu.
+    discoverable tinyint(1) DEFAULT NULL,
     label varchar(128) NOT NULL DEFAULT '',
     created_at int(11) unsigned NOT NULL DEFAULT 0,
     last_used_at int(11) unsigned NOT NULL DEFAULT 0,


### PR DESCRIPTION
Reported from the demo instance: clicking the username field offers one passkey but not the `nr_admin` one, while the passkey button offers both. The cause is not in the login flow — both paths ask the server for the same discoverable options with the same rpId. It is the credential itself: the browser can only put **discoverable (resident)** credentials into the autofill menu, whereas a password manager's own picker also lists non-discoverable ones it holds. Registration uses `residentKey: PREFERRED`, which permits the authenticator to store a non-discoverable credential without saying so, and the extension had no way to know or show it — no `credProps` request, no column.

Registration now requests the `credProps` extension; the browser forwards `credProps.rk` from `getClientExtensionResults()` (it is not part of the attestation object, so the server cannot recover it later), and the answer is stored per credential. The management list marks a credential that was positively reported as non-discoverable with a "No autofill" badge whose tooltip says registering it again fixes it.

Modelled as three states rather than a boolean: authenticators may stay silent, and every credential registered before this has no answer at all. `CredentialDiscoverability` keeps "unknown" apart from "not discoverable" so the UI never claims a limitation it has not established; the column stays NULL in that case. `?bool` was the first shape and the repo's ergebnis ruleset rejects nullable parameters — the enum is both rule-compliant and the more honest model.

`residentKey` deliberately stays PREFERRED: REQUIRED would guarantee autofill for every new passkey but shuts out authenticators without room for resident keys. That trade-off is a policy decision, not part of this fix.

Verified: credProps reaches the browser payload as `"extensions":{"credProps":true}` through the library's own serializer; the tri-state round-trips through the column (unknown/1/0), checked by re-injecting a defect in the hydration mapping and watching the test fail. CGL, Rector, PHPStan, 668 unit tests and the JS suite are green.